### PR TITLE
Prometheus dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Added
+- Dashboard for Prometheus
+
 ## Changed
 - Update metrics version to 0.5.0
 - Replace average latency collector with summary collector in example cluster

--- a/README.md
+++ b/README.md
@@ -38,17 +38,23 @@ Guide on Tarantool project prerequirements and metrics collectors configuration 
 
 ## How to compile dashboard
 
-### InfluxDB dashboard
+You can compile Prometheus dashboard template with
+```bash
+jsonnet -J ./vendor/ ./tarantool/prometheus_dashboard.jsonnet
+```
+and InfluxDB dashboard template with
+```bash
+jsonnet -J ./vendor/ ./tarantool/influxdb_dashboard.jsonnet
+```
 
-Compile board template with
+To save output into `output.json` file, use
 ```bash
-jsonnet -J ./vendor/ ./tarantool/dashboard.libsonnet -o ./output.json
+jsonnet -J ./vendor/ ./tarantool/prometheus_dashboard.jsonnet -o ./output.json
 ```
-to save json template into `output.json` file or
+and to save output into clipboard, use
 ```bash
-jsonnet -J ./vendor/ ./tarantool/dashboard.libsonnet | xclip -selection clipboard
+jsonnet -J ./vendor/ ./tarantool/prometheus_dashboard.jsonnet | xclip -selection clipboard
 ```
-to put json template into clipboard.
 
 ## Tests
 

--- a/tarantool/dashboard.libsonnet
+++ b/tarantool/dashboard.libsonnet
@@ -3,249 +3,238 @@ local grafana = import 'grafonnet/grafana.libsonnet';
 local http = import 'http.libsonnet';
 local slab = import 'slab.libsonnet';
 local space = import 'space.libsonnet';
+local row = grafana.row;
 
