### PR TITLE
Add missing metrics label tags to Telegraf configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Prometheus example alert rules (instance state, memory usage, HTTP load and latency rule examples)
 - Test Prometheus example alert rules with promtool
 
+## Changed
+- Update metrics version to 0.9.0
+
 ## [0.2.3] - 2021-03-11
 Grafana revisions: [InfluxDB revision 4](https://grafana.com/api/dashboards/12567/revisions/4/download), [Prometheus revision 4](https://grafana.com/api/dashboards/13054/revisions/4/download)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 - Prometheus example alert rules (instance state, memory usage, HTTP load and latency rule examples)
 - Test Prometheus example alert rules with promtool
+- Cartridge issues metrics labels to Telegraf configuration
 
 ## Changed
 - Update metrics version to 0.9.0
+
+## Fixed
+- Add missing space and replication metrics labels to Telegraf configuration
 
 ## [0.2.3] - 2021-03-11
 Grafana revisions: [InfluxDB revision 4](https://grafana.com/api/dashboards/12567/revisions/4/download), [Prometheus revision 4](https://grafana.com/api/dashboards/13054/revisions/4/download)

--- a/doc/monitoring/grafana_dashboard.rst
+++ b/doc/monitoring/grafana_dashboard.rst
@@ -95,7 +95,12 @@ to Telegraf configuration including each Tarantool instance metrics URL:
             "label_pairs_path",
             "label_pairs_method",
             "label_pairs_status",
-            "label_pairs_operation"
+            "label_pairs_operation",
+            "label_pairs_level",
+            "label_pairs_id",
+            "label_pairs_engine",
+            "label_pairs_name",
+            "label_pairs_index_name"
         ]
         insecure_skip_verify = true
         interval = "10s"

--- a/example/project/Dockerfile
+++ b/example/project/Dockerfile
@@ -5,7 +5,8 @@ WORKDIR /app
 RUN yum install -y git \
                    cmake \
                    make \
-                   gcc
+                   gcc \
+                   gcc-c++
 COPY . .
 RUN mkdir -p tmp
 

--- a/example/project/project-scm-1.rockspec
+++ b/example/project/project-scm-1.rockspec
@@ -9,8 +9,8 @@ dependencies = {
     'lua >= 5.1',
     'checks == 3.0.1-1',
     'http == 1.1.0-1',
-    'cartridge == 2.1.2-1',
-    'metrics == 0.5.0-1'
+    'cartridge == 2.6.0-1',
+    'metrics == 0.9.0-1'
 }
 build = {
     type = 'none';

--- a/example/telegraf/telegraf.conf
+++ b/example/telegraf/telegraf.conf
@@ -14,7 +14,12 @@
         "label_pairs_path",
         "label_pairs_method",
         "label_pairs_status",
-        "label_pairs_operation"
+        "label_pairs_operation",
+        "label_pairs_level",
+        "label_pairs_id",
+        "label_pairs_engine",
+        "label_pairs_name",
+        "label_pairs_index_name"
     ]
     insecure_skip_verify = true
     interval = "10s"


### PR DESCRIPTION
Closes #58 

Update metrics and cartridge packages version.
Add missing space replication and cartridge issues metrics labels to Telegraf configuration