### PR TITLE
Prometheus example alert rules

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on:
     - ubuntu-latest
     container:
-      image: golang:1.14.2-alpine3.11
+      image: golang:1.16.2-alpine3.13
     steps:
       - name: Prepare container # Fails with "Not a git repo" with git version < 2.18
-        run: apk add --update git make
+        run: apk add --update git make gcc libc-dev
 
       - name: Check out git repo
         uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 - Prometheus example alert rules (instance state, memory usage, HTTP load and latency rule examples)
+- Test Prometheus example alert rules with promtool
 
 ## [0.2.3] - 2021-03-11
 Grafana revisions: [InfluxDB revision 4](https://grafana.com/api/dashboards/12567/revisions/4/download), [Prometheus revision 4](https://grafana.com/api/dashboards/13054/revisions/4/download)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## Added
+- Prometheus example alert rules (instance state, memory usage, HTTP load and latency rule examples)
+
 ## [0.2.3] - 2021-03-11
 Grafana revisions: [InfluxDB revision 4](https://grafana.com/api/dashboards/12567/revisions/4/download), [Prometheus revision 4](https://grafana.com/api/dashboards/13054/revisions/4/download)
 

--- a/Makefile
+++ b/Makefile
@@ -5,9 +5,11 @@ install:
 	go get github.com/google/go-jsonnet/cmd/jsonnetfmt
 	go get github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
 	jb install
+	GO111MODULE=on go get github.com/prometheus/prometheus/cmd/promtool@fcfc0e8888749cbf67aa9aac14c5d78e4c23d0a5
 
 test:
 	./tests.sh
+	promtool test rules example/prometheus/test_alerts.yml
 
 update-tests:
 	./tests.sh update

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
       - 9090:9090
     volumes:
       - ./example/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./example/prometheus/alerts.yml:/etc/prometheus/alerts.yml
 
   grafana:
     image: grafana/grafana:6.6.0

--- a/example/prometheus/alerts.yml
+++ b/example/prometheus/alerts.yml
@@ -1,0 +1,155 @@
+groups:
+- name: common
+  rules:
+  # Alert for any instance that is unreachable by Prometheus for more than a minute.
+  - alert: InstanceDown
+    expr: up == 0
+    for: 1m
+    labels:
+      severity: page
+    annotations:
+      summary: "Instance {{ $labels.instance }} down"
+      description: "{{ $labels.instance }} of job {{ $labels.job }} has been down for more than a minute."
+
+
+- name: tarantool-common
+  rules:
+  # Warning for any instance that uses too Lua runtime memory.
+  - alert: LuaRuntimeWarning
+    expr: tnt_info_memory_lua >= (512 * 1024 * 1024) 
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Instance {{ $labels.alias }} Lua runtime warning"
+      description: "{{ $labels.alias }} instance of job {{ $labels.job }} uses too much Lua memory
+        and may hit threshold soon."
+
+  # Alert for any instance that uses too Lua runtime memory.
+  - alert: LuaRuntimeAlert
+    expr: tnt_info_memory_lua >= (1024 * 1024 * 1024) 
+    for: 1m
+    labels:
+      severity: page
+    annotations:
+      summary: "Instance {{ $labels.alias }} Lua runtime alert"
+      description: "{{ $labels.alias }} instance of job {{ $labels.job }} uses too much Lua memory
+        and likely to hit threshold soon."
+
+  # Warning for any instance that have low remaining arena memory.
+  - alert: MemtxArenaWarning
+    expr: (tnt_slab_quota_used_ratio >= 80) and (tnt_slab_arena_used_ratio >= 80)
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Instance {{ $labels.alias }} low arena memory remaining"
+      description: "Low arena memory (tuples and indexes) remaining for {{ $labels.alias }} instance of job {{ $labels.job }}.
+        Consider increasing memtx_memory or number of storages in case of sharded data."
+
+  # Alert for any instance that have low remaining arena memory.
+  - alert: MemtxArenaAlert
+    expr: (tnt_slab_quota_used_ratio >= 90) and (tnt_slab_arena_used_ratio >= 90)
+    for: 1m
+    labels:
+      severity: page
+    annotations:
+      summary: "Instance {{ $labels.alias }} low arena memory remaining"
+      description: "Low arena memory (tuples and indexes) remaining for {{ $labels.alias }} instance of job {{ $labels.job }}.
+      You are likely to hit limit soon.
+      It is strongly recommended to increase memtx_memory or number of storages in case of sharded data."
+
+  # Warning for any instance that have low remaining items memory.
+  - alert: MemtxItemsWarning
+    expr: (tnt_slab_quota_used_ratio >= 80) and (tnt_slab_items_used_ratio >= 80)
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Instance {{ $labels.alias }} low items memory remaining"
+      description: "Low items memory (tuples) remaining for {{ $labels.alias }} instance of job {{ $labels.job }}.
+        Consider increasing memtx_memory or number of storages in case of sharded data."
+
+  # Alert for any instance that have low remaining arena memory.
+  - alert: MemtxItemsAlert
+    expr: (tnt_slab_quota_used_ratio >= 90) and (tnt_slab_items_used_ratio >= 90)
+    for: 1m
+    labels:
+      severity: page
+    annotations:
+      summary: "Instance {{ $labels.alias }} low items memory remaining"
+      description: "Low items memory (tuples) remaining for {{ $labels.alias }} instance of job {{ $labels.job }}.
+      You are likely to hit limit soon.
+      It is strongly recommended to increase memtx_memory or number of storages in case of sharded data."
+
+- name: tarantool-business
+  rules:
+  # Warning for any endpoint of an instance in example_project job that responds too long.
+  # Beware that metric name depends on name of the collector you use in HTTP metrics middleware
+  # and request depends on type of this collector.
+  # This example based on summary collector with default name.
+  - alert: HTTPHighLatency
+    expr: http_server_request_latency{ job="example_project", quantile="0.99" } > 0.1
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Instance {{ $labels.alias }} high HTTP latency"
+      description: "Some {{ $labels.method }} requests to {{ $labels.path }} path with {{ $labels.status }} response status
+        on {{ $labels.alias }} instance of job {{ $labels.job }} are processed too long."
+
+  # Warning for any endpoint of an instance in example_project job that sends too much 4xx responses.
+  # Beware that metric name depends on name of the collector you use in HTTP metrics middleware
+  # and request depends on type of this collector.
+  # This example based on summary collector with default name.
+  - alert: HTTPHighClientErrorRateInstance
+    expr: sum by (job, instance, method, path, alias) (rate(http_server_request_latency_count{ job="example_project", status=~"^4\\d{2}$" }[5m])) > 10
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Instance {{ $labels.alias }} high rate of client error responses"
+      description: "Too many {{ $labels.method }} requests to {{ $labels.path }} path 
+        on {{ $labels.alias }} instance of job {{ $labels.job }} get client error (4xx) responses."
+
+  # Warning for any endpoint in example_project job that sends too much 4xx responses (cluster overall).
+  # Beware that metric name depends on name of the collector you use in HTTP metrics middleware
+  # and request depends on type of this collector.
+  # This example based on summary collector with default name.
+  - alert: HTTPHighClientErrorRate
+    expr: sum by (job, method, path) (rate(http_server_request_latency_count{ job="example_project", status=~"^4\\d{2}$" }[5m])) > 20
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Job {{ $labels.job }} high rate of client error responses"
+      description: "Too many {{ $labels.method }} requests to {{ $labels.path }} path
+        on instances of job {{ $labels.job }} get client error (4xx) responses."
+
+  # Warning for any endpoint of an instance in example_project job that sends 5xx responses.
+  # Beware that metric name depends on name of the collector you use in HTTP metrics middleware
+  # and request depends on type of this collector.
+  # This example based on summary collector with default name.
+  - alert: HTTPServerErrors
+    expr: sum by (job, instance, method, path, alias) (rate(http_server_request_latency_count{ job="example_project", status=~"^5\\d{2}$" }[5m])) > 0
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Instance {{ $labels.alias }} server error responses"
+      description: "Some {{ $labels.method }} requests to {{ $labels.path }} path 
+        on {{ $labels.alias }} instance of job {{ $labels.job }} get server error (5xx) responses."
+
+  # Warning for any endpoint of a router instance (with "router" in alias) in example_project job that gets too little requests.
+  # Beware that metric name depends on name of the collector you use in HTTP metrics middleware
+  # and request depends on type of this collector.
+  # This example based on summary collector with default name.
+  - alert: HTTPLowRequestRateRouter
+    expr: sum by (job, instance, alias) (rate(http_server_request_latency_count{ job="example_project", alias=~"^.*router.*$" }[5m])) < 10
+    for: 5m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Router {{ $labels.alias }} low activity"
+      description: Router {{ $labels.alias }} instance of job {{ $labels.job }} gets too little requests.
+        Please, check up your balancer middleware."

--- a/example/prometheus/prometheus.yml
+++ b/example/prometheus/prometheus.yml
@@ -1,7 +1,7 @@
 # my global config
 global:
-  scrape_interval: 1m # Set the scrape interval to every 15 seconds. Default is every 1 minute.
-  evaluation_interval: 1m # Evaluate rules every 15 seconds. The default is every 1 minute.
+  scrape_interval: 15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
   # scrape_timeout is set to the global default (10s).
 
 # Alertmanager configuration
@@ -13,8 +13,7 @@ alerting:
 
 # Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
 rule_files:
-  # - "first_rules.yml"
-  # - "second_rules.yml"
+  - "alerts.yml"
 
 # A scrape configuration containing exactly one endpoint to scrape:
 # Here it's Prometheus itself.

--- a/example/prometheus/test_alerts.yml
+++ b/example/prometheus/test_alerts.yml
@@ -1,0 +1,355 @@
+# This is a list of rule files to consider for testing. Globs are supported.
+rule_files:
+  - alerts.yml
+
+# optional, default = 1m
+evaluation_interval: 15s
+
+# All the tests are listed here.
+tests:
+  - interval: 15s
+    input_series:
+      - series: 'up{job="example_project", instance="example_project:8081"}'
+        values: '1+0x12'
+      - series: 'up{job="example_project", instance="example_project:8082"}'
+        values: '1 0+0x11'
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: InstanceDown
+        exp_alerts:
+          - exp_labels:
+              severity: page
+              instance: example_project:8082
+              job: example_project
+            exp_annotations:
+              summary: "Instance example_project:8082 down"
+              description: "example_project:8082 of job example_project has been down for more than a minute."
+
+
+  - interval: 15s
+    input_series:
+      - series: 'tnt_info_memory_lua{job="example_project", instance="example_project:8081", alias="tnt_router"}'
+        values: '209715200+104857600x8' # 200 Mb + 100 Mb each interval
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: LuaRuntimeWarning
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: example_project:8081
+              alias: tnt_router
+              job: example_project
+            exp_annotations:
+              summary: "Instance tnt_router Lua runtime warning"
+              description: "tnt_router instance of job example_project uses too much Lua memory
+                and may hit threshold soon."
+      - eval_time: 2m
+        alertname: LuaRuntimeAlert
+        exp_alerts: # no alert firing
+
+
+  - interval: 15s
+    input_series:
+      - series: 'tnt_info_memory_lua{job="example_project", instance="example_project:8081", alias="tnt_router"}'
+        values: '419430400+209715200x8' # 400 Mb + 200 Mb each interval
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: LuaRuntimeWarning
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: example_project:8081
+              alias: tnt_router
+              job: example_project
+            exp_annotations:
+              summary: "Instance tnt_router Lua runtime warning"
+              description: "tnt_router instance of job example_project uses too much Lua memory
+                and may hit threshold soon."
+      - eval_time: 2m
+        alertname: LuaRuntimeAlert
+        exp_alerts:
+          - exp_labels:
+              severity: page
+              instance: example_project:8081
+              alias: tnt_router
+              job: example_project
+            exp_annotations:
+              summary: "Instance tnt_router Lua runtime alert"
+              description: "tnt_router instance of job example_project uses too much Lua memory
+                and likely to hit threshold soon."
+
+
+  - interval: 15s
+    input_series:
+      - series: 'tnt_slab_quota_used_ratio{job="example_project", instance="example_project:8081", alias="tnt_router"}'
+        values: '75+0x2 92+0x8'
+      - series: 'tnt_slab_arena_used_ratio{job="example_project", instance="example_project:8081", alias="tnt_router"}'
+        values: '92+0x2 76+0x8'
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: MemtxArenaWarning
+        exp_alerts: # no alert firing
+      - eval_time: 2m
+        alertname: MemtxArenaAlert
+        exp_alerts: # no alert firing
+
+
+  - interval: 15s
+    input_series:
+      - series: 'tnt_slab_quota_used_ratio{job="example_project", instance="example_project:8081", alias="tnt_router"}'
+        values: '75+0x2 92+0x8'
+      - series: 'tnt_slab_arena_used_ratio{job="example_project", instance="example_project:8081", alias="tnt_router"}'
+        values: '92+0x2 82+0x8'
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: MemtxArenaWarning
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: example_project:8081
+              alias: tnt_router
+              job: example_project
+            exp_annotations:
+              summary: "Instance tnt_router low arena memory remaining"
+              description: "Low arena memory (tuples and indexes) remaining for tnt_router instance of job example_project.
+                Consider increasing memtx_memory or number of storages in case of sharded data."
+      - eval_time: 2m
+        alertname: MemtxArenaAlert
+        exp_alerts: # no alert firing
+
+
+  - interval: 15s
+    input_series:
+      - series: 'tnt_slab_quota_used_ratio{job="example_project", instance="example_project:8081", alias="tnt_router"}'
+        values: '85+0x2 92+0x8'
+      - series: 'tnt_slab_arena_used_ratio{job="example_project", instance="example_project:8081", alias="tnt_router"}'
+        values: '92+0x2 91+0x8'
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: MemtxArenaWarning
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: example_project:8081
+              alias: tnt_router
+              job: example_project
+            exp_annotations:
+              summary: "Instance tnt_router low arena memory remaining"
+              description: "Low arena memory (tuples and indexes) remaining for tnt_router instance of job example_project.
+                Consider increasing memtx_memory or number of storages in case of sharded data."
+      - eval_time: 2m
+        alertname: MemtxArenaAlert
+        exp_alerts:
+          - exp_labels:
+              severity: page
+              instance: example_project:8081
+              alias: tnt_router
+              job: example_project
+            exp_annotations:
+              summary: "Instance tnt_router low arena memory remaining"
+              description: "Low arena memory (tuples and indexes) remaining for tnt_router instance of job example_project.
+                You are likely to hit limit soon.
+                It is strongly recommended to increase memtx_memory or number of storages in case of sharded data."
+
+
+  - interval: 15s
+    input_series:
+      - series: 'tnt_slab_quota_used_ratio{job="example_project", instance="example_project:8081", alias="tnt_router"}'
+        values: '75+0x2 92+0x8'
+      - series: 'tnt_slab_items_used_ratio{job="example_project", instance="example_project:8081", alias="tnt_router"}'
+        values: '95+0x2 79+0x8'
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: MemtxItemsWarning
+        exp_alerts: # no alert firing
+      - eval_time: 2m
+        alertname: MemtxItemsAlert
+        exp_alerts: # no alert firing
+
+
+  - interval: 15s
+    input_series:
+      - series: 'tnt_slab_quota_used_ratio{job="example_project", instance="example_project:8081", alias="tnt_router"}'
+        values: '75+0x2 92+0x8'
+      - series: 'tnt_slab_items_used_ratio{job="example_project", instance="example_project:8081", alias="tnt_router"}'
+        values: '92+0x2 82+0x8'
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: MemtxItemsWarning
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: example_project:8081
+              alias: tnt_router
+              job: example_project
+            exp_annotations:
+              summary: "Instance tnt_router low items memory remaining"
+              description: "Low items memory (tuples) remaining for tnt_router instance of job example_project.
+                Consider increasing memtx_memory or number of storages in case of sharded data."
+      - eval_time: 2m
+        alertname: MemtxItemsAlert
+        exp_alerts: # no alert firing
+
+
+  - interval: 15s
+    input_series:
+        - series: http_server_request_latency_count{job="example_project", instance="example_project:8081",path="/hello",method="GET",status="200",alias="tnt_router"}
+          values: '0+100x60'
+        - series: http_server_request_latency_sum{job="example_project", instance="example_project:8081",path="/hello",method="GET",status="200",alias="tnt_router"}
+          values: '0+2x60'
+        - series: http_server_request_latency{job="example_project", instance="example_project:8081",path="/hello",method="GET",status="200",alias="tnt_router",quantile="0.5"}
+          values: '0.02+0x60'
+        - series: http_server_request_latency{job="example_project", instance="example_project:8081",path="/hello",method="GET",status="200",alias="tnt_router",quantile="0.9"}
+          values: '0.05+0x60'
+        - series: http_server_request_latency{job="example_project", instance="example_project:8081",path="/hello",method="GET",status="200",alias="tnt_router",quantile="0.99"}
+          values: '0.11+0x60'
+    alert_rule_test:
+      - eval_time: 10m
+        alertname: HTTPHighLatency
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: example_project:8081
+              alias: tnt_router
+              job: example_project
+              path: /hello
+              method: GET
+              status: '200'
+              quantile: '0.99'
+            exp_annotations:
+              summary: "Instance tnt_router high HTTP latency"
+              description: "Some GET requests to /hello path with 200 response status
+                on tnt_router instance of job example_project are processed too long."
+
+
+  - interval: 15s
+    input_series:
+        - series: http_server_request_latency_count{job="example_project", instance="example_project:8081",path="/hell0",method="GET",status="400",alias="tnt_router"}
+          values: '0+200x100'
+        - series: http_server_request_latency_sum{job="example_project", instance="example_project:8081",path="/hell0",method="GET",status="400",alias="tnt_router"}
+          values: '0+2x100'
+        - series: http_server_request_latency{job="example_project", instance="example_project:8081",path="/hell0",method="GET",status="400",alias="tnt_router",quantile="0.5"}
+          values: '0.02+0x100'
+        - series: http_server_request_latency{job="example_project", instance="example_project:8081",path="/hell0",method="GET",status="400",alias="tnt_router",quantile="0.9"}
+          values: '0.02+0x100'
+        - series: http_server_request_latency{job="example_project", instance="example_project:8081",path="/hell0",method="GET",status="400",alias="tnt_router",quantile="0.99"}
+          values: '0.02+0x100'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: HTTPHighClientErrorRateInstance
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: example_project:8081
+              alias: tnt_router
+              job: example_project
+              path: /hell0
+              method: GET
+            exp_annotations:
+              summary: "Instance tnt_router high rate of client error responses"
+              description: "Too many GET requests to /hell0 path 
+                on tnt_router instance of job example_project get client error (4xx) responses."
+
+  # Total rate of 4xx is high, but distributed between different routers
+  - interval: 15s
+    input_series:
+        - series: http_server_request_latency_count{job="example_project", instance="example_project:8081",path="/hell0",method="GET",status="400",alias="tnt_router_1"}
+          values: '0+150x100'
+        - series: http_server_request_latency_sum{job="example_project", instance="example_project:8081",path="/hell0",method="GET",status="400",alias="tnt_router_1"}
+          values: '0+2x100'
+        - series: http_server_request_latency{job="example_project", instance="example_project:8081",path="/hell0",method="GET",status="400",alias="tnt_router_1",quantile="0.5"}
+          values: '0.02+0x100'
+        - series: http_server_request_latency{job="example_project", instance="example_project:8081",path="/hell0",method="GET",status="400",alias="tnt_router_1",quantile="0.9"}
+          values: '0.02+0x100'
+        - series: http_server_request_latency{job="example_project", instance="example_project:8081",path="/hell0",method="GET",status="400",alias="tnt_router_1",quantile="0.99"}
+          values: '0.02+0x100'
+        - series: http_server_request_latency_count{job="example_project", instance="example_project:8081",path="/hell0",method="GET",status="400",alias="tnt_router_2"}
+          values: '0+150x100'
+        - series: http_server_request_latency_sum{job="example_project", instance="example_project:8081",path="/hell0",method="GET",status="400",alias="tnt_router_2"}
+          values: '0+2x100'
+        - series: http_server_request_latency{job="example_project", instance="example_project:8081",path="/hell0",method="GET",status="400",alias="tnt_router_2",quantile="0.5"}
+          values: '0.02+0x100'
+        - series: http_server_request_latency{job="example_project", instance="example_project:8081",path="/hell0",method="GET",status="400",alias="tnt_router_2",quantile="0.9"}
+          values: '0.02+0x100'
+        - series: http_server_request_latency{job="example_project", instance="example_project:8081",path="/hell0",method="GET",status="400",alias="tnt_router_2",quantile="0.99"}
+          values: '0.02+0x100'
+        - series: http_server_request_latency_count{job="example_project", instance="example_project:8081",path="/hell0",method="GET",status="400",alias="tnt_router_3"}
+          values: '0+150x100'
+        - series: http_server_request_latency_sum{job="example_project", instance="example_project:8081",path="/hell0",method="GET",status="400",alias="tnt_router_3"}
+          values: '0+2x100'
+        - series: http_server_request_latency{job="example_project", instance="example_project:8081",path="/hell0",method="GET",status="400",alias="tnt_router_3",quantile="0.5"}
+          values: '0.02+0x100'
+        - series: http_server_request_latency{job="example_project", instance="example_project:8081",path="/hell0",method="GET",status="400",alias="tnt_router_3",quantile="0.9"}
+          values: '0.02+0x100'
+        - series: http_server_request_latency{job="example_project", instance="example_project:8081",path="/hell0",method="GET",status="400",alias="tnt_router_3",quantile="0.99"}
+          values: '0.02+0x100'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: HTTPHighClientErrorRateInstance
+        exp_alerts: # no alert firing
+      - eval_time: 5m
+        alertname: HTTPHighClientErrorRate
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              job: example_project
+              path: /hell0
+              method: GET
+            exp_annotations:
+              summary: "Job example_project high rate of client error responses"
+              description: "Too many GET requests to /hell0 path
+                on instances of job example_project get client error (4xx) responses."
+
+  - interval: 15s
+    input_series:
+        - series: http_server_request_latency_count{job="example_project", instance="example_project:8081",path="/goodbye",method="POST",status="500",alias="tnt_router"}
+          values: '0+0x10 1+0x10 2+0x10 3+0x10 4+0x10 5+0x10 6+0x10 7+0x10 8+0x10 9+0x10'
+        - series: http_server_request_latency_sum{job="example_project", instance="example_project:8081",path="/goodbye",method="POST",status="500",alias="tnt_router"}
+          values: '0+0x10 0.01+0x10 0.02+0x10 0.03+0x10 0.04+0x10 0.05+0x10 0.06+0x10 0.07+0x10 0.08+0x10 0.09+0x10'
+        - series: http_server_request_latency{job="example_project", instance="example_project:8081",path="/goodbye",method="POST",status="500",alias="tnt_router",quantile="0.5"}
+          values: '0+0x10 0.01+0x100'
+        - series: http_server_request_latency{job="example_project", instance="example_project:8081",path="/goodbye",method="POST",status="500",alias="tnt_router",quantile="0.9"}
+          values: '0+0x10 0.01+0x100'
+        - series: http_server_request_latency{job="example_project", instance="example_project:8081",path="/goodbye",method="POST",status="500",alias="tnt_router",quantile="0.99"}
+          values: '0+0x10 0.01+0x100'
+    alert_rule_test:
+      - eval_time: 5m
+        alertname: HTTPServerErrors
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: example_project:8081
+              alias: tnt_router
+              job: example_project
+              path: /goodbye
+              method: POST
+            exp_annotations:
+              summary: "Instance tnt_router server error responses"
+              description: "Some POST requests to /goodbye path 
+                on tnt_router instance of job example_project get server error (5xx) responses."
+
+  - interval: 15s
+    input_series:
+        - series: http_server_request_latency_count{job="example_project", instance="example_project:8081",path="/hello",method="GET",status="200",alias="tnt_router"}
+          values: '0+0x10 1+0x10 2+0x10 3+0x10 4+0x10 5+0x10 6+0x10 7+0x10 8+0x10 9+0x10'
+        - series: http_server_request_latency_sum{job="example_project", instance="example_project:8081",path="/hello",method="GET",status="200",alias="tnt_router"}
+          values: '0+0x10 0.01+0x10 0.02+0x10 0.03+0x10 0.04+0x10 0.05+0x10 0.06+0x10 0.07+0x10 0.08+0x10 0.09+0x10'
+        - series: http_server_request_latency{job="example_project", instance="example_project:8081",path="/hello",method="GET",status="200",alias="tnt_router",quantile="0.5"}
+          values: '0+0x10 0.01+0x100'
+        - series: http_server_request_latency{job="example_project", instance="example_project:8081",path="/hello",method="GET",status="200",alias="tnt_router",quantile="0.9"}
+          values: '0+0x10 0.01+0x100'
+        - series: http_server_request_latency{job="example_project", instance="example_project:8081",path="/hello",method="GET",status="200",alias="tnt_router",quantile="0.99"}
+          values: '0+0x10 0.01+0x100'
+    alert_rule_test:
+      - eval_time: 15m
+        alertname: HTTPLowRequestRateRouter
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: example_project:8081
+              alias: tnt_router
+              job: example_project
+            exp_annotations:
+              summary: "Router tnt_router low activity"
+              description: Router tnt_router instance of job example_project gets too little requests.
+                Please, check up your balancer middleware."


### PR DESCRIPTION
Closes #43 

Added Prometheus example alert rules:
- instance state (Prometheus `up`),
- Lua memory (warning and alert),
- arena/items limit warnings and alerts,
- high HTTP latency,
- too many HTTP 4xx responses (on a single instance or overall on cluster),
- HTTP 5xx errors,
- low router HTTP activity.

Alerts are separated into three groups. `common` is non-Tarantool alert on process work (Prometheus `up`). `tarantool-common` are general Tarantool alerts (Lua memory and slab_ratio) that can be applied to any Tarantool application. `tarantool-business` is a list of references on how you can monitor your business logic. One can base its alert rules on what's described there (because it's impossible to say if it is OK for your app to have 1000 RPS of 4xx errors or 0 requests on a router for an hour or not without knowing your app business logic beforehand). That's also the reason why I fixed `job='example_project'` in all `tarantool-business` alert rules while leaving `common` and `tarantool-common` alert rules process all possible Tarantool instances (if you have two different apps, they are likely to have different HTTP load and business logic, while 2 Gb Lua threshold is true for both of them).

Test Prometheus example alert rules with promtool.

The next step should be adding some documentation based on this example (here or in tarantool/metrics), but I think it should be a different PR.