-local dashboard = grafana.dashboard.new(
-  title='example_project_http',
-  description='example dashboard',
-  editable=true,
-  schemaVersion=21,
-  time_from='now-6h',
-  time_to='now',
-  refresh='30s',
-  tags=['tag1', 'tag2'],
-);
-
-local datasource = '${DS_INFLUXDB}';
-local policy = '${INFLUXDB_POLICY}';
-local measurement = '${INFLUXDB_MEASUREMENT}';
-
-dashboard
-.addInput(
-  name='DS_INFLUXDB',
-  label='InfluxDB bank',
-  type='datasource',
-  pluginId='influxdb',
-  pluginName='InfluxDB',
-  description='InfluxDB Tarantool metrics bank'
-)
-.addInput(
-  name='INFLUXDB_MEASUREMENT',
-  label='InfluxDB measurement',
-  type='constant',
-  description='InfluxDB Tarantool metrics measurement'
-)
-.addInput(
-  name='INFLUXDB_POLICY',
-  label='InfluxDB policy',
-  type='constant',
-  value='default',
-  description='InfluxDB Tarantool metrics policy'
-)
-.addRequired(
-  type='grafana',
-  id='grafana',
-  name='Grafana',
-  version='6.6.0'
-)
-.addRequired(
-  type='datasource',
-  id='influxdb',
-  name='InfluxDB',
-  version='1.0.0'
-)
-.addRequired(
-  type='panel',
-  id='graph',
-  name='Graph',
-  version=''
-)
-.addRequired(
-  type='panel',
-  id='text',
-  name='Text',
-  version=''
-)
-.addPanel(
-  grafana.row.new(title='Tarantool HTTP statistics'),
-  { w: 24, h: 1, x: 0, y: 0 }
-)
-.addPanel(
-  http.rps_success(
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-  ),
-  { w: 8, h: 8, x: 0, y: 1 }
-)
-.addPanel(
-  http.rps_error_4xx(
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-  ),
-  { w: 8, h: 8, x: 8, y: 1 },
-)
-.addPanel(
-  http.rps_error_5xx(
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-  ),
-  { w: 8, h: 8, x: 16, y: 1 },
-)
-.addPanel(
-  http.latency_success(
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-  ),
-  { w: 8, h: 8, x: 0, y: 9 }
-)
-.addPanel(
-  http.latency_error_4xx(
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-  ),
-  { w: 8, h: 8, x: 8, y: 9 },
-)
-.addPanel(
-  http.latency_error_5xx(
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-  ),
-  { w: 8, h: 8, x: 16, y: 9 },
-)
-.addPanel(
-  grafana.row.new(title='Tarantool memory overview'),
-  { w: 24, h: 1, x: 0, y: 17 }
-)
-.addPanel(
-  slab.monitor_info(),
-  { w: 24, h: 3, x: 0, y: 18 }
-)
-.addPanel(
-  slab.quota_used_ratio(
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-  ),
-  { w: 8, h: 8, x: 0, y: 21 }
-)
-.addPanel(
-  slab.arena_used_ratio(
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-  ),
-  { w: 8, h: 8, x: 8, y: 21 },
-)
-.addPanel(
-  slab.items_used_ratio(
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-  ),
-  { w: 8, h: 8, x: 16, y: 21 },
-)
-.addPanel(
-  slab.quota_used(
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-  ),
-  { w: 8, h: 8, x: 0, y: 29 }
-)
-.addPanel(
-  slab.arena_used(
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-  ),
-  { w: 8, h: 8, x: 8, y: 29 },
-)
-.addPanel(
-  slab.items_used(
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-  ),
-  { w: 8, h: 8, x: 16, y: 29 },
-)
-.addPanel(
-  slab.quota_size(
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-  ),
-  { w: 8, h: 8, x: 0, y: 37 }
-)
-.addPanel(
-  slab.arena_size(
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-  ),
-  { w: 8, h: 8, x: 8, y: 37 },
-)
-.addPanel(
-  slab.items_size(
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-  ),
-  { w: 8, h: 8, x: 16, y: 37 },
-)
-.addPanel(
-  grafana.row.new(title='Tarantool spaces statistics'),
-  { w: 24, h: 1, x: 0, y: 45 }
-)
-.addPanel(
-  space.select_rps(
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-  ),
-  { w: 8, h: 8, x: 0, y: 46 },
-)
-.addPanel(
-  space.insert_rps(
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-  ),
-  { w: 8, h: 8, x: 8, y: 46 },
-)
-.addPanel(
-  space.replace_rps(
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-  ),
-  { w: 8, h: 8, x: 16, y: 46 },
-)
-.addPanel(
-  space.upsert_rps(
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-  ),
-  { w: 8, h: 8, x: 0, y: 46 },
-)
-.addPanel(
-  space.update_rps(
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-  ),
-  { w: 8, h: 8, x: 8, y: 46 },
-)
-.addPanel(
-  space.delete_rps(
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-  ),
-  { w: 8, h: 8, x: 16, y: 46 },
-)
+{
+  build(
+    dashboard,
+    datasource,
+    policy=null,
+    measurement=null,
+    job=null
+  )::
+    dashboard
+    .addRequired(
+      type='grafana',
+      id='grafana',
+      name='Grafana',
+      version='6.6.0'
+    )
+    .addRequired(
+      type='panel',
+      id='graph',
+      name='Graph',
+      version=''
+    )
+    .addRequired(
+      type='panel',
+      id='text',
+      name='Text',
+      version=''
+    )
+    .addPanel(
+      row.new(title='Tarantool HTTP statistics'),
+      { w: 24, h: 1, x: 0, y: 0 }
+    )
+    .addPanel(
+      http.rps_success(
+        datasource=datasource,
+        policy=policy,
+        measurement=measurement,
+        job=job,
+      ),
+      { w: 8, h: 8, x: 0, y: 1 }
+    )
+    .addPanel(
+      http.rps_error_4xx(
+        datasource=datasource,
+        policy=policy,
+        measurement=measurement,
+        job=job,
+      ),
+      { w: 8, h: 8, x: 8, y: 1 },
+    )
+    .addPanel(
+      http.rps_error_5xx(
+        datasource=datasource,
+        policy=policy,
+        measurement=measurement,
+        job=job,
+      ),
+      { w: 8, h: 8, x: 16, y: 1 },
+    )
+    .addPanel(
+      http.latency_success(
+        datasource=datasource,
+        policy=policy,
+        measurement=measurement,
+        job=job,
+      ),
+      { w: 8, h: 8, x: 0, y: 9 }
+    )
+    .addPanel(
+      http.latency_error_4xx(
+        datasource=datasource,
+        policy=policy,
+        measurement=measurement,
+        job=job,
+      ),
+      { w: 8, h: 8, x: 8, y: 9 },
+    )
+    .addPanel(
+      http.latency_error_5xx(
+        datasource=datasource,
+        policy=policy,
+        measurement=measurement,
+        job=job,
+      ),
+      { w: 8, h: 8, x: 16, y: 9 },
+    )
+    .addPanel(
+      row.new(title='Tarantool memory overview'),
+      { w: 24, h: 1, x: 0, y: 17 }
+    )
+    .addPanel(
+      slab.monitor_info(),
+      { w: 24, h: 3, x: 0, y: 18 }
+    )
+    .addPanel(
+      slab.quota_used_ratio(
+        datasource=datasource,
+        policy=policy,
+        measurement=measurement,
+        job=job,
+      ),
+      { w: 8, h: 8, x: 0, y: 21 }
+    )
+    .addPanel(
+      slab.arena_used_ratio(
+        datasource=datasource,
+        policy=policy,
+        measurement=measurement,
+        job=job,
+      ),
+      { w: 8, h: 8, x: 8, y: 21 },
+    )
+    .addPanel(
+      slab.items_used_ratio(
+        datasource=datasource,
+        policy=policy,
+        measurement=measurement,
+        job=job,
+      ),
+      { w: 8, h: 8, x: 16, y: 21 },
+    )
+    .addPanel(
+      slab.quota_used(
+        datasource=datasource,
+        policy=policy,
+        measurement=measurement,
+        job=job,
+      ),
+      { w: 8, h: 8, x: 0, y: 29 }
+    )
+    .addPanel(
+      slab.arena_used(
+        datasource=datasource,
+        policy=policy,
+        measurement=measurement,
+        job=job,
+      ),
+      { w: 8, h: 8, x: 8, y: 29 },
+    )
+    .addPanel(
+      slab.items_used(
+        datasource=datasource,
+        policy=policy,
+        measurement=measurement,
+        job=job,
+      ),
+      { w: 8, h: 8, x: 16, y: 29 },
+    )
+    .addPanel(
+      slab.quota_size(
+        datasource=datasource,
+        policy=policy,
+        measurement=measurement,
+        job=job,
+      ),
+      { w: 8, h: 8, x: 0, y: 37 }
+    )
+    .addPanel(
+      slab.arena_size(
+        datasource=datasource,
+        policy=policy,
+        measurement=measurement,
+        job=job,
+      ),
+      { w: 8, h: 8, x: 8, y: 37 },
+    )
+    .addPanel(
+      slab.items_size(
+        datasource=datasource,
+        policy=policy,
+        measurement=measurement,
+        job=job,
+      ),
+      { w: 8, h: 8, x: 16, y: 37 },
+    )
+    .addPanel(
+      row.new(title='Tarantool spaces statistics'),
+      { w: 24, h: 1, x: 0, y: 45 }
+    )
+    .addPanel(
+      space.select_rps(
+        datasource=datasource,
+        policy=policy,
+        measurement=measurement,
+        job=job,
+      ),
+      { w: 8, h: 8, x: 0, y: 46 },
+    )
+    .addPanel(
+      space.insert_rps(
+        datasource=datasource,
+        policy=policy,
+        measurement=measurement,
+        job=job,
+      ),
+      { w: 8, h: 8, x: 8, y: 46 },
+    )
+    .addPanel(
+      space.replace_rps(
+        datasource=datasource,
+        policy=policy,
+        measurement=measurement,
+        job=job,
+      ),
+      { w: 8, h: 8, x: 16, y: 46 },
+    )
+    .addPanel(
+      space.upsert_rps(
+        datasource=datasource,
+        policy=policy,
+        measurement=measurement,
+        job=job,
+      ),
+      { w: 8, h: 8, x: 0, y: 46 },
+    )
+    .addPanel(
+      space.update_rps(
+        datasource=datasource,
+        policy=policy,
+        measurement=measurement,
+        job=job,
+      ),
+      { w: 8, h: 8, x: 8, y: 46 },
+    )
+    .addPanel(
+      space.delete_rps(
+        datasource=datasource,
+        policy=policy,
+        measurement=measurement,
+        job=job,
+      ),
+      { w: 8, h: 8, x: 16, y: 46 },
+    ),
+}

--- a/tarantool/influxdb_dashboard.jsonnet
+++ b/tarantool/influxdb_dashboard.jsonnet
@@ -1,0 +1,52 @@
+local grafana = import 'grafonnet/grafana.libsonnet';
+
+local dashboard = import 'dashboard.libsonnet';
+
+local raw_dashboard = grafana.dashboard.new(
+  title='Example InfluxDB dashboard',
+  description='Example dashboard',
+  editable=true,
+  schemaVersion=21,
+  time_from='now-6h',
+  time_to='now',
+  refresh='30s',
+  tags=['tag1', 'tag2'],
+);
+
+local datasource = '${DS_INFLUXDB}';
+local policy = '${INFLUXDB_POLICY}';
+local measurement = '${INFLUXDB_MEASUREMENT}';
+
+dashboard.build(
+  raw_dashboard
+  .addInput(
+    name='DS_INFLUXDB',
+    label='InfluxDB bank',
+    type='datasource',
+    pluginId='influxdb',
+    pluginName='InfluxDB',
+    description='InfluxDB Tarantool metrics bank'
+  )
+  .addInput(
+    name='INFLUXDB_MEASUREMENT',
+    label='Measurement',
+    type='constant',
+    description='InfluxDB Tarantool metrics measurement'
+  )
+  .addInput(
+    name='INFLUXDB_POLICY',
+    label='Policy',
+    type='constant',
+    value='default',
+    description='InfluxDB Tarantool metrics policy'
+  )
+  .addRequired(
+    type='datasource',
+    id='influxdb',
+    name='InfluxDB',
+    version='1.0.0'
+  ),
+  datasource,
+  policy=policy,
+  measurement=measurement
+)

--- a/tarantool/prometheus_dashboard.jsonnet
+++ b/tarantool/prometheus_dashboard.jsonnet
@@ -1,0 +1,53 @@
+local grafana = import 'grafonnet/grafana.libsonnet';
+
+local dashboard = import 'dashboard.libsonnet';
+
+local raw_dashboard = grafana.dashboard.new(
+  title='Example Prometheus dashboard',
+  description='Example dashboard',
+  editable=true,
+  schemaVersion=21,
+  time_from='now-6h',
+  time_to='now',
+  refresh='30s',
+  tags=['tag1', 'tag2'],
+);
+
+local datasource = '${DS_PROMETHEUS}';
+local job = '[[job]]';
+
+dashboard.build(
+  raw_dashboard
+  .addInput(
+    name='DS_PROMETHEUS',
+    label='Prometheus',
+    type='datasource',
+    pluginId='prometheus',
+    pluginName='Prometheus',
+    description='Prometheus Tarantool metrics bank'
+  )
+  .addInput(
+    name='PROMETHEUS_JOB',
+    label='Job',
+    type='constant',
+    pluginId=null,
+    pluginName=null,
+    description='Prometheus Tarantool metrics job'
+  )
+  .addRequired(
+    type='datasource',
+    id='prometheus',
+    name='Prometheus',
+    version='1.0.0'
+  ).addTemplate(
+    grafana.template.custom(
+      name='job',
+      query='${PROMETHEUS_JOB}',
+      current='${PROMETHEUS_JOB}',
+      hide='variable',
+      label='Prometheus job',
+    ),
+  ),
+  datasource,
+  job=job,
+)

--- a/tarantool/slab.libsonnet
+++ b/tarantool/slab.libsonnet
@@ -1,9 +1,9 @@
 local grafana = import 'grafonnet/grafana.libsonnet';
-local influxdb = import 'grafonnet/influxdb.libsonnet';
 
 local text = grafana.text;
 local graph = grafana.graphPanel;
 local influxdb = grafana.influxdb;
+local prometheus = grafana.prometheus;
 
 {
   monitor_info(
@@ -22,6 +22,7 @@ local influxdb = grafana.influxdb;
     datasource,
     policy,
     measurement,
+    job,
     metric_name,
     format,
     labelY1
@@ -41,12 +42,18 @@ local influxdb = grafana.influxdb;
     legend_sort='current',
     legend_sortDesc=true,
   ).addTarget(
-    influxdb.target(
-      policy=policy,
-      measurement=measurement,
-      group_tags=['label_pairs_alias'],
-      alias='$tag_label_pairs_alias',
-    ).where('metric_name', '=', metric_name).selectField('value').addConverter('mean')
+    if datasource == '${DS_PROMETHEUS}' then
+      prometheus.target(
+        expr=std.format('%s{job=~"%s"}', [metric_name, job]),
+        legendFormat='{{alias}}',
+      )
+    else if datasource == '${DS_INFLUXDB}' then
+      influxdb.target(
+        policy=policy,
+        measurement=measurement,
+        group_tags=['label_pairs_alias'],
+        alias='$tag_label_pairs_alias',
+      ).where('metric_name', '=', metric_name).selectField('value').addConverter('mean')
   ),
 
   local used_ratio(
@@ -55,6 +62,7 @@ local influxdb = grafana.influxdb;
     datasource,
     policy,
     measurement,
+    job,
     metric_name,
   ) = used_panel(
     title,
@@ -62,6 +70,7 @@ local influxdb = grafana.influxdb;
     datasource,
     policy,
     measurement,
+    job,
     metric_name,
     format='percent',
     labelY1='used ratio'
@@ -80,12 +89,14 @@ local influxdb = grafana.influxdb;
     datasource=null,
     policy=null,
     measurement=null,
+    job=null,
   ):: used_ratio(
     title=title,
     description=description,
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    job=job,
     metric_name='tnt_slab_quota_used_ratio',
   ),
 
@@ -102,12 +113,14 @@ local influxdb = grafana.influxdb;
     datasource=null,
     policy=null,
     measurement=null,
+    job=null,
   ):: used_ratio(
     title=title,
     description=description,
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    job=job,
     metric_name='tnt_slab_arena_used_ratio',
   ),
 
@@ -124,12 +137,14 @@ local influxdb = grafana.influxdb;
     datasource=null,
     policy=null,
     measurement=null,
+    job=null,
   ):: used_ratio(
     title=title,
     description=description,
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    job=job,
     metric_name='tnt_slab_items_used_ratio',
   ),
 
@@ -139,6 +154,7 @@ local influxdb = grafana.influxdb;
     datasource,
     policy,
     measurement,
+    job,
     metric_name,
   ) = used_panel(
     title,
@@ -146,6 +162,7 @@ local influxdb = grafana.influxdb;
     datasource,
     policy,
     measurement,
+    job,
     metric_name,
     format='bytes',
     labelY1='in bytes',
@@ -160,12 +177,14 @@ local influxdb = grafana.influxdb;
     datasource=null,
     policy=null,
     measurement=null,
+    job=null,
   ):: used_memory(
     title=title,
     description=description,
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    job=job,
     metric_name='tnt_slab_quota_used',
   ),
 
@@ -178,12 +197,14 @@ local influxdb = grafana.influxdb;
     datasource=null,
     policy=null,
     measurement=null,
+    job=null,
   ):: used_memory(
     title=title,
     description=description,
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    job=job,
     metric_name='tnt_slab_quota_size',
   ),
 
@@ -196,12 +217,14 @@ local influxdb = grafana.influxdb;
     datasource=null,
     policy=null,
     measurement=null,
+    job=null,
   ):: used_memory(
     title=title,
     description=description,
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    job=job,
     metric_name='tnt_slab_arena_used',
   ),
 
@@ -214,12 +237,14 @@ local influxdb = grafana.influxdb;
     datasource=null,
     policy=null,
     measurement=null,
+    job=null,
   ):: used_memory(
     title=title,
     description=description,
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    job=job,
     metric_name='tnt_slab_arena_size',
   ),
 
@@ -232,12 +257,14 @@ local influxdb = grafana.influxdb;
     datasource=null,
     policy=null,
     measurement=null,
+    job=null,
   ):: used_memory(
     title=title,
     description=description,
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    job=job,
     metric_name='tnt_slab_items_used',
   ),
 
@@ -250,12 +277,14 @@ local influxdb = grafana.influxdb;
     datasource=null,
     policy=null,
     measurement=null,
+    job=null,
   ):: used_memory(
     title=title,
     description=description,
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    job=job,
     metric_name='tnt_slab_items_size',
   ),
 }

--- a/tests/InfluxDB/dashboard.jsonnet
+++ b/tests/InfluxDB/dashboard.jsonnet
@@ -1,1 +1,1 @@
-import 'tarantool/dashboard.libsonnet'
+import 'tarantool/influxdb_dashboard.jsonnet'

--- a/tests/Prometheus/dashboard.jsonnet
+++ b/tests/Prometheus/dashboard.jsonnet
@@ -1,0 +1,1 @@
+import 'tarantool/prometheus_dashboard.jsonnet'

--- a/tests/Prometheus/dashboard_compiled.json
+++ b/tests/Prometheus/dashboard_compiled.json
@@ -1,31 +1,24 @@
 {
    "__inputs": [
       {
-         "description": "InfluxDB Tarantool metrics bank",
-         "label": "InfluxDB bank",
-         "name": "DS_INFLUXDB",
-         "pluginId": "influxdb",
-         "pluginName": "InfluxDB",
+         "description": "Prometheus Tarantool metrics bank",
+         "label": "Prometheus",
+         "name": "DS_PROMETHEUS",
+         "pluginId": "prometheus",
+         "pluginName": "Prometheus",
          "type": "datasource"
       },
       {
-         "description": "InfluxDB Tarantool metrics measurement",
-         "label": "Measurement",
-         "name": "INFLUXDB_MEASUREMENT",
+         "description": "Prometheus Tarantool metrics job",
+         "label": "Job",
+         "name": "PROMETHEUS_JOB",
          "type": "constant"
-      },
-      {
-         "description": "InfluxDB Tarantool metrics policy",
-         "label": "Policy",
-         "name": "INFLUXDB_POLICY",
-         "type": "constant",
-         "value": "default"
       }
    ],
    "__requires": [
       {
-         "id": "influxdb",
-         "name": "InfluxDB",
+         "id": "prometheus",
+         "name": "Prometheus",
          "type": "datasource",
          "version": "1.0.0"
       },
@@ -83,7 +76,7 @@
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "${DS_INFLUXDB}",
+         "datasource": "${DS_PROMETHEUS}",
          "decimals": 2,
          "description": "Requests, processed with success (code 2xx) on Tarantool's side.\nGraph shows mean count per second.\n",
          "fill": 0,
@@ -123,82 +116,11 @@
          "steppedLine": false,
          "targets": [
             {
-               "alias": "$tag_label_pairs_alias — $tag_label_pairs_method $tag_label_pairs_path (code $tag_label_pairs_status)",
-               "groupBy": [
-                  {
-                     "params": [
-                        "$__interval"
-                     ],
-                     "type": "time"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_alias"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_path"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_method"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_status"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "none"
-                     ],
-                     "type": "fill"
-                  }
-               ],
-               "measurement": "${INFLUXDB_MEASUREMENT}",
-               "policy": "${INFLUXDB_POLICY}",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                  [
-                     {
-                        "params": [
-                           "value"
-                        ],
-                        "type": "field"
-                     },
-                     {
-                        "params": [ ],
-                        "type": "mean"
-                     },
-                     {
-                        "params": [
-                           "1s"
-                        ],
-                        "type": "non_negative_derivative"
-                     }
-                  ]
-               ],
-               "tags": [
-                  {
-                     "key": "metric_name",
-                     "operator": "=",
-                     "value": "http_server_request_latency_count"
-                  },
-                  {
-                     "condition": "AND",
-                     "key": "label_pairs_status",
-                     "operator": "=~",
-                     "value": "/^2\\d{2}$/"
-                  }
-               ]
+               "expr": "rate(http_server_request_latency_count{job=~\"[[job]]\",status=~\"^2\\\\d{2}$\"}[1m])",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
+               "refId": "A"
             }
          ],
          "thresholds": [ ],
@@ -244,7 +166,7 @@
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "${DS_INFLUXDB}",
+         "datasource": "${DS_PROMETHEUS}",
          "decimals": 2,
          "description": "Requests, processed with 4xx error on Tarantool's side.\nGraph shows mean count per second.\n",
          "fill": 0,
@@ -284,82 +206,11 @@
          "steppedLine": false,
          "targets": [
             {
-               "alias": "$tag_label_pairs_alias — $tag_label_pairs_method $tag_label_pairs_path (code $tag_label_pairs_status)",
-               "groupBy": [
-                  {
-                     "params": [
-                        "$__interval"
-                     ],
-                     "type": "time"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_alias"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_path"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_method"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_status"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "none"
-                     ],
-                     "type": "fill"
-                  }
-               ],
-               "measurement": "${INFLUXDB_MEASUREMENT}",
-               "policy": "${INFLUXDB_POLICY}",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                  [
-                     {
-                        "params": [
-                           "value"
-                        ],
-                        "type": "field"
-                     },
-                     {
-                        "params": [ ],
-                        "type": "mean"
-                     },
-                     {
-                        "params": [
-                           "1s"
-                        ],
-                        "type": "non_negative_derivative"
-                     }
-                  ]
-               ],
-               "tags": [
-                  {
-                     "key": "metric_name",
-                     "operator": "=",
-                     "value": "http_server_request_latency_count"
-                  },
-                  {
-                     "condition": "AND",
-                     "key": "label_pairs_status",
-                     "operator": "=~",
-                     "value": "/^4\\d{2}$/"
-                  }
-               ]
+               "expr": "rate(http_server_request_latency_count{job=~\"[[job]]\",status=~\"^4\\\\d{2}$\"}[1m])",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
+               "refId": "A"
             }
          ],
          "thresholds": [ ],
@@ -405,7 +256,7 @@
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "${DS_INFLUXDB}",
+         "datasource": "${DS_PROMETHEUS}",
          "decimals": 2,
          "description": "Requests, processed with 5xx error on Tarantool's side.\nGraph shows mean count per second.\n",
          "fill": 0,
@@ -445,82 +296,11 @@
          "steppedLine": false,
          "targets": [
             {
-               "alias": "$tag_label_pairs_alias — $tag_label_pairs_method $tag_label_pairs_path (code $tag_label_pairs_status)",
-               "groupBy": [
-                  {
-                     "params": [
-                        "$__interval"
-                     ],
-                     "type": "time"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_alias"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_path"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_method"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_status"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "none"
-                     ],
-                     "type": "fill"
-                  }
-               ],
-               "measurement": "${INFLUXDB_MEASUREMENT}",
-               "policy": "${INFLUXDB_POLICY}",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                  [
-                     {
-                        "params": [
-                           "value"
-                        ],
-                        "type": "field"
-                     },
-                     {
-                        "params": [ ],
-                        "type": "mean"
-                     },
-                     {
-                        "params": [
-                           "1s"
-                        ],
-                        "type": "non_negative_derivative"
-                     }
-                  ]
-               ],
-               "tags": [
-                  {
-                     "key": "metric_name",
-                     "operator": "=",
-                     "value": "http_server_request_latency_count"
-                  },
-                  {
-                     "condition": "AND",
-                     "key": "label_pairs_status",
-                     "operator": "=~",
-                     "value": "/^5\\d{2}$/"
-                  }
-               ]
+               "expr": "rate(http_server_request_latency_count{job=~\"[[job]]\",status=~\"^5\\\\d{2}$\"}[1m])",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
+               "refId": "A"
             }
          ],
          "thresholds": [ ],
@@ -566,7 +346,7 @@
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "${DS_INFLUXDB}",
+         "datasource": "${DS_PROMETHEUS}",
          "decimals": 3,
          "description": "99th percentile of requests latency. Includes only requests processed with success (code 2xx) on Tarantool's side.\n",
          "fill": 0,
@@ -606,82 +386,11 @@
          "steppedLine": false,
          "targets": [
             {
-               "alias": "$tag_label_pairs_alias — $tag_label_pairs_method $tag_label_pairs_path (code $tag_label_pairs_status)",
-               "groupBy": [
-                  {
-                     "params": [
-                        "$__interval"
-                     ],
-                     "type": "time"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_alias"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_path"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_method"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_status"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "none"
-                     ],
-                     "type": "fill"
-                  }
-               ],
-               "measurement": "${INFLUXDB_MEASUREMENT}",
-               "policy": "${INFLUXDB_POLICY}",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                  [
-                     {
-                        "params": [
-                           "value"
-                        ],
-                        "type": "field"
-                     },
-                     {
-                        "params": [ ],
-                        "type": "mean"
-                     }
-                  ]
-               ],
-               "tags": [
-                  {
-                     "key": "metric_name",
-                     "operator": "=",
-                     "value": "http_server_request_latency"
-                  },
-                  {
-                     "condition": "AND",
-                     "key": "label_pairs_quantile",
-                     "operator": "=",
-                     "value": "0.99"
-                  },
-                  {
-                     "condition": "AND",
-                     "key": "label_pairs_status",
-                     "operator": "=~",
-                     "value": "/^2\\d{2}$/"
-                  }
-               ]
+               "expr": "http_server_request_latency{job=~\"[[job]]\",quantile=\"0.99\",status=~\"^2\\\\d{2}$\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
+               "refId": "A"
             }
          ],
          "thresholds": [ ],
@@ -727,7 +436,7 @@
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "${DS_INFLUXDB}",
+         "datasource": "${DS_PROMETHEUS}",
          "decimals": 3,
          "description": "99th percentile of requests latency. Includes only requests processed with 4xx error on Tarantool's side.\n",
          "fill": 0,
@@ -767,82 +476,11 @@
          "steppedLine": false,
          "targets": [
             {
-               "alias": "$tag_label_pairs_alias — $tag_label_pairs_method $tag_label_pairs_path (code $tag_label_pairs_status)",
-               "groupBy": [
-                  {
-                     "params": [
-                        "$__interval"
-                     ],
-                     "type": "time"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_alias"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_path"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_method"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_status"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "none"
-                     ],
-                     "type": "fill"
-                  }
-               ],
-               "measurement": "${INFLUXDB_MEASUREMENT}",
-               "policy": "${INFLUXDB_POLICY}",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                  [
-                     {
-                        "params": [
-                           "value"
-                        ],
-                        "type": "field"
-                     },
-                     {
-                        "params": [ ],
-                        "type": "mean"
-                     }
-                  ]
-               ],
-               "tags": [
-                  {
-                     "key": "metric_name",
-                     "operator": "=",
-                     "value": "http_server_request_latency"
-                  },
-                  {
-                     "condition": "AND",
-                     "key": "label_pairs_quantile",
-                     "operator": "=",
-                     "value": "0.99"
-                  },
-                  {
-                     "condition": "AND",
-                     "key": "label_pairs_status",
-                     "operator": "=~",
-                     "value": "/^4\\d{2}$/"
-                  }
-               ]
+               "expr": "http_server_request_latency{job=~\"[[job]]\",quantile=\"0.99\",status=~\"^4\\\\d{2}$\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
+               "refId": "A"
             }
          ],
          "thresholds": [ ],
@@ -888,7 +526,7 @@
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "${DS_INFLUXDB}",
+         "datasource": "${DS_PROMETHEUS}",
          "decimals": 3,
          "description": "99th percentile of requests latency. Includes only requests processed with 5xx error on Tarantool's side.\n",
          "fill": 0,
@@ -928,82 +566,11 @@
          "steppedLine": false,
          "targets": [
             {
-               "alias": "$tag_label_pairs_alias — $tag_label_pairs_method $tag_label_pairs_path (code $tag_label_pairs_status)",
-               "groupBy": [
-                  {
-                     "params": [
-                        "$__interval"
-                     ],
-                     "type": "time"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_alias"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_path"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_method"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_status"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "none"
-                     ],
-                     "type": "fill"
-                  }
-               ],
-               "measurement": "${INFLUXDB_MEASUREMENT}",
-               "policy": "${INFLUXDB_POLICY}",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                  [
-                     {
-                        "params": [
-                           "value"
-                        ],
-                        "type": "field"
-                     },
-                     {
-                        "params": [ ],
-                        "type": "mean"
-                     }
-                  ]
-               ],
-               "tags": [
-                  {
-                     "key": "metric_name",
-                     "operator": "=",
-                     "value": "http_server_request_latency"
-                  },
-                  {
-                     "condition": "AND",
-                     "key": "label_pairs_quantile",
-                     "operator": "=",
-                     "value": "0.99"
-                  },
-                  {
-                     "condition": "AND",
-                     "key": "label_pairs_status",
-                     "operator": "=~",
-                     "value": "/^5\\d{2}$/"
-                  }
-               ]
+               "expr": "http_server_request_latency{job=~\"[[job]]\",quantile=\"0.99\",status=~\"^5\\\\d{2}$\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
+               "refId": "A"
             }
          ],
          "thresholds": [ ],
@@ -1082,7 +649,7 @@
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "${DS_INFLUXDB}",
+         "datasource": "${DS_PROMETHEUS}",
          "decimals": 2,
          "description": "`quota_used_ratio` = `quota_used` / `quota_size`.\n\n`quota_used` – used by slab allocator (for both tuple and index slabs).\n\n`quota_size` – memory limit for slab allocator (as configured in the *memtx_memory* parameter).\n",
          "fill": 0,
@@ -1122,52 +689,11 @@
          "steppedLine": false,
          "targets": [
             {
-               "alias": "$tag_label_pairs_alias",
-               "groupBy": [
-                  {
-                     "params": [
-                        "$__interval"
-                     ],
-                     "type": "time"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_alias"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "none"
-                     ],
-                     "type": "fill"
-                  }
-               ],
-               "measurement": "${INFLUXDB_MEASUREMENT}",
-               "policy": "${INFLUXDB_POLICY}",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                  [
-                     {
-                        "params": [
-                           "value"
-                        ],
-                        "type": "field"
-                     },
-                     {
-                        "params": [ ],
-                        "type": "mean"
-                     }
-                  ]
-               ],
-               "tags": [
-                  {
-                     "key": "metric_name",
-                     "operator": "=",
-                     "value": "tnt_slab_quota_used_ratio"
-                  }
-               ]
+               "expr": "tnt_slab_quota_used_ratio{job=~\"[[job]]\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
             }
          ],
          "thresholds": [ ],
@@ -1213,7 +739,7 @@
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "${DS_INFLUXDB}",
+         "datasource": "${DS_PROMETHEUS}",
          "decimals": 2,
          "description": "`arena_used_ratio` = `arena_used` / `arena_size`.\n\n`arena_used` – used for both tuples and indexes.\n\n`arena_size` – allocated for both tuples and indexes.\n",
          "fill": 0,
@@ -1253,52 +779,11 @@
          "steppedLine": false,
          "targets": [
             {
-               "alias": "$tag_label_pairs_alias",
-               "groupBy": [
-                  {
-                     "params": [
-                        "$__interval"
-                     ],
-                     "type": "time"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_alias"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "none"
-                     ],
-                     "type": "fill"
-                  }
-               ],
-               "measurement": "${INFLUXDB_MEASUREMENT}",
-               "policy": "${INFLUXDB_POLICY}",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                  [
-                     {
-                        "params": [
-                           "value"
-                        ],
-                        "type": "field"
-                     },
-                     {
-                        "params": [ ],
-                        "type": "mean"
-                     }
-                  ]
-               ],
-               "tags": [
-                  {
-                     "key": "metric_name",
-                     "operator": "=",
-                     "value": "tnt_slab_arena_used_ratio"
-                  }
-               ]
+               "expr": "tnt_slab_arena_used_ratio{job=~\"[[job]]\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
             }
          ],
          "thresholds": [ ],
@@ -1344,7 +829,7 @@
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "${DS_INFLUXDB}",
+         "datasource": "${DS_PROMETHEUS}",
          "decimals": 2,
          "description": "`items_used_ratio` = `items_used` / `items_size`.\n\n`items_used` – used only for tuples.\n\n`items_size` – allocated only for tuples.\n",
          "fill": 0,
@@ -1384,52 +869,11 @@
          "steppedLine": false,
          "targets": [
             {
-               "alias": "$tag_label_pairs_alias",
-               "groupBy": [
-                  {
-                     "params": [
-                        "$__interval"
-                     ],
-                     "type": "time"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_alias"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "none"
-                     ],
-                     "type": "fill"
-                  }
-               ],
-               "measurement": "${INFLUXDB_MEASUREMENT}",
-               "policy": "${INFLUXDB_POLICY}",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                  [
-                     {
-                        "params": [
-                           "value"
-                        ],
-                        "type": "field"
-                     },
-                     {
-                        "params": [ ],
-                        "type": "mean"
-                     }
-                  ]
-               ],
-               "tags": [
-                  {
-                     "key": "metric_name",
-                     "operator": "=",
-                     "value": "tnt_slab_items_used_ratio"
-                  }
-               ]
+               "expr": "tnt_slab_items_used_ratio{job=~\"[[job]]\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
             }
          ],
          "thresholds": [ ],
@@ -1475,7 +919,7 @@
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "${DS_INFLUXDB}",
+         "datasource": "${DS_PROMETHEUS}",
          "decimals": 2,
          "description": "Memory used by slab allocator (for both tuple and index slabs).\n",
          "fill": 0,
@@ -1515,52 +959,11 @@
          "steppedLine": false,
          "targets": [
             {
-               "alias": "$tag_label_pairs_alias",
-               "groupBy": [
-                  {
-                     "params": [
-                        "$__interval"
-                     ],
-                     "type": "time"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_alias"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "none"
-                     ],
-                     "type": "fill"
-                  }
-               ],
-               "measurement": "${INFLUXDB_MEASUREMENT}",
-               "policy": "${INFLUXDB_POLICY}",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                  [
-                     {
-                        "params": [
-                           "value"
-                        ],
-                        "type": "field"
-                     },
-                     {
-                        "params": [ ],
-                        "type": "mean"
-                     }
-                  ]
-               ],
-               "tags": [
-                  {
-                     "key": "metric_name",
-                     "operator": "=",
-                     "value": "tnt_slab_quota_used"
-                  }
-               ]
+               "expr": "tnt_slab_quota_used{job=~\"[[job]]\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
             }
          ],
          "thresholds": [ ],
@@ -1606,7 +1009,7 @@
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "${DS_INFLUXDB}",
+         "datasource": "${DS_PROMETHEUS}",
          "decimals": 2,
          "description": "Memory used for both tuples and indexes.\n",
          "fill": 0,
@@ -1646,52 +1049,11 @@
          "steppedLine": false,
          "targets": [
             {
-               "alias": "$tag_label_pairs_alias",
-               "groupBy": [
-                  {
-                     "params": [
-                        "$__interval"
-                     ],
-                     "type": "time"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_alias"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "none"
-                     ],
-                     "type": "fill"
-                  }
-               ],
-               "measurement": "${INFLUXDB_MEASUREMENT}",
-               "policy": "${INFLUXDB_POLICY}",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                  [
-                     {
-                        "params": [
-                           "value"
-                        ],
-                        "type": "field"
-                     },
-                     {
-                        "params": [ ],
-                        "type": "mean"
-                     }
-                  ]
-               ],
-               "tags": [
-                  {
-                     "key": "metric_name",
-                     "operator": "=",
-                     "value": "tnt_slab_arena_used"
-                  }
-               ]
+               "expr": "tnt_slab_arena_used{job=~\"[[job]]\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
             }
          ],
          "thresholds": [ ],
@@ -1737,7 +1099,7 @@
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "${DS_INFLUXDB}",
+         "datasource": "${DS_PROMETHEUS}",
          "decimals": 2,
          "description": "Memory used for only tuples.\n",
          "fill": 0,
@@ -1777,52 +1139,11 @@
          "steppedLine": false,
          "targets": [
             {
-               "alias": "$tag_label_pairs_alias",
-               "groupBy": [
-                  {
-                     "params": [
-                        "$__interval"
-                     ],
-                     "type": "time"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_alias"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "none"
-                     ],
-                     "type": "fill"
-                  }
-               ],
-               "measurement": "${INFLUXDB_MEASUREMENT}",
-               "policy": "${INFLUXDB_POLICY}",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                  [
-                     {
-                        "params": [
-                           "value"
-                        ],
-                        "type": "field"
-                     },
-                     {
-                        "params": [ ],
-                        "type": "mean"
-                     }
-                  ]
-               ],
-               "tags": [
-                  {
-                     "key": "metric_name",
-                     "operator": "=",
-                     "value": "tnt_slab_items_used"
-                  }
-               ]
+               "expr": "tnt_slab_items_used{job=~\"[[job]]\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
             }
          ],
          "thresholds": [ ],
@@ -1868,7 +1189,7 @@
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "${DS_INFLUXDB}",
+         "datasource": "${DS_PROMETHEUS}",
          "decimals": 2,
          "description": "Memory limit for slab allocator (as configured in the *memtx_memory* parameter).\n",
          "fill": 0,
@@ -1908,52 +1229,11 @@
          "steppedLine": false,
          "targets": [
             {
-               "alias": "$tag_label_pairs_alias",
-               "groupBy": [
-                  {
-                     "params": [
-                        "$__interval"
-                     ],
-                     "type": "time"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_alias"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "none"
-                     ],
-                     "type": "fill"
-                  }
-               ],
-               "measurement": "${INFLUXDB_MEASUREMENT}",
-               "policy": "${INFLUXDB_POLICY}",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                  [
-                     {
-                        "params": [
-                           "value"
-                        ],
-                        "type": "field"
-                     },
-                     {
-                        "params": [ ],
-                        "type": "mean"
-                     }
-                  ]
-               ],
-               "tags": [
-                  {
-                     "key": "metric_name",
-                     "operator": "=",
-                     "value": "tnt_slab_quota_size"
-                  }
-               ]
+               "expr": "tnt_slab_quota_size{job=~\"[[job]]\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
             }
          ],
          "thresholds": [ ],
@@ -1999,7 +1279,7 @@
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "${DS_INFLUXDB}",
+         "datasource": "${DS_PROMETHEUS}",
          "decimals": 2,
          "description": "Memory allocated for both tuples and indexes by slab allocator.\n",
          "fill": 0,
@@ -2039,52 +1319,11 @@
          "steppedLine": false,
          "targets": [
             {
-               "alias": "$tag_label_pairs_alias",
-               "groupBy": [
-                  {
-                     "params": [
-                        "$__interval"
-                     ],
-                     "type": "time"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_alias"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "none"
-                     ],
-                     "type": "fill"
-                  }
-               ],
-               "measurement": "${INFLUXDB_MEASUREMENT}",
-               "policy": "${INFLUXDB_POLICY}",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                  [
-                     {
-                        "params": [
-                           "value"
-                        ],
-                        "type": "field"
-                     },
-                     {
-                        "params": [ ],
-                        "type": "mean"
-                     }
-                  ]
-               ],
-               "tags": [
-                  {
-                     "key": "metric_name",
-                     "operator": "=",
-                     "value": "tnt_slab_arena_size"
-                  }
-               ]
+               "expr": "tnt_slab_arena_size{job=~\"[[job]]\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
             }
          ],
          "thresholds": [ ],
@@ -2130,7 +1369,7 @@
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "${DS_INFLUXDB}",
+         "datasource": "${DS_PROMETHEUS}",
          "decimals": 2,
          "description": "Memory allocated for only tuples by slab allocator.\n",
          "fill": 0,
@@ -2170,52 +1409,11 @@
          "steppedLine": false,
          "targets": [
             {
-               "alias": "$tag_label_pairs_alias",
-               "groupBy": [
-                  {
-                     "params": [
-                        "$__interval"
-                     ],
-                     "type": "time"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_alias"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "none"
-                     ],
-                     "type": "fill"
-                  }
-               ],
-               "measurement": "${INFLUXDB_MEASUREMENT}",
-               "policy": "${INFLUXDB_POLICY}",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                  [
-                     {
-                        "params": [
-                           "value"
-                        ],
-                        "type": "field"
-                     },
-                     {
-                        "params": [ ],
-                        "type": "mean"
-                     }
-                  ]
-               ],
-               "tags": [
-                  {
-                     "key": "metric_name",
-                     "operator": "=",
-                     "value": "tnt_slab_items_size"
-                  }
-               ]
+               "expr": "tnt_slab_items_size{job=~\"[[job]]\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
             }
          ],
          "thresholds": [ ],
@@ -2280,7 +1478,7 @@
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "${DS_INFLUXDB}",
+         "datasource": "${DS_PROMETHEUS}",
          "decimals": 2,
          "description": "Average count of SELECT requests per second from all Tarantool spaces",
          "fill": 0,
@@ -2320,64 +1518,11 @@
          "steppedLine": false,
          "targets": [
             {
-               "alias": "$tag_label_pairs_alias",
-               "groupBy": [
-                  {
-                     "params": [
-                        "$__interval"
-                     ],
-                     "type": "time"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_alias"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "none"
-                     ],
-                     "type": "fill"
-                  }
-               ],
-               "measurement": "${INFLUXDB_MEASUREMENT}",
-               "policy": "${INFLUXDB_POLICY}",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                  [
-                     {
-                        "params": [
-                           "value"
-                        ],
-                        "type": "field"
-                     },
-                     {
-                        "params": [ ],
-                        "type": "mean"
-                     },
-                     {
-                        "params": [
-                           "1s"
-                        ],
-                        "type": "non_negative_derivative"
-                     }
-                  ]
-               ],
-               "tags": [
-                  {
-                     "key": "metric_name",
-                     "operator": "=",
-                     "value": "tnt_stats_op_total"
-                  },
-                  {
-                     "condition": "AND",
-                     "key": "label_pairs_operation",
-                     "operator": "=",
-                     "value": "select"
-                  }
-               ]
+               "expr": "rate(tnt_stats_op_total{job=~\"[[job]]\",operation=\"select\"}[1m])",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
             }
          ],
          "thresholds": [ ],
@@ -2423,7 +1568,7 @@
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "${DS_INFLUXDB}",
+         "datasource": "${DS_PROMETHEUS}",
          "decimals": 2,
          "description": "Average count of INSERT requests per second from all Tarantool spaces",
          "fill": 0,
@@ -2463,64 +1608,11 @@
          "steppedLine": false,
          "targets": [
             {
-               "alias": "$tag_label_pairs_alias",
-               "groupBy": [
-                  {
-                     "params": [
-                        "$__interval"
-                     ],
-                     "type": "time"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_alias"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "none"
-                     ],
-                     "type": "fill"
-                  }
-               ],
-               "measurement": "${INFLUXDB_MEASUREMENT}",
-               "policy": "${INFLUXDB_POLICY}",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                  [
-                     {
-                        "params": [
-                           "value"
-                        ],
-                        "type": "field"
-                     },
-                     {
-                        "params": [ ],
-                        "type": "mean"
-                     },
-                     {
-                        "params": [
-                           "1s"
-                        ],
-                        "type": "non_negative_derivative"
-                     }
-                  ]
-               ],
-               "tags": [
-                  {
-                     "key": "metric_name",
-                     "operator": "=",
-                     "value": "tnt_stats_op_total"
-                  },
-                  {
-                     "condition": "AND",
-                     "key": "label_pairs_operation",
-                     "operator": "=",
-                     "value": "insert"
-                  }
-               ]
+               "expr": "rate(tnt_stats_op_total{job=~\"[[job]]\",operation=\"insert\"}[1m])",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
             }
          ],
          "thresholds": [ ],
@@ -2566,7 +1658,7 @@
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "${DS_INFLUXDB}",
+         "datasource": "${DS_PROMETHEUS}",
          "decimals": 2,
          "description": "Average count of REPLACE requests per second from all Tarantool spaces",
          "fill": 0,
@@ -2606,64 +1698,11 @@
          "steppedLine": false,
          "targets": [
             {
-               "alias": "$tag_label_pairs_alias",
-               "groupBy": [
-                  {
-                     "params": [
-                        "$__interval"
-                     ],
-                     "type": "time"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_alias"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "none"
-                     ],
-                     "type": "fill"
-                  }
-               ],
-               "measurement": "${INFLUXDB_MEASUREMENT}",
-               "policy": "${INFLUXDB_POLICY}",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                  [
-                     {
-                        "params": [
-                           "value"
-                        ],
-                        "type": "field"
-                     },
-                     {
-                        "params": [ ],
-                        "type": "mean"
-                     },
-                     {
-                        "params": [
-                           "1s"
-                        ],
-                        "type": "non_negative_derivative"
-                     }
-                  ]
-               ],
-               "tags": [
-                  {
-                     "key": "metric_name",
-                     "operator": "=",
-                     "value": "tnt_stats_op_total"
-                  },
-                  {
-                     "condition": "AND",
-                     "key": "label_pairs_operation",
-                     "operator": "=",
-                     "value": "replace"
-                  }
-               ]
+               "expr": "rate(tnt_stats_op_total{job=~\"[[job]]\",operation=\"replace\"}[1m])",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
             }
          ],
          "thresholds": [ ],
@@ -2709,7 +1748,7 @@
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "${DS_INFLUXDB}",
+         "datasource": "${DS_PROMETHEUS}",
          "decimals": 2,
          "description": "Average count of UPSERT requests per second from all Tarantool spaces",
          "fill": 0,
@@ -2749,64 +1788,11 @@
          "steppedLine": false,
          "targets": [
             {
-               "alias": "$tag_label_pairs_alias",
-               "groupBy": [
-                  {
-                     "params": [
-                        "$__interval"
-                     ],
-                     "type": "time"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_alias"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "none"
-                     ],
-                     "type": "fill"
-                  }
-               ],
-               "measurement": "${INFLUXDB_MEASUREMENT}",
-               "policy": "${INFLUXDB_POLICY}",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                  [
-                     {
-                        "params": [
-                           "value"
-                        ],
-                        "type": "field"
-                     },
-                     {
-                        "params": [ ],
-                        "type": "mean"
-                     },
-                     {
-                        "params": [
-                           "1s"
-                        ],
-                        "type": "non_negative_derivative"
-                     }
-                  ]
-               ],
-               "tags": [
-                  {
-                     "key": "metric_name",
-                     "operator": "=",
-                     "value": "tnt_stats_op_total"
-                  },
-                  {
-                     "condition": "AND",
-                     "key": "label_pairs_operation",
-                     "operator": "=",
-                     "value": "upsert"
-                  }
-               ]
+               "expr": "rate(tnt_stats_op_total{job=~\"[[job]]\",operation=\"upsert\"}[1m])",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
             }
          ],
          "thresholds": [ ],
@@ -2852,7 +1838,7 @@
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "${DS_INFLUXDB}",
+         "datasource": "${DS_PROMETHEUS}",
          "decimals": 2,
          "description": "Average count of UPDATE requests per second from all Tarantool spaces",
          "fill": 0,
@@ -2892,64 +1878,11 @@
          "steppedLine": false,
          "targets": [
             {
-               "alias": "$tag_label_pairs_alias",
-               "groupBy": [
-                  {
-                     "params": [
-                        "$__interval"
-                     ],
-                     "type": "time"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_alias"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "none"
-                     ],
-                     "type": "fill"
-                  }
-               ],
-               "measurement": "${INFLUXDB_MEASUREMENT}",
-               "policy": "${INFLUXDB_POLICY}",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                  [
-                     {
-                        "params": [
-                           "value"
-                        ],
-                        "type": "field"
-                     },
-                     {
-                        "params": [ ],
-                        "type": "mean"
-                     },
-                     {
-                        "params": [
-                           "1s"
-                        ],
-                        "type": "non_negative_derivative"
-                     }
-                  ]
-               ],
-               "tags": [
-                  {
-                     "key": "metric_name",
-                     "operator": "=",
-                     "value": "tnt_stats_op_total"
-                  },
-                  {
-                     "condition": "AND",
-                     "key": "label_pairs_operation",
-                     "operator": "=",
-                     "value": "update"
-                  }
-               ]
+               "expr": "rate(tnt_stats_op_total{job=~\"[[job]]\",operation=\"update\"}[1m])",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
             }
          ],
          "thresholds": [ ],
@@ -2995,7 +1928,7 @@
          "bars": false,
          "dashLength": 10,
          "dashes": false,
-         "datasource": "${DS_INFLUXDB}",
+         "datasource": "${DS_PROMETHEUS}",
          "decimals": 2,
          "description": "Average count of DELETE requests per second from all Tarantool spaces",
          "fill": 0,
@@ -3035,64 +1968,11 @@
          "steppedLine": false,
          "targets": [
             {
-               "alias": "$tag_label_pairs_alias",
-               "groupBy": [
-                  {
-                     "params": [
-                        "$__interval"
-                     ],
-                     "type": "time"
-                  },
-                  {
-                     "params": [
-                        "label_pairs_alias"
-                     ],
-                     "type": "tag"
-                  },
-                  {
-                     "params": [
-                        "none"
-                     ],
-                     "type": "fill"
-                  }
-               ],
-               "measurement": "${INFLUXDB_MEASUREMENT}",
-               "policy": "${INFLUXDB_POLICY}",
-               "refId": "A",
-               "resultFormat": "time_series",
-               "select": [
-                  [
-                     {
-                        "params": [
-                           "value"
-                        ],
-                        "type": "field"
-                     },
-                     {
-                        "params": [ ],
-                        "type": "mean"
-                     },
-                     {
-                        "params": [
-                           "1s"
-                        ],
-                        "type": "non_negative_derivative"
-                     }
-                  ]
-               ],
-               "tags": [
-                  {
-                     "key": "metric_name",
-                     "operator": "=",
-                     "value": "tnt_stats_op_total"
-                  },
-                  {
-                     "condition": "AND",
-                     "key": "label_pairs_operation",
-                     "operator": "=",
-                     "value": "delete"
-                  }
-               ]
+               "expr": "rate(tnt_stats_op_total{job=~\"[[job]]\",operation=\"delete\"}[1m])",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
             }
          ],
          "thresholds": [ ],
@@ -3143,7 +2023,29 @@
       "tag2"
    ],
    "templating": {
-      "list": [ ]
+      "list": [
+         {
+            "allValue": null,
+            "current": {
+               "text": "${PROMETHEUS_JOB}",
+               "value": "${PROMETHEUS_JOB}"
+            },
+            "hide": 2,
+            "includeAll": false,
+            "label": "Prometheus job",
+            "multi": false,
+            "name": "job",
+            "options": [
+               {
+                  "text": "${PROMETHEUS_JOB}",
+                  "value": "${PROMETHEUS_JOB}"
+               }
+            ],
+            "query": "${PROMETHEUS_JOB}",
+            "refresh": 0,
+            "type": "custom"
+         }
+      ]
    },
    "time": {
       "from": "now-6h",
@@ -3175,6 +2077,6 @@
       ]
    },
    "timezone": "browser",
-   "title": "Example InfluxDB dashboard",
+   "title": "Example Prometheus dashboard",
    "version": 0
 }


### PR DESCRIPTION
Rework code to support both InfluxDB and Prometheus targets.
Add Prometheus dashboard (closes #14).
Clean up code (closes #24).