### PR TITLE
Replace average collector with summary collector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## Changed
+- Update metrics version to 0.5.0
+- Replace average latency collector with summary collector in example cluster
+- Replace average latency panels with summary 99th percentile panels
+
 ## Fixed
 - Example cluster now starts successfully
+- Example cluster metrics no more breaks Prometheus metrics collect
 
 ## [0.1.1] - 2020-09-04
 Grafana revisions: [InfluxDB revision 2](https://grafana.com/api/dashboards/12567/revisions/2/download)

--- a/example/project/app/roles/custom.lua
+++ b/example/project/app/roles/custom.lua
@@ -1,5 +1,6 @@
 local cartridge = require('cartridge')
 local config = require('cartridge.argparse')
+local fiber = require('fiber')
 
 local function init(opts) -- luacheck: no unused args
     local local_cfg = config.get_opts({
@@ -10,13 +11,14 @@ local function init(opts) -- luacheck: no unused args
     local metrics = cartridge.service_get('metrics')
     local http_middleware = metrics.http_middleware
 
-    local http_collector = http_middleware.build_default_collector('average')
+    local http_collector = http_middleware.build_default_collector('summary')
 
     local httpd = cartridge.service_get('httpd')
     httpd:route(
         { method = 'GET', path = '/hello' },
         http_middleware.v1(
             function()
+                fiber.sleep(0.02)
                 return { status = 200, body = 'Hello world!' }
             end,
             http_collector
@@ -26,6 +28,7 @@ local function init(opts) -- luacheck: no unused args
         { method = 'GET', path = '/hell0' },
         http_middleware.v1(
             function()
+                fiber.sleep(0.01)
                 return { status = 400, body = 'Hell0 world!' }
             end,
             http_collector
@@ -35,6 +38,7 @@ local function init(opts) -- luacheck: no unused args
         { method = 'POST', path = '/goodbye' },
         http_middleware.v1(
             function()
+                fiber.sleep(0.005)
                 return { status = 500, body = 'Goodbye cruel world!' }
             end,
             http_collector

--- a/example/project/project-scm-1.rockspec
+++ b/example/project/project-scm-1.rockspec
@@ -10,7 +10,7 @@ dependencies = {
     'checks == 3.0.1-1',
     'http == 1.1.0-1',
     'cartridge == 2.1.2-1',
-    'metrics ~> 0.3'
+    'metrics == 0.5.0-1'
 }
 build = {
     type = 'none';

--- a/example/telegraf/telegraf.conf
+++ b/example/telegraf/telegraf.conf
@@ -7,7 +7,15 @@
         "http://example_project:8085/metrics"
     ]
     timeout = "30s"
-    tag_keys = ["metric_name", "label_pairs_alias", "label_pairs_path", "label_pairs_method", "label_pairs_status", "label_pairs_operation"]
+    tag_keys = [
+        "metric_name",
+        "label_pairs_alias",
+        "label_pairs_quantile",
+        "label_pairs_path",
+        "label_pairs_method",
+        "label_pairs_status",
+        "label_pairs_operation"
+    ]
     insecure_skip_verify = true
     interval = "10s"
     data_format = "json"

--- a/tarantool/http.libsonnet
+++ b/tarantool/http.libsonnet
@@ -110,6 +110,8 @@ local influxdb = grafana.influxdb;
     policy,
     measurement,
     metric_name,
+    quantile,
+    label,
     status_regex,
   ) = graph.new(
     title=title,
@@ -117,7 +119,7 @@ local influxdb = grafana.influxdb;
     datasource=datasource,
 
     format='s',
-    labelY1='average',
+    labelY1=label,
     fill=0,
     decimals=3,
     decimalsY1=2,
@@ -135,20 +137,22 @@ local influxdb = grafana.influxdb;
       measurement=measurement,
       group_tags=['label_pairs_alias', 'label_pairs_path', 'label_pairs_method', 'label_pairs_status'],
       alias='$tag_label_pairs_alias — $tag_label_pairs_method $tag_label_pairs_path (code $tag_label_pairs_status)',
-    ).where('metric_name', '=', metric_name).where('label_pairs_status', '=~', status_regex)
-    .selectField('value').addConverter('mean')
+    ).where('metric_name', '=', metric_name).where('label_pairs_quantile', '=', quantile)
+    .where('label_pairs_status', '=~', status_regex).selectField('value').addConverter('mean')
   ),
 
   latency_success(
     title='Success requests latency (code 2xx)',
     description=|||
-      Latency of requests, processed with success (code 2xx) on Tarantool's side.
+      99th percentile of requests latency. Includes only requests processed with success (code 2xx) on Tarantool's side.
     |||,
 
     datasource=null,
     policy=null,
     measurement=null,
-    metric_name='http_server_request_latency_avg',
+    metric_name='http_server_request_latency',
+    quantile='0.99',
+    label='99th percentile',
   ):: latency_graph(
     title=title,
     description=description,
@@ -156,19 +160,23 @@ local influxdb = grafana.influxdb;
     policy=policy,
     measurement=measurement,
     metric_name=metric_name,
+    quantile=quantile,
+    label=label,
     status_regex='/^2\\d{2}$/',
   ),
 
   latency_error_4xx(
     title='Error requests latency (code 4xx)',
     description=|||
-      Latency of requests, processed with 4xx error on Tarantool's side.
+      99th percentile of requests latency. Includes only requests processed with 4xx error on Tarantool's side.
     |||,
 
     datasource=null,
     policy=null,
     measurement=null,
-    metric_name='http_server_request_latency_avg',
+    metric_name='http_server_request_latency',
+    quantile='0.99',
+    label='99th percentile',
   ):: latency_graph(
     title=title,
     description=description,
@@ -176,19 +184,23 @@ local influxdb = grafana.influxdb;
     policy=policy,
     measurement=measurement,
     metric_name=metric_name,
+    quantile=quantile,
+    label=label,
     status_regex='/^4\\d{2}$/',
   ),
 
   latency_error_5xx(
     title='Error requests latency (code 5xx)',
     description=|||
-      Latency of requests, processed with 5xx error on Tarantool's side.
+      99th percentile of requests latency. Includes only requests processed with 5xx error on Tarantool's side.
     |||,
 
     datasource=null,
     policy=null,
     measurement=null,
-    metric_name='http_server_request_latency_avg',
+    metric_name='http_server_request_latency',
+    quantile='0.99',
+    label='99th percentile',
   ):: latency_graph(
     title=title,
     description=description,
@@ -196,6 +208,8 @@ local influxdb = grafana.influxdb;
     policy=policy,
     measurement=measurement,
     metric_name=metric_name,
+    quantile=quantile,
+    label=label,
     status_regex='/^5\\d{2}$/',
   ),
 }

--- a/tests/InfluxDB/dashboard_compiled.json
+++ b/tests/InfluxDB/dashboard_compiled.json
@@ -568,7 +568,7 @@
          "dashes": false,
          "datasource": "${DS_INFLUXDB}",
          "decimals": 3,
-         "description": "Latency of requests, processed with success (code 2xx) on Tarantool's side.\n",
+         "description": "99th percentile of requests latency. Includes only requests processed with success (code 2xx) on Tarantool's side.\n",
          "fill": 0,
          "gridPos": {
             "h": 8,
@@ -667,7 +667,13 @@
                   {
                      "key": "metric_name",
                      "operator": "=",
-                     "value": "http_server_request_latency_avg"
+                     "value": "http_server_request_latency"
+                  },
+                  {
+                     "condition": "AND",
+                     "key": "label_pairs_quantile",
+                     "operator": "=",
+                     "value": "0.99"
                   },
                   {
                      "condition": "AND",
@@ -699,7 +705,7 @@
             {
                "decimals": 2,
                "format": "s",
-               "label": "average",
+               "label": "99th percentile",
                "logBase": 1,
                "max": null,
                "min": null,
@@ -723,7 +729,7 @@
          "dashes": false,
          "datasource": "${DS_INFLUXDB}",
          "decimals": 3,
-         "description": "Latency of requests, processed with 4xx error on Tarantool's side.\n",
+         "description": "99th percentile of requests latency. Includes only requests processed with 4xx error on Tarantool's side.\n",
          "fill": 0,
          "gridPos": {
             "h": 8,
@@ -822,7 +828,13 @@
                   {
                      "key": "metric_name",
                      "operator": "=",
-                     "value": "http_server_request_latency_avg"
+                     "value": "http_server_request_latency"
+                  },
+                  {
+                     "condition": "AND",
+                     "key": "label_pairs_quantile",
+                     "operator": "=",
+                     "value": "0.99"
                   },
                   {
                      "condition": "AND",
@@ -854,7 +866,7 @@
             {
                "decimals": 2,
                "format": "s",
-               "label": "average",
+               "label": "99th percentile",
                "logBase": 1,
                "max": null,
                "min": null,
@@ -878,7 +890,7 @@
          "dashes": false,
          "datasource": "${DS_INFLUXDB}",
          "decimals": 3,
-         "description": "Latency of requests, processed with 5xx error on Tarantool's side.\n",
+         "description": "99th percentile of requests latency. Includes only requests processed with 5xx error on Tarantool's side.\n",
          "fill": 0,
          "gridPos": {
             "h": 8,
@@ -977,7 +989,13 @@
                   {
                      "key": "metric_name",
                      "operator": "=",
-                     "value": "http_server_request_latency_avg"
+                     "value": "http_server_request_latency"
+                  },
+                  {
+                     "condition": "AND",
+                     "key": "label_pairs_quantile",
+                     "operator": "=",
+                     "value": "0.99"
                   },
                   {
                      "condition": "AND",
@@ -1009,7 +1027,7 @@
             {
                "decimals": 2,
                "format": "s",
-               "label": "average",
+               "label": "99th percentile",
                "logBase": 1,
                "max": null,
                "min": null,


### PR DESCRIPTION
Update metrics version to 0.5.0.
Replace average latency collector with summary collector in example cluster.
Example cluster metrics no more breaks Prometheus metrics collect (closes #13).
Replace average latency panels with summary 99th percentile panels (closes #29).