### PR TITLE
Vinyl metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Code rework: introduce grid generation, separate dashboards code
-- Code rework: use common graph template to reduce code copypaste
+- Code rework: use common graph template to reduce code copypaste, set panel size in code
 
 
 ## [0.3.0] - 2021-06-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Code rework: introduce grid generation, separate dashboards code
 - Code rework: use common graph template to reduce code copypaste, set panel size in code
+- Rename "Tarantool memory allocation overview" to "Tarantool memtx allocation overview"
 
 
 ## [0.3.0] - 2021-06-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Code rework: introduce grid generation, separate dashboards code
 - Code rework: use common graph template to reduce code copypaste, set panel size in code
 - Rename "Tarantool memory allocation overview" to "Tarantool memtx allocation overview"
-- Add vinyl panels
+- Add vinyl panels and alert examples
 
 
 ## [0.3.0] - 2021-06-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Code rework: introduce grid generation, separate dashboards code
 - Code rework: use common graph template to reduce code copypaste, set panel size in code
 - Rename "Tarantool memory allocation overview" to "Tarantool memtx allocation overview"
+- Add vinyl panels
 
 
 ## [0.3.0] - 2021-06-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Code rework: introduce grid generation, separate dashboards code
+- Code rework: use common graph template to reduce code copypaste
 
 
 ## [0.3.0] - 2021-06-17

--- a/dashboard/cluster.libsonnet
+++ b/dashboard/cluster.libsonnet
@@ -8,7 +8,7 @@ local influxdb = grafana.influxdb;
 local prometheus = grafana.prometheus;
 
 {
-  row:: grafana.row.new(title='Cluster overview'),
+  row:: common.row('Cluster overview'),
 
   health_overview_table(
     title='Cluster status overview',
@@ -89,7 +89,7 @@ local prometheus = grafana.prometheus;
       )
     else if datasource == '${DS_INFLUXDB}' then
       error 'InfluxDB target not supported yet'
-  ),
+  ) { gridPos: { w: 12, h: 8 } },
 
   local title_workaround(  // Workaround for missing options.fieldOptions.defaults.title https://github.com/grafana/grafonnet-lib/pull/260
     stat_panel,
@@ -164,7 +164,7 @@ local prometheus = grafana.prometheus;
     decimals=0,
     unit='none',
     expr=std.format('sum(up{job=~"%s"})', job),
-  ),
+  ) { gridPos: { w: 8, h: 3 } },
 
   memory_used_stat(
     title='',
@@ -195,7 +195,7 @@ local prometheus = grafana.prometheus;
     decimals=2,
     unit='bytes',
     expr=std.format('sum(tnt_slab_arena_used{job=~"%s"})', job),
-  ),
+  ) { gridPos: { w: 4, h: 5 } },
 
   memory_reserved_stat(
     title='',
@@ -226,7 +226,7 @@ local prometheus = grafana.prometheus;
     decimals=2,
     unit='bytes',
     expr=std.format('sum(tnt_slab_quota_size{job=~"%s"})', job),
-  ),
+  ) { gridPos: { w: 4, h: 5 } },
 
   space_ops_stat(
     title='',
@@ -259,7 +259,7 @@ local prometheus = grafana.prometheus;
     decimals=3,
     unit='ops',
     expr=std.format('sum(rate(tnt_stats_op_total{job=~"%s"}[%s]))', [job, rate_time_range]),
-  ),
+  ) { gridPos: { w: 4, h: 4 } },
 
   http_rps_stat(
     title='',
@@ -292,7 +292,7 @@ local prometheus = grafana.prometheus;
     decimals=3,
     unit='reqps',
     expr=std.format('sum(rate(http_server_request_latency_count{job=~"%s"}[%s]))', [job, rate_time_range]),
-  ),
+  ) { gridPos: { w: 4, h: 4 } },
 
   local cartridge_issues(
     title,
@@ -302,21 +302,16 @@ local prometheus = grafana.prometheus;
     measurement,
     job,
     level,
-  ) = graph.new(
+  ) = common.default_graph(
     title=title,
     description=description,
     datasource=datasource,
-
-    format='none',
     min=0,
-    fill=0,
     decimals=0,
-    sort='decreasing',
-    legend_alignAsTable=true,
-    legend_current=true,
-    legend_values=true,
-    legend_sort='current',
-    legend_sortDesc=true,
+    legend_avg=false,
+    legend_max=false,
+    panel_height=6,
+    panel_width=12,
   ).addTarget(
     if datasource == '${DS_PROMETHEUS}' then
       prometheus.target(
@@ -398,6 +393,7 @@ local prometheus = grafana.prometheus;
     decimalsY1=null,
     legend_avg=false,
     min=0,
+    panel_width=24,
   ).addTarget(
     if datasource == '${DS_PROMETHEUS}' then
       prometheus.target(

--- a/dashboard/cluster.libsonnet
+++ b/dashboard/cluster.libsonnet
@@ -1,3 +1,4 @@
+local common = import 'common.libsonnet';
 local grafana = import 'grafonnet/grafana.libsonnet';
 
 local graph = grafana.graphPanel;
@@ -7,6 +8,8 @@ local influxdb = grafana.influxdb;
 local prometheus = grafana.prometheus;
 
 {
+  row:: grafana.row.new(title='Cluster overview'),
+
   health_overview_table(
     title='Cluster status overview',
     description=null,
@@ -386,21 +389,15 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
-  ):: graph.new(
+  ):: common.default_graph(
     title=title,
     description=description,
     datasource=datasource,
-
     format='s',
-    fill=0,
+    decimals=null,
+    decimalsY1=null,
+    legend_avg=false,
     min=0,
-    sort='decreasing',
-    legend_alignAsTable=true,
-    legend_current=true,
-    legend_max=true,
-    legend_values=true,
-    legend_sort='current',
-    legend_sortDesc=true,
   ).addTarget(
     if datasource == '${DS_PROMETHEUS}' then
       prometheus.target(

--- a/dashboard/common.libsonnet
+++ b/dashboard/common.libsonnet
@@ -1,0 +1,85 @@
+local grafana = import 'grafonnet/grafana.libsonnet';
+
+local influxdb = grafana.influxdb;
+local prometheus = grafana.prometheus;
+
+{
+  default_graph(
+    title=null,
+    description=null,
+    datasource=null,
+    format='none',
+    min=null,
+    max=null,
+    labelY1=null,
+    decimals=3,
+    decimalsY1=0,
+    legend_avg=true,
+    legend_max=true,
+  ):: grafana.graphPanel.new(
+    title=title,
+    description=description,
+    datasource=datasource,
+
+    format=format,
+    min=min,
+    max=max,
+    labelY1=labelY1,
+    fill=0,
+    decimals=decimals,
+    decimalsY1=decimalsY1,
+    sort='decreasing',
+    legend_alignAsTable=true,
+    legend_avg=legend_avg,
+    legend_current=true,
+    legend_max=legend_max,
+    legend_values=true,
+    legend_sort='current',
+    legend_sortDesc=true,
+  ),
+
+  default_metric_target(
+    datasource,
+    metric_name,
+    job=null,
+    policy=null,
+    measurement=null,
+    converter='mean'
+  )::
+    if datasource == '${DS_PROMETHEUS}' then
+      prometheus.target(
+        expr=std.format('%s{job=~"%s"}', [metric_name, job]),
+        legendFormat='{{alias}}',
+      )
+    else if datasource == '${DS_INFLUXDB}' then
+      influxdb.target(
+        policy=policy,
+        measurement=measurement,
+        group_tags=['label_pairs_alias'],
+        alias='$tag_label_pairs_alias',
+      ).where('metric_name', '=', metric_name)
+      .selectField('value').addConverter(converter),
+
+  default_rps_target(
+    datasource,
+    metric_name,
+    job=null,
+    rate_time_range=null,
+    policy=null,
+    measurement=null,
+  )::
+    if datasource == '${DS_PROMETHEUS}' then
+      prometheus.target(
+        expr=std.format('rate(%s{job=~"%s"}[%s])',
+                        [metric_name, job, rate_time_range]),
+        legendFormat='{{alias}}',
+      )
+    else if datasource == '${DS_INFLUXDB}' then
+      influxdb.target(
+        policy=policy,
+        measurement=measurement,
+        group_tags=['label_pairs_alias'],
+        alias='$tag_label_pairs_alias',
+      ).where('metric_name', '=', metric_name)
+      .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s']),
+}

--- a/dashboard/common.libsonnet
+++ b/dashboard/common.libsonnet
@@ -16,6 +16,8 @@ local prometheus = grafana.prometheus;
     decimalsY1=0,
     legend_avg=true,
     legend_max=true,
+    panel_height=8,
+    panel_width=8,
   ):: grafana.graphPanel.new(
     title=title,
     description=description,
@@ -36,7 +38,9 @@ local prometheus = grafana.prometheus;
     legend_values=true,
     legend_sort='current',
     legend_sortDesc=true,
-  ),
+  ) { gridPos: { w: panel_width, h: panel_height } },
+
+  row(title):: grafana.row.new(title) { gridPos: { w: 24, h: 1 } },
 
   default_metric_target(
     datasource,

--- a/dashboard/cpu.libsonnet
+++ b/dashboard/cpu.libsonnet
@@ -1,10 +1,9 @@
+local common = import 'common.libsonnet';
 local grafana = import 'grafonnet/grafana.libsonnet';
 
-local graph = grafana.graphPanel;
-local influxdb = grafana.influxdb;
-local prometheus = grafana.prometheus;
-
 {
+  row:: grafana.row.new(title='Tarantool CPU statistics'),
+
   local getrusage_cpu_time_graph(
     title,
     description,
@@ -14,41 +13,22 @@ local prometheus = grafana.prometheus;
     job,
     rate_time_range,
     metric_name,
-  ) = graph.new(
+  ) = common.default_graph(
     title=title,
     description=description,
     datasource=datasource,
-
     format='s',
-    min=0,
     labelY1='time per minute',
-    fill=0,
-    decimals=3,
     decimalsY1=3,
-    sort='decreasing',
-    legend_alignAsTable=true,
-    legend_avg=true,
-    legend_current=true,
-    legend_max=true,
-    legend_values=true,
-    legend_sort='current',
-    legend_sortDesc=true,
-  ).addTarget(
-    if datasource == '${DS_PROMETHEUS}' then
-      prometheus.target(
-        expr=std.format('rate(%s{job=~"%s"}[%s])',
-                        [metric_name, job, rate_time_range]),
-        legendFormat='{{alias}}',
-      )
-    else if datasource == '${DS_INFLUXDB}' then
-      influxdb.target(
-        policy=policy,
-        measurement=measurement,
-        group_tags=['label_pairs_alias'],
-        alias='$tag_label_pairs_alias',
-      ).where('metric_name', '=', metric_name)
-      .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s'])
-  ),
+    min=0,
+  ).addTarget(common.default_rps_target(
+    datasource,
+    metric_name,
+    job,
+    rate_time_range,
+    policy,
+    measurement
+  )),
 
   getrusage_cpu_user_time(
     title='CPU user time',

--- a/dashboard/cpu.libsonnet
+++ b/dashboard/cpu.libsonnet
@@ -1,8 +1,7 @@
 local common = import 'common.libsonnet';
-local grafana = import 'grafonnet/grafana.libsonnet';
 
 {
-  row:: grafana.row.new(title='Tarantool CPU statistics'),
+  row:: common.row('Tarantool CPU statistics'),
 
   local getrusage_cpu_time_graph(
     title,
@@ -21,6 +20,7 @@ local grafana = import 'grafonnet/grafana.libsonnet';
     labelY1='time per minute',
     decimalsY1=3,
     min=0,
+    panel_width=12,
   ).addTarget(common.default_rps_target(
     datasource,
     metric_name,

--- a/dashboard/http.libsonnet
+++ b/dashboard/http.libsonnet
@@ -5,7 +5,7 @@ local influxdb = grafana.influxdb;
 local prometheus = grafana.prometheus;
 
 {
-  row:: grafana.row.new(title='Tarantool HTTP statistics'),
+  row:: common.row('Tarantool HTTP statistics'),
 
   local rps_graph(
     title,

--- a/dashboard/http.libsonnet
+++ b/dashboard/http.libsonnet
@@ -1,10 +1,12 @@
+local common = import 'common.libsonnet';
 local grafana = import 'grafonnet/grafana.libsonnet';
 
-local graph = grafana.graphPanel;
 local influxdb = grafana.influxdb;
 local prometheus = grafana.prometheus;
 
 {
+  row:: grafana.row.new(title='Tarantool HTTP statistics'),
+
   local rps_graph(
     title,
     description,
@@ -15,25 +17,11 @@ local prometheus = grafana.prometheus;
     rate_time_range,
     metric_name,
     status_regex,
-  ) = graph.new(
+  ) = common.default_graph(
     title=title,
     description=description,
     datasource=datasource,
-
-    format='none',
-    min=0,
     labelY1='requests per second',
-    fill=0,
-    decimals=3,
-    decimalsY1=0,
-    sort='decreasing',
-    legend_alignAsTable=true,
-    legend_avg=true,
-    legend_current=true,
-    legend_max=true,
-    legend_values=true,
-    legend_sort='current',
-    legend_sortDesc=true,
   ).addTarget(
     if datasource == '${DS_PROMETHEUS}' then
       prometheus.target(
@@ -143,24 +131,13 @@ local prometheus = grafana.prometheus;
     quantile,
     label,
     status_regex,
-  ) = graph.new(
+  ) = common.default_graph(
     title=title,
     description=description,
     datasource=datasource,
-
     format='s',
-    min=0,
     labelY1=label,
-    fill=0,
-    decimals=3,
-    sort='decreasing',
-    legend_alignAsTable=true,
-    legend_avg=true,
-    legend_current=true,
-    legend_max=true,
-    legend_values=true,
-    legend_sort='current',
-    legend_sortDesc=true,
+    decimalsY1=null,
   ).addTarget(
     if datasource == '${DS_PROMETHEUS}' then
       prometheus.target(

--- a/dashboard/influxdb_dashboard.jsonnet
+++ b/dashboard/influxdb_dashboard.jsonnet
@@ -72,7 +72,7 @@ grafana.dashboard.new(
   description='InfluxDB Tarantool metrics policy'
 )
 .addPanels(utils.generate_grid([
-  row.new(title='Cluster overview') { gridPos: { w: 24, h: 1 } },
+  cluster.row { gridPos: { w: 24, h: 1 } },
 
   cluster.cartridge_warning_issues(
     datasource=datasource,
@@ -92,7 +92,7 @@ grafana.dashboard.new(
     measurement=measurement,
   ) { gridPos: { w: 24, h: 8 } },
 
-  row.new(title='Tarantool HTTP statistics') { gridPos: { w: 24, h: 1 } },
+  http.row { gridPos: { w: 24, h: 1 } },
 
   http.rps_success(
     datasource=datasource,
@@ -130,7 +130,7 @@ grafana.dashboard.new(
     measurement=measurement,
   ) { gridPos: { w: 8, h: 8 } },
 
-  row.new(title='Tarantool network activity') { gridPos: { w: 24, h: 1 } },
+  net.row { gridPos: { w: 24, h: 1 } },
 
   net.bytes_received_per_second(
     datasource=datasource,
@@ -162,7 +162,7 @@ grafana.dashboard.new(
     measurement=measurement,
   ) { gridPos: { w: 8, h: 8 } },
 
-  row.new(title='Tarantool memory allocation overview') { gridPos: { w: 24, h: 1 } },
+  slab.row { gridPos: { w: 24, h: 1 } },
 
   slab.monitor_info() { gridPos: { w: 24, h: 3 } },
 
@@ -220,7 +220,7 @@ grafana.dashboard.new(
     measurement=measurement,
   ) { gridPos: { w: 8, h: 8 } },
 
-  row.new(title='Tarantool CPU statistics') { gridPos: { w: 24, h: 1 } },
+  cpu.row { gridPos: { w: 24, h: 1 } },
 
   cpu.getrusage_cpu_user_time(
     datasource=datasource,
@@ -234,7 +234,7 @@ grafana.dashboard.new(
     measurement=measurement,
   ) { gridPos: { w: 12, h: 8 } },
 
-  row.new(title='Tarantool memory miscellaneous') { gridPos: { w: 24, h: 1 } },
+  memory_misc.row { gridPos: { w: 24, h: 1 } },
 
   memory_misc.lua_memory(
     datasource=datasource,
@@ -242,7 +242,7 @@ grafana.dashboard.new(
     measurement=measurement,
   ) { gridPos: { w: 24, h: 8 } },
 
-  row.new(title='Tarantool operations statistics') { gridPos: { w: 24, h: 1 } },
+  operations.row { gridPos: { w: 24, h: 1 } },
 
   operations.space_select_rps(
     datasource=datasource,

--- a/dashboard/influxdb_dashboard.jsonnet
+++ b/dashboard/influxdb_dashboard.jsonnet
@@ -8,8 +8,7 @@ local net = import 'net.libsonnet';
 local operations = import 'operations.libsonnet';
 local slab = import 'slab.libsonnet';
 local utils = import 'utils.libsonnet';
-local row = grafana.row;
-local dashboard = grafana.dashboard;
+local vinyl = import 'vinyl.libsonnet';
 
 
 local datasource = '${DS_INFLUXDB}';
@@ -215,6 +214,93 @@ grafana.dashboard.new(
   ),
 
   slab.items_size(
+    datasource=datasource,
+    policy=policy,
+    measurement=measurement,
+  ),
+
+
+  vinyl.row,
+
+  vinyl.disk_data(
+    datasource=datasource,
+    policy=policy,
+    measurement=measurement,
+  ),
+
+  vinyl.index_data(
+    datasource=datasource,
+    policy=policy,
+    measurement=measurement,
+  ),
+
+  vinyl.regulator_dump_bandwidth(
+    datasource=datasource,
+    policy=policy,
+    measurement=measurement,
+  ),
+
+  vinyl.regulator_write_rate(
+    datasource=datasource,
+    policy=policy,
+    measurement=measurement,
+  ),
+
+  vinyl.regulator_rate_limit(
+    datasource=datasource,
+    policy=policy,
+    measurement=measurement,
+  ),
+
+  vinyl.regulator_dump_watermark(
+    datasource=datasource,
+    policy=policy,
+    measurement=measurement,
+  ),
+
+  vinyl.tx_commit_rate(
+    datasource=datasource,
+    policy=policy,
+    measurement=measurement,
+  ),
+
+  vinyl.tx_rollback_rate(
+    datasource=datasource,
+    policy=policy,
+    measurement=measurement,
+  ),
+
+  vinyl.tx_conflicts_rate(
+    datasource=datasource,
+    policy=policy,
+    measurement=measurement,
+  ),
+
+  vinyl.tx_read_views(
+    datasource=datasource,
+    policy=policy,
+    measurement=measurement,
+  ),
+
+  vinyl.scheduler_tasks_inprogress(
+    datasource=datasource,
+    policy=policy,
+    measurement=measurement,
+  ),
+
+  vinyl.scheduler_tasks_failed_rate(
+    datasource=datasource,
+    policy=policy,
+    measurement=measurement,
+  ),
+
+  vinyl.scheduler_dump_time_rate(
+    datasource=datasource,
+    policy=policy,
+    measurement=measurement,
+  ),
+
+  vinyl.scheduler_dump_count_rate(
     datasource=datasource,
     policy=policy,
     measurement=measurement,

--- a/dashboard/influxdb_dashboard.jsonnet
+++ b/dashboard/influxdb_dashboard.jsonnet
@@ -72,247 +72,247 @@ grafana.dashboard.new(
   description='InfluxDB Tarantool metrics policy'
 )
 .addPanels(utils.generate_grid([
-  cluster.row { gridPos: { w: 24, h: 1 } },
+  cluster.row,
 
   cluster.cartridge_warning_issues(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 12, h: 6 } },
+  ),
 
   cluster.cartridge_critical_issues(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 12, h: 6 } },
+  ),
 
   cluster.replication_lag(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 24, h: 8 } },
+  ),
 
-  http.row { gridPos: { w: 24, h: 1 } },
+  http.row,
 
   http.rps_success(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   http.rps_error_4xx(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   http.rps_error_5xx(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   http.latency_success(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   http.latency_error_4xx(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   http.latency_error_5xx(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
-  net.row { gridPos: { w: 24, h: 1 } },
+  net.row,
 
   net.bytes_received_per_second(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 12, h: 8 } },
+  ),
 
   net.bytes_sent_per_second(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 12, h: 8 } },
+  ),
 
   net.net_rps(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   net.net_pending(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   net.current_connections(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
-  slab.row { gridPos: { w: 24, h: 1 } },
+  slab.row,
 
-  slab.monitor_info() { gridPos: { w: 24, h: 3 } },
+  slab.monitor_info(),
 
   slab.quota_used_ratio(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   slab.arena_used_ratio(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   slab.items_used_ratio(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   slab.quota_used(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   slab.arena_used(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   slab.items_used(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   slab.quota_size(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   slab.arena_size(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   slab.items_size(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
-  cpu.row { gridPos: { w: 24, h: 1 } },
+  cpu.row,
 
   cpu.getrusage_cpu_user_time(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 12, h: 8 } },
+  ),
 
   cpu.getrusage_cpu_system_time(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 12, h: 8 } },
+  ),
 
-  memory_misc.row { gridPos: { w: 24, h: 1 } },
+  memory_misc.row,
 
   memory_misc.lua_memory(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 24, h: 8 } },
+  ),
 
-  operations.row { gridPos: { w: 24, h: 1 } },
+  operations.row,
 
   operations.space_select_rps(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   operations.space_insert_rps(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   operations.space_replace_rps(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   operations.space_upsert_rps(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   operations.space_update_rps(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   operations.space_delete_rps(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   operations.call_rps(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   operations.eval_rps(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   operations.error_rps(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   operations.auth_rps(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   operations.SQL_prepare_rps(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   operations.SQL_execute_rps(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 ]))

--- a/dashboard/memory_misc.libsonnet
+++ b/dashboard/memory_misc.libsonnet
@@ -1,8 +1,7 @@
 local common = import 'common.libsonnet';
-local grafana = import 'grafonnet/grafana.libsonnet';
 
 {
-  row:: grafana.row.new(title='Tarantool memory miscellaneous'),
+  row:: common.row('Tarantool memory miscellaneous'),
 
   lua_memory(
     title='Lua runtime',
@@ -19,6 +18,7 @@ local grafana = import 'grafonnet/grafana.libsonnet';
     datasource=datasource,
     format='bytes',
     labelY1='in bytes',
+    panel_width=24,
   ).addTarget(common.default_metric_target(
     datasource,
     'tnt_info_memory_lua',

--- a/dashboard/memory_misc.libsonnet
+++ b/dashboard/memory_misc.libsonnet
@@ -1,50 +1,8 @@
+local common = import 'common.libsonnet';
 local grafana = import 'grafonnet/grafana.libsonnet';
 
-local graph = grafana.graphPanel;
-local influxdb = grafana.influxdb;
-local prometheus = grafana.prometheus;
-
 {
-  local memory_panel(
-    title,
-    description,
-    datasource,
-    policy,
-    measurement,
-    job,
-    metric_name,
-  ) = graph.new(
-    title=title,
-    description=description,
-    datasource=datasource,
-
-    format='bytes',
-    labelY1='in bytes',
-    fill=0,
-    decimals=3,
-    decimalsY1=0,
-    sort='decreasing',
-    legend_alignAsTable=true,
-    legend_avg=true,
-    legend_current=true,
-    legend_max=true,
-    legend_values=true,
-    legend_sort='current',
-    legend_sortDesc=true,
-  ).addTarget(
-    if datasource == '${DS_PROMETHEUS}' then
-      prometheus.target(
-        expr=std.format('%s{job=~"%s"}', [metric_name, job]),
-        legendFormat='{{alias}}',
-      )
-    else if datasource == '${DS_INFLUXDB}' then
-      influxdb.target(
-        policy=policy,
-        measurement=measurement,
-        group_tags=['label_pairs_alias'],
-        alias='$tag_label_pairs_alias',
-      ).where('metric_name', '=', metric_name).selectField('value').addConverter('mean')
-  ),
+  row:: grafana.row.new(title='Tarantool memory miscellaneous'),
 
   lua_memory(
     title='Lua runtime',
@@ -55,13 +13,17 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
-  ):: memory_panel(
+  ):: common.default_graph(
     title=title,
     description=description,
     datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    metric_name='tnt_info_memory_lua',
-  ),
+    format='bytes',
+    labelY1='in bytes',
+  ).addTarget(common.default_metric_target(
+    datasource,
+    'tnt_info_memory_lua',
+    job,
+    policy,
+    measurement
+  )),
 }

--- a/dashboard/net.libsonnet
+++ b/dashboard/net.libsonnet
@@ -1,10 +1,9 @@
+local common = import 'common.libsonnet';
 local grafana = import 'grafonnet/grafana.libsonnet';
 
-local graph = grafana.graphPanel;
-local influxdb = grafana.influxdb;
-local prometheus = grafana.prometheus;
-
 {
+  row:: grafana.row.new(title='Tarantool network activity'),
+
   local bytes_per_second_graph(
     title,
     description,
@@ -15,41 +14,20 @@ local prometheus = grafana.prometheus;
     rate_time_range,
     metric_name,
     labelY1,
-  ) = graph.new(
+  ) = common.default_graph(
     title=title,
     description=description,
     datasource=datasource,
-
     format='Bps',
-    min=0,
     labelY1=labelY1,
-    fill=0,
-    decimals=3,
-    decimalsY1=0,
-    sort='decreasing',
-    legend_alignAsTable=true,
-    legend_avg=true,
-    legend_current=true,
-    legend_max=true,
-    legend_values=true,
-    legend_sort='current',
-    legend_sortDesc=true,
-  ).addTarget(
-    if datasource == '${DS_PROMETHEUS}' then
-      prometheus.target(
-        expr=std.format('rate(%s{job=~"%s"}[%s])',
-                        [metric_name, job, rate_time_range]),
-        legendFormat='{{alias}}',
-      )
-    else if datasource == '${DS_INFLUXDB}' then
-      influxdb.target(
-        policy=policy,
-        measurement=measurement,
-        group_tags=['label_pairs_alias'],
-        alias='$tag_label_pairs_alias',
-      ).where('metric_name', '=', metric_name)
-      .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s'])
-  ),
+  ).addTarget(common.default_rps_target(
+    datasource,
+    metric_name,
+    job,
+    rate_time_range,
+    policy,
+    measurement
+  )),
 
   bytes_received_per_second(
     title='Data received',
@@ -115,40 +93,19 @@ local prometheus = grafana.prometheus;
     measurement=null,
     job=null,
     rate_time_range=null,
-  ):: graph.new(
+  ):: common.default_graph(
     title=title,
     description=description,
     datasource=datasource,
-
-    format='none',
-    min=0,
     labelY1='requests per second',
-    fill=0,
-    decimals=3,
-    decimalsY1=0,
-    sort='decreasing',
-    legend_alignAsTable=true,
-    legend_avg=true,
-    legend_current=true,
-    legend_max=true,
-    legend_values=true,
-    legend_sort='current',
-    legend_sortDesc=true,
-  ).addTarget(
-    if datasource == '${DS_PROMETHEUS}' then
-      prometheus.target(
-        expr=std.format('rate(tnt_net_requests_total{job=~"%s"}[%s])', [job, rate_time_range]),
-        legendFormat='{{alias}}',
-      )
-    else if datasource == '${DS_INFLUXDB}' then
-      influxdb.target(
-        policy=policy,
-        measurement=measurement,
-        group_tags=['label_pairs_alias'],
-        alias='$tag_label_pairs_alias',
-      ).where('metric_name', '=', 'tnt_net_requests_total')
-      .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s'])
-  ),
+  ).addTarget(common.default_rps_target(
+    datasource,
+    'tnt_net_requests_total',
+    job,
+    rate_time_range,
+    policy,
+    measurement
+  )),
 
   net_pending(
     title='Network requests pending',
@@ -160,39 +117,20 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
-  ):: graph.new(
+  ):: common.default_graph(
     title=title,
     description=description,
     datasource=datasource,
-
-    format='none',
-    min=0,
     decimals=0,
     labelY1='pending',
-    fill=0,
-    sort='decreasing',
-    legend_alignAsTable=true,
-    legend_avg=true,
-    legend_current=true,
-    legend_max=true,
-    legend_values=true,
-    legend_sort='current',
-    legend_sortDesc=true,
-  ).addTarget(
-    if datasource == '${DS_PROMETHEUS}' then
-      prometheus.target(
-        expr=std.format('tnt_net_requests_current{job=~"%s"}', [job]),
-        legendFormat='{{alias}}',
-      )
-    else if datasource == '${DS_INFLUXDB}' then
-      influxdb.target(
-        policy=policy,
-        measurement=measurement,
-        group_tags=['label_pairs_alias'],
-        alias='$tag_label_pairs_alias',
-      ).where('metric_name', '=', 'tnt_net_requests_current')
-      .selectField('value').addConverter('mean')
-  ),
+    min=0,
+  ).addTarget(common.default_metric_target(
+    datasource,
+    'tnt_net_requests_current',
+    job,
+    policy,
+    measurement
+  )),
 
   current_connections(
     title='Binary protocol connections',
@@ -204,37 +142,18 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
-  ):: graph.new(
+  ):: common.default_graph(
     title=title,
     description=description,
     datasource=datasource,
-
-    format='none',
-    min=0,
-    labelY1='current',
-    fill=0,
     decimals=0,
-    sort='decreasing',
-    legend_alignAsTable=true,
-    legend_avg=true,
-    legend_current=true,
-    legend_max=true,
-    legend_values=true,
-    legend_sort='current',
-    legend_sortDesc=true,
-  ).addTarget(
-    if datasource == '${DS_PROMETHEUS}' then
-      prometheus.target(
-        expr=std.format('tnt_net_connections_current{job=~"%s"}', [job]),
-        legendFormat='{{alias}}',
-      )
-    else if datasource == '${DS_INFLUXDB}' then
-      influxdb.target(
-        policy=policy,
-        measurement=measurement,
-        group_tags=['label_pairs_alias'],
-        alias='$tag_label_pairs_alias',
-      ).where('metric_name', '=', 'tnt_net_connections_current')
-      .selectField('value').addConverter('last')
-  ),
+    labelY1='current',
+  ).addTarget(common.default_metric_target(
+    datasource,
+    'tnt_net_connections_current',
+    job,
+    policy,
+    measurement,
+    'last',
+  )),
 }

--- a/dashboard/net.libsonnet
+++ b/dashboard/net.libsonnet
@@ -1,8 +1,7 @@
 local common = import 'common.libsonnet';
-local grafana = import 'grafonnet/grafana.libsonnet';
 
 {
-  row:: grafana.row.new(title='Tarantool network activity'),
+  row:: common.row('Tarantool network activity'),
 
   local bytes_per_second_graph(
     title,
@@ -20,6 +19,7 @@ local grafana = import 'grafonnet/grafana.libsonnet';
     datasource=datasource,
     format='Bps',
     labelY1=labelY1,
+    panel_width=12,
   ).addTarget(common.default_rps_target(
     datasource,
     metric_name,

--- a/dashboard/operations.libsonnet
+++ b/dashboard/operations.libsonnet
@@ -5,7 +5,7 @@ local influxdb = grafana.influxdb;
 local prometheus = grafana.prometheus;
 
 {
-  row:: grafana.row.new(title='Tarantool operations statistics'),
+  row:: common.row('Tarantool operations statistics'),
 
   local operation_rps(
     title=null,

--- a/dashboard/operations.libsonnet
+++ b/dashboard/operations.libsonnet
@@ -1,10 +1,12 @@
+local common = import 'common.libsonnet';
 local grafana = import 'grafonnet/grafana.libsonnet';
 
-local graph = grafana.graphPanel;
 local influxdb = grafana.influxdb;
 local prometheus = grafana.prometheus;
 
 {
+  row:: grafana.row.new(title='Tarantool operations statistics'),
+
   local operation_rps(
     title=null,
     description=null,
@@ -15,25 +17,12 @@ local prometheus = grafana.prometheus;
     rate_time_range=null,
     labelY1=null,
     operation=null,
-  ) = graph.new(
+  ) = common.default_graph(
     title=title,
     description=description,
     datasource=datasource,
-
-    format='none',
     min=0,
     labelY1=labelY1,
-    fill=0,
-    decimals=3,
-    decimalsY1=0,
-    sort='decreasing',
-    legend_alignAsTable=true,
-    legend_avg=true,
-    legend_current=true,
-    legend_max=true,
-    legend_values=true,
-    legend_sort='current',
-    legend_sortDesc=true,
   ).addTarget(
     if datasource == '${DS_PROMETHEUS}' then
       prometheus.target(

--- a/dashboard/prometheus_dashboard.jsonnet
+++ b/dashboard/prometheus_dashboard.jsonnet
@@ -8,8 +8,7 @@ local net = import 'net.libsonnet';
 local operations = import 'operations.libsonnet';
 local slab = import 'slab.libsonnet';
 local utils = import 'utils.libsonnet';
-local row = grafana.row;
-local dashboard = grafana.dashboard;
+local vinyl = import 'vinyl.libsonnet';
 
 
 local datasource = '${DS_PROMETHEUS}';
@@ -264,6 +263,84 @@ grafana.dashboard.new(
   slab.items_size(
     datasource=datasource,
     job=job,
+  ),
+
+  vinyl.row,
+
+  vinyl.disk_data(
+    datasource=datasource,
+    job=job,
+  ),
+
+  vinyl.index_data(
+    datasource=datasource,
+    job=job,
+  ),
+
+  vinyl.regulator_dump_bandwidth(
+    datasource=datasource,
+    job=job,
+  ),
+
+  vinyl.regulator_write_rate(
+    datasource=datasource,
+    job=job,
+  ),
+
+  vinyl.regulator_rate_limit(
+    datasource=datasource,
+    job=job,
+  ),
+
+  vinyl.regulator_dump_watermark(
+    datasource=datasource,
+    job=job,
+  ),
+
+  vinyl.tx_commit_rate(
+    datasource=datasource,
+    job=job,
+    rate_time_range=rate_time_range,
+  ),
+
+  vinyl.tx_rollback_rate(
+    datasource=datasource,
+    job=job,
+    rate_time_range=rate_time_range,
+  ),
+
+  vinyl.tx_conflicts_rate(
+    datasource=datasource,
+    job=job,
+    rate_time_range=rate_time_range,
+  ),
+
+  vinyl.tx_read_views(
+    datasource=datasource,
+    job=job,
+  ),
+
+  vinyl.scheduler_tasks_inprogress(
+    datasource=datasource,
+    job=job,
+  ),
+
+  vinyl.scheduler_tasks_failed_rate(
+    datasource=datasource,
+    job=job,
+    rate_time_range=rate_time_range,
+  ),
+
+  vinyl.scheduler_dump_time_rate(
+    datasource=datasource,
+    job=job,
+    rate_time_range=rate_time_range,
+  ),
+
+  vinyl.scheduler_dump_count_rate(
+    datasource=datasource,
+    job=job,
+    rate_time_range=rate_time_range,
   ),
 
   cpu.row,

--- a/dashboard/prometheus_dashboard.jsonnet
+++ b/dashboard/prometheus_dashboard.jsonnet
@@ -103,7 +103,7 @@ grafana.dashboard.new(
     label='rate() time range',
   ),
 ).addPanels(utils.generate_grid([
-  cluster.row { gridPos: { w: 24, h: 1 } },
+  cluster.row,
 
   cluster.health_overview_table(
     datasource=datasource,
@@ -140,224 +140,224 @@ grafana.dashboard.new(
   cluster.cartridge_warning_issues(
     datasource=datasource,
     job=job,
-  ) { gridPos: { w: 12, h: 6 } },
+  ),
 
   cluster.cartridge_critical_issues(
     datasource=datasource,
     job=job,
-  ) { gridPos: { w: 12, h: 6 } },
+  ),
 
   cluster.replication_lag(
     datasource=datasource,
     job=job,
-  ) { gridPos: { w: 24, h: 8 } },
+  ),
 
-  http.row { gridPos: { w: 24, h: 1 } },
+  http.row,
 
   http.rps_success(
     datasource=datasource,
     job=job,
     rate_time_range=rate_time_range,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   http.rps_error_4xx(
     datasource=datasource,
     job=job,
     rate_time_range=rate_time_range,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   http.rps_error_5xx(
     datasource=datasource,
     job=job,
     rate_time_range=rate_time_range,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   http.latency_success(
     datasource=datasource,
     job=job,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   http.latency_error_4xx(
     datasource=datasource,
     job=job,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   http.latency_error_5xx(
     datasource=datasource,
     job=job,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
-  net.row { gridPos: { w: 24, h: 1 } },
+  net.row,
 
   net.bytes_received_per_second(
     datasource=datasource,
     job=job,
     rate_time_range=rate_time_range,
-  ) { gridPos: { w: 12, h: 8 } },
+  ),
 
   net.bytes_sent_per_second(
     datasource=datasource,
     job=job,
     rate_time_range=rate_time_range,
-  ) { gridPos: { w: 12, h: 8 } },
+  ),
 
   net.net_rps(
     datasource=datasource,
     job=job,
     rate_time_range=rate_time_range,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   net.net_pending(
     datasource=datasource,
     job=job,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   net.current_connections(
     datasource=datasource,
     job=job,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
-  slab.row { gridPos: { w: 24, h: 1 } },
+  slab.row,
 
-  slab.monitor_info() { gridPos: { w: 24, h: 3 } },
+  slab.monitor_info(),
 
   slab.quota_used_ratio(
     datasource=datasource,
     job=job,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   slab.arena_used_ratio(
     datasource=datasource,
     job=job,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   slab.items_used_ratio(
     datasource=datasource,
     job=job,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   slab.quota_used(
     datasource=datasource,
     job=job,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   slab.arena_used(
     datasource=datasource,
     job=job,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   slab.items_used(
     datasource=datasource,
     job=job,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   slab.quota_size(
     datasource=datasource,
     job=job,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   slab.arena_size(
     datasource=datasource,
     job=job,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   slab.items_size(
     datasource=datasource,
     job=job,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
-  cpu.row { gridPos: { w: 24, h: 1 } },
+  cpu.row,
 
   cpu.getrusage_cpu_user_time(
     datasource=datasource,
     job=job,
     rate_time_range=rate_time_range,
-  ) { gridPos: { w: 12, h: 8 } },
+  ),
 
   cpu.getrusage_cpu_system_time(
     datasource=datasource,
     job=job,
     rate_time_range=rate_time_range,
-  ) { gridPos: { w: 12, h: 8 } },
+  ),
 
-  memory_misc.row { gridPos: { w: 24, h: 1 } },
+  memory_misc.row,
 
   memory_misc.lua_memory(
     datasource=datasource,
     job=job,
-  ) { gridPos: { w: 24, h: 8 } },
+  ),
 
-  operations.row { gridPos: { w: 24, h: 1 } },
+  operations.row,
 
   operations.space_select_rps(
     datasource=datasource,
     job=job,
     rate_time_range=rate_time_range,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   operations.space_insert_rps(
     datasource=datasource,
     job=job,
     rate_time_range=rate_time_range,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   operations.space_replace_rps(
     datasource=datasource,
     job=job,
     rate_time_range=rate_time_range,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   operations.space_upsert_rps(
     datasource=datasource,
     job=job,
     rate_time_range=rate_time_range,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   operations.space_update_rps(
     datasource=datasource,
     job=job,
     rate_time_range=rate_time_range,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   operations.space_delete_rps(
     datasource=datasource,
     job=job,
     rate_time_range=rate_time_range,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   operations.call_rps(
     datasource=datasource,
     job=job,
     rate_time_range=rate_time_range,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   operations.eval_rps(
     datasource=datasource,
     job=job,
     rate_time_range=rate_time_range,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   operations.error_rps(
     datasource=datasource,
     job=job,
     rate_time_range=rate_time_range,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   operations.auth_rps(
     datasource=datasource,
     job=job,
     rate_time_range=rate_time_range,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   operations.SQL_prepare_rps(
     datasource=datasource,
     job=job,
     rate_time_range=rate_time_range,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 
   operations.SQL_execute_rps(
     datasource=datasource,
     job=job,
     rate_time_range=rate_time_range,
-  ) { gridPos: { w: 8, h: 8 } },
+  ),
 ]))

--- a/dashboard/prometheus_dashboard.jsonnet
+++ b/dashboard/prometheus_dashboard.jsonnet
@@ -103,7 +103,7 @@ grafana.dashboard.new(
     label='rate() time range',
   ),
 ).addPanels(utils.generate_grid([
-  row.new(title='Cluster overview') { gridPos: { w: 24, h: 1 } },
+  cluster.row { gridPos: { w: 24, h: 1 } },
 
   cluster.health_overview_table(
     datasource=datasource,
@@ -152,7 +152,7 @@ grafana.dashboard.new(
     job=job,
   ) { gridPos: { w: 24, h: 8 } },
 
-  row.new(title='Tarantool HTTP statistics') { gridPos: { w: 24, h: 1 } },
+  http.row { gridPos: { w: 24, h: 1 } },
 
   http.rps_success(
     datasource=datasource,
@@ -187,7 +187,7 @@ grafana.dashboard.new(
     job=job,
   ) { gridPos: { w: 8, h: 8 } },
 
-  row.new(title='Tarantool network activity') { gridPos: { w: 24, h: 1 } },
+  net.row { gridPos: { w: 24, h: 1 } },
 
   net.bytes_received_per_second(
     datasource=datasource,
@@ -217,7 +217,7 @@ grafana.dashboard.new(
     job=job,
   ) { gridPos: { w: 8, h: 8 } },
 
-  row.new(title='Tarantool memory allocation overview') { gridPos: { w: 24, h: 1 } },
+  slab.row { gridPos: { w: 24, h: 1 } },
 
   slab.monitor_info() { gridPos: { w: 24, h: 3 } },
 
@@ -266,7 +266,7 @@ grafana.dashboard.new(
     job=job,
   ) { gridPos: { w: 8, h: 8 } },
 
-  row.new(title='Tarantool CPU statistics') { gridPos: { w: 24, h: 1 } },
+  cpu.row { gridPos: { w: 24, h: 1 } },
 
   cpu.getrusage_cpu_user_time(
     datasource=datasource,
@@ -280,14 +280,14 @@ grafana.dashboard.new(
     rate_time_range=rate_time_range,
   ) { gridPos: { w: 12, h: 8 } },
 
-  row.new(title='Tarantool memory miscellaneous') { gridPos: { w: 24, h: 1 } },
+  memory_misc.row { gridPos: { w: 24, h: 1 } },
 
   memory_misc.lua_memory(
     datasource=datasource,
     job=job,
   ) { gridPos: { w: 24, h: 8 } },
 
-  row.new(title='Tarantool operations statistics') { gridPos: { w: 24, h: 1 } },
+  operations.row { gridPos: { w: 24, h: 1 } },
 
   operations.space_select_rps(
     datasource=datasource,

--- a/dashboard/slab.libsonnet
+++ b/dashboard/slab.libsonnet
@@ -2,7 +2,7 @@ local common = import 'common.libsonnet';
 local grafana = import 'grafonnet/grafana.libsonnet';
 
 {
-  row:: common.row('Tarantool memory allocation overview'),
+  row:: common.row('Tarantool memtx allocation overview'),
 
   monitor_info(
   ):: grafana.text.new(

--- a/dashboard/slab.libsonnet
+++ b/dashboard/slab.libsonnet
@@ -2,7 +2,7 @@ local common = import 'common.libsonnet';
 local grafana = import 'grafonnet/grafana.libsonnet';
 
 {
-  row:: grafana.row.new(title='Tarantool memory allocation overview'),
+  row:: common.row('Tarantool memory allocation overview'),
 
   monitor_info(
   ):: grafana.text.new(
@@ -12,7 +12,7 @@ local grafana = import 'grafonnet/grafana.libsonnet';
 
       `quota_used_ratio` > 90%, `arena_used_ratio` > 90%, `items_used_ratio` > 90% – you are running out of memory. You should consider increasing Tarantool’s memory limit (*box.cfg.memtx_memory*).
     |||,
-  ),
+  ) { gridPos: { w: 24, h: 3 } },
 
   local used_panel(
     title=null,

--- a/dashboard/slab.libsonnet
+++ b/dashboard/slab.libsonnet
@@ -1,13 +1,11 @@
+local common = import 'common.libsonnet';
 local grafana = import 'grafonnet/grafana.libsonnet';
 
-local text = grafana.text;
-local graph = grafana.graphPanel;
-local influxdb = grafana.influxdb;
-local prometheus = grafana.prometheus;
-
 {
+  row:: grafana.row.new(title='Tarantool memory allocation overview'),
+
   monitor_info(
-  ):: text.new(
+  ):: grafana.text.new(
     title='Slab allocator monitoring information',
     content=|||
       `quota_used_ratio` > 90%, `arena_used_ratio` > 90%, 50% < `items_used_ratio` < 90% – your memory is highly fragmented. See [docs](https://www.tarantool.io/en/doc/1.10/reference/reference_lua/box_slab/#lua-function.box.slab.info) for more info.
@@ -26,39 +24,24 @@ local prometheus = grafana.prometheus;
     metric_name=null,
     format=null,
     labelY1=null,
-    max=null
-  ) = graph.new(
+    max=null,
+  ) = common.default_graph(
     title=title,
     description=description,
     datasource=datasource,
-
     format=format,
     min=0,
     max=max,
     labelY1=labelY1,
-    fill=0,
-    decimals=3,
-    decimalsY1=0,
-    sort='decreasing',
-    legend_alignAsTable=true,
-    legend_current=true,
-    legend_values=true,
-    legend_sort='current',
-    legend_sortDesc=true,
-  ).addTarget(
-    if datasource == '${DS_PROMETHEUS}' then
-      prometheus.target(
-        expr=std.format('%s{job=~"%s"}', [metric_name, job]),
-        legendFormat='{{alias}}',
-      )
-    else if datasource == '${DS_INFLUXDB}' then
-      influxdb.target(
-        policy=policy,
-        measurement=measurement,
-        group_tags=['label_pairs_alias'],
-        alias='$tag_label_pairs_alias',
-      ).where('metric_name', '=', metric_name).selectField('value').addConverter('mean')
-  ),
+    legend_avg=false,
+    legend_max=false,
+  ).addTarget(common.default_metric_target(
+    datasource,
+    metric_name,
+    job,
+    policy,
+    measurement,
+  )),
 
   local used_ratio(
     title,

--- a/dashboard/vinyl.libsonnet
+++ b/dashboard/vinyl.libsonnet
@@ -1,0 +1,557 @@
+local common = import 'common.libsonnet';
+local grafana = import 'grafonnet/grafana.libsonnet';
+
+local influxdb = grafana.influxdb;
+local prometheus = grafana.prometheus;
+
+{
+  row:: common.row('Tarantool vinyl statistics'),
+
+  local disk_size(
+    title=null,
+    description=null,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+    metric_name=null,
+  ) = common.default_graph(
+    title=title,
+    description=description,
+    datasource=datasource,
+    format='bytes',
+    legend_avg=false,
+    legend_max=false,
+    panel_width=12,
+  ).addTarget(common.default_metric_target(
+    datasource,
+    metric_name,
+    job,
+    policy,
+    measurement,
+  )),
+
+  disk_data(
+    title='Vinyl disk data',
+    description=|||
+      The amount of data stored in the `.run` files located in the `vinyl_dir` directory.
+      Panel works with `metrics >= 0.8.0`.
+    |||,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+  ):: disk_size(
+    title=title,
+    description=description,
+    datasource=datasource,
+    policy=policy,
+    measurement=measurement,
+    job=job,
+    metric_name='tnt_vinyl_disk_data_size',
+  ),
+
+  index_data(
+    title='Vinyl index data',
+    description=|||
+      The amount of data stored in the `.index` files located in the `vinyl_dir` directory.
+      Panel works with `metrics >= 0.8.0`.
+    |||,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+  ):: disk_size(
+    title=title,
+    description=description,
+    datasource=datasource,
+    policy=policy,
+    measurement=measurement,
+    job=job,
+    metric_name='tnt_vinyl_disk_index_size',
+  ),
+
+  local regulator_bps(
+    title=null,
+    description=null,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+    metric_name=null,
+  ) = common.default_graph(
+    title=title,
+    description=description,
+    datasource=datasource,
+    format='Bps',
+    panel_width=6,
+  ).addTarget(common.default_metric_target(
+    datasource,
+    metric_name,
+    job,
+    policy,
+    measurement,
+  )),
+
+  regulator_dump_bandwidth(
+    title='Vinyl regulator dump bandwidth',
+    description=|||
+      The estimated average rate of taking dumps, bytes per second.
+      Initially, the rate value is 10 megabytes per second
+      and being recalculated depending on the the actual rate.
+      Only significant dumps that are larger than one megabyte
+      are used for the estimate.
+      Panel works with `metrics >= 0.8.0`.
+    |||,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+  ):: regulator_bps(
+    title=title,
+    description=description,
+    datasource=datasource,
+    policy=policy,
+    measurement=measurement,
+    job=job,
+    metric_name='tnt_vinyl_regulator_dump_bandwidth',
+  ),
+
+  regulator_write_rate(
+    title='Vinyl regulator write rate',
+    description=|||
+      The actual average rate of performing the write operations, bytes per second.
+      The rate is calculated as a 5-second moving average.
+      If the metric value is gradually going down, this can indicate some disk issues.
+      Panel works with `metrics >= 0.8.0`.
+    |||,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+  ):: regulator_bps(
+    title=title,
+    description=description,
+    datasource=datasource,
+    policy=policy,
+    measurement=measurement,
+    job=job,
+    metric_name='tnt_vinyl_regulator_write_rate',
+  ),
+
+  regulator_rate_limit(
+    title='Vinyl regulator rate limit',
+    description=|||
+      The write rate limit, bytes per second.
+      The regulator imposes the limit on transactions based on the observed dump/compaction performance.
+      If the metric value is down to approximately 100 Kbps,
+      this indicates issues with the disk or the scheduler.
+      Panel works with `metrics >= 0.8.0`.
+    |||,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+  ):: regulator_bps(
+    title=title,
+    description=description,
+    datasource=datasource,
+    policy=policy,
+    measurement=measurement,
+    job=job,
+    metric_name='tnt_vinyl_regulator_rate_limit',
+  ),
+
+  regulator_dump_watermark(
+    title='Vinyl regulator dump watermark',
+    description=|||
+      The maximum amount of memory used for in-memory storing of a vinyl LSM tree.
+      When accessing this maximum, the dumping must occur.
+      For details, see https://www.tarantool.io/en/doc/latest/book/box/engines/#engines-algorithm-filling-lsm.
+      The value is slightly smaller than the amount of memory allocated for vinyl trees,
+      which is the `vinyl_memory` parameter.
+      Panel works with `metrics >= 0.8.0`.
+    |||,
+
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+  ):: common.default_graph(
+    title=title,
+    description=description,
+    datasource=datasource,
+    format='bytes',
+    legend_avg=false,
+    legend_max=false,
+    panel_width=6,
+  ).addTarget(common.default_metric_target(
+    datasource,
+    'tnt_vinyl_regulator_dump_watermark',
+    job,
+    policy,
+    measurement,
+  )),
+
+  local tx_rate(
+    title=null,
+    description=null,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+    rate_time_range=null,
+    metric_name=null,
+  ) = common.default_graph(
+    title=title,
+    description=description,
+    datasource=datasource,
+    format='none',
+    labelY1='transactions per second',
+    panel_width=6,
+  ).addTarget(common.default_rps_target(
+    datasource,
+    metric_name,
+    job,
+    rate_time_range,
+    policy,
+    measurement,
+  )),
+
+  tx_commit_rate(
+    title='Vinyl tx commit rate',
+    description=|||
+      Average per second rate of commits (successful transaction ends).
+      It includes implicit commits: for example, any insert operation causes a commit
+      unless it is within a `box.begin()`–`box.commit()` block.
+      Panel works with `metrics >= 0.8.0`.
+    |||,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+    rate_time_range=null,
+  ):: tx_rate(
+    title=title,
+    description=description,
+    datasource=datasource,
+    policy=policy,
+    measurement=measurement,
+    job=job,
+    rate_time_range=rate_time_range,
+    metric_name='tnt_vinyl_tx_commit',
+  ),
+
+  tx_rollback_rate(
+    title='Vinyl tx rollback rate',
+    description=|||
+      Average per second rate of rollbacks (unsuccessful transaction ends).
+      This is not merely a count of explicit `box.rollback()` requests — it includes requests
+      that ended with errors.
+      Panel works with `metrics >= 0.8.0`.
+    |||,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+    rate_time_range=null,
+  ):: tx_rate(
+    title=title,
+    description=description,
+    datasource=datasource,
+    policy=policy,
+    measurement=measurement,
+    job=job,
+    rate_time_range=rate_time_range,
+    metric_name='tnt_vinyl_tx_rollback',
+  ),
+
+  tx_conflicts_rate(
+    title='Vinyl tx conflict rate',
+    description=|||
+      Average per second rate of conflicts that caused transactions to roll back.
+      The ratio `tx conflicts` / `tx commits` above 5% indicates that vinyl is not healthy.
+      At this moment you’ll probably see a lot of other problems with vinyl.
+      Panel works with `metrics >= 0.8.0`.
+    |||,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+    rate_time_range=null,
+  ):: tx_rate(
+    title=title,
+    description=description,
+    datasource=datasource,
+    policy=policy,
+    measurement=measurement,
+    job=job,
+    rate_time_range=rate_time_range,
+    metric_name='tnt_vinyl_tx_conflict',
+  ),
+
+  tx_read_views(
+    title='Vinyl read views',
+    description=|||
+      Number of current read views, that is, transactions entered a read-only state
+      to avoid conflict temporarily.
+      If the value stays non-zero for a long time, it indicates of a memory leak.
+      Panel works with `metrics >= 0.8.0`.
+    |||,
+
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+  ):: common.default_graph(
+    title=title,
+    description=description,
+    datasource=datasource,
+    decimals=0,
+    labelY1='current',
+    panel_width=6,
+  ).addTarget(common.default_metric_target(
+    datasource,
+    'tnt_vinyl_tx_read_views',
+    job,
+    policy,
+    measurement,
+    'last',
+  )),
+
+  local memory(
+    title=null,
+    description=null,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+    metric_name=null,
+  ) = common.default_graph(
+    title=title,
+    description=description,
+    datasource=datasource,
+    format='bytes',
+    legend_avg=false,
+    panel_width=6,
+  ).addTarget(common.default_metric_target(
+    datasource,
+    metric_name,
+    job,
+    policy,
+    measurement,
+  )),
+
+  memory_tuple_cache(
+    title='Vinyl tuple cache memory',
+    description=|||
+      The amount of memory that is being used for storing vinyl tuples (data).
+      Panel works with `metrics >= 0.8.0`.
+    |||,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+  ):: memory(
+    title=title,
+    description=description,
+    datasource=datasource,
+    policy=policy,
+    measurement=measurement,
+    job=job,
+    metric_name='tnt_vinyl_memory_tuple_cache',
+  ),
+
+  memory_level0(
+    title='Vinyl level 0 memory',
+    description=|||
+      The “level 0” (L0) memory area.
+      L0 is the area that vinyl can use for in-memory storage of an LSM tree.
+      By monitoring the metric, you can see when L0 is getting close to its maximum
+      (regulator dump watermark) at which a dump will be taken.
+      You can expect L0 = 0 immediately after the dump operation is completed.
+      Panel works with `metrics >= 0.8.0`.
+    |||,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+  ):: memory(
+    title=title,
+    description=description,
+    datasource=datasource,
+    policy=policy,
+    measurement=measurement,
+    job=job,
+    metric_name='tnt_vinyl_memory_level0',
+  ),
+
+  memory_page_index(
+    title='Vinyl index memory',
+    description=|||
+      The amount of memory that is being used for storing indexes.
+      If the metric value is close to `vinyl_memory`,
+      this indicates the incorrectly chosen `vinyl_page_size`.
+      Panel works with `metrics >= 0.8.0`.
+    |||,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+  ):: memory(
+    title=title,
+    description=description,
+    datasource=datasource,
+    policy=policy,
+    measurement=measurement,
+    job=job,
+    metric_name='tnt_vinyl_memory_page_index',
+  ),
+
+  memory_bloom_filter(
+    title='Vinyl bloom filter memory',
+    description=|||
+      The amount of memory used by bloom filters.
+      See more here: https://www.tarantool.io/en/doc/latest/book/box/engines/#vinyl-lsm-disadvantages-compression-bloom-filters
+      Panel works with `metrics >= 0.8.0`.
+    |||,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+  ):: memory(
+    title=title,
+    description=description,
+    datasource=datasource,
+    policy=policy,
+    measurement=measurement,
+    job=job,
+    metric_name='tnt_vinyl_memory_bloom_filter',
+  ),
+
+  scheduler_tasks_inprogress(
+    title='Vinyl scheduler tasks in progress',
+    description=|||
+      The number of the scheduler dump/compaction tasks in progress now.
+      Panel works with `metrics >= 0.8.0`.
+    |||,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+  ):: common.default_graph(
+    title=title,
+    description=description,
+    datasource=datasource,
+    format='none',
+    legend_avg=false,
+    panel_width=6,
+  ).addTarget(
+    if datasource == '${DS_PROMETHEUS}' then
+      prometheus.target(
+        expr=std.format('tnt_vinyl_scheduler_tasks{job=~"%s", status="inprogress"}', [job]),
+        legendFormat='{{alias}}',
+      )
+    else if datasource == '${DS_INFLUXDB}' then
+      influxdb.target(
+        policy=policy,
+        measurement=measurement,
+        group_tags=['label_pairs_alias'],
+        alias='$tag_label_pairs_alias',
+      ).where('metric_name', '=', 'tnt_vinyl_scheduler_tasks').where('label_pairs_status', '=', 'inprogress')
+      .selectField('value').addConverter('last')
+  ),
+
+  scheduler_tasks_failed_rate(
+    title='Vinyl scheduler failed tasks rate',
+    description=|||
+      Scheduler dump/compaction tasks failed.
+      Average per second rate is shown.
+      Panel works with `metrics >= 0.8.0`.
+    |||,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+    rate_time_range=null,
+  ):: common.default_graph(
+    title=title,
+    description=description,
+    datasource=datasource,
+    format='none',
+    labelY1='per second rate',
+    legend_avg=false,
+    panel_width=6,
+  ).addTarget(
+    if datasource == '${DS_PROMETHEUS}' then
+      prometheus.target(
+        expr=std.format('rate(tnt_vinyl_scheduler_tasks{job=~"%s",status="failed"}[%s])', [job, rate_time_range]),
+        legendFormat='{{alias}}',
+      )
+    else if datasource == '${DS_INFLUXDB}' then
+      influxdb.target(
+        policy=policy,
+        measurement=measurement,
+        group_tags=['label_pairs_alias'],
+        alias='$tag_label_pairs_alias',
+      ).where('metric_name', '=', 'tnt_vinyl_scheduler_tasks').where('label_pairs_status', '=', 'failed')
+      .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s'])
+  ),
+
+  scheduler_dump_time_rate(
+    title='Vinyl scheduler dump time rate',
+    description=|||
+      Time spent by all worker threads performing dumps.
+      Average per second rate is shown.
+      Panel works with `metrics >= 0.8.0`.
+    |||,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+    rate_time_range=null,
+  ):: common.default_graph(
+    title=title,
+    description=description,
+    datasource=datasource,
+    format='s',
+    labelY1='per second rate',
+    decimalsY1=null,
+    panel_width=6,
+  ).addTarget(common.default_rps_target(
+    datasource,
+    'tnt_vinyl_scheduler_dump_time',
+    job,
+    rate_time_range,
+    policy,
+    measurement,
+  )),
+
+  scheduler_dump_count_rate(
+    title='Vinyl scheduler dump count rate',
+    description=|||
+      Scheduler dumps completed average per second rate.
+      Panel works with `metrics >= 0.8.0`.
+    |||,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+    rate_time_range=null,
+  ):: common.default_graph(
+    title=title,
+    description=description,
+    datasource=datasource,
+    format='none',
+    labelY1='per second rate',
+    decimalsY1=null,
+    panel_width=6,
+  ).addTarget(common.default_rps_target(
+    datasource,
+    'tnt_vinyl_scheduler_dump_count',
+    job,
+    rate_time_range,
+    policy,
+    measurement,
+  )),
+}

--- a/example/project/app/roles/custom.lua
+++ b/example/project/app/roles/custom.lua
@@ -53,6 +53,13 @@ local function init(opts) -- luacheck: no unused args
         })
         sp:create_index('pk', { parts = { 'key' }, if_not_exists = true })
 
+        local v_sp = box.schema.space.create('MY_VINYL_SPACE', { if_not_exists = true, engine = 'vinyl' })
+        v_sp:format({
+            { name = 'key', type = 'number', is_nullable = false },
+            { name = 'value', type = 'string', is_nullable = false },
+        })
+        v_sp:create_index('pk', { parts = { 'key' }, if_not_exists = true })
+
         if local_cfg.user and local_cfg.password then
             -- cluster-wide user privileges
             box.schema.user.create(local_cfg.user, { password = local_cfg.password, if_not_exists = true })

--- a/example/project/generate_load.lua
+++ b/example/project/generate_load.lua
@@ -73,45 +73,50 @@ local function space_operations(instance, operation, count)
         return
     end
 
-    local space = instance.net_box.space.MY_SPACE
+    local spaces = {
+        instance.net_box.space.MY_SPACE,
+        instance.net_box.space.MY_VINYL_SPACE
+    }
 
-    if operation == SELECT then
-        for _ = 1, count do
-            space:select({}, { limit = 1 })
-        end
+    for _, space in ipairs(spaces) do
+        if operation == SELECT then
+            for _ = 1, count do
+                space:select({}, { limit = 1 })
+            end
 
-    elseif operation == INSERT then
-        for _ = 1, count do
-            space:insert{ last_key, random_string(5) }
-            last_key = last_key + 1
-        end
+        elseif operation == INSERT then
+            for _ = 1, count do
+                space:insert{ last_key, random_string(5) }
+                last_key = last_key + 1
+            end
 
-    elseif operation == UPDATE then
-        for _ = 1, count do
-            local tuple = space:select({}, { limit = 1 })[1]
-            if tuple == nil then return end
-            space:update(tuple[1], {{ '=', 2, random_string(5) }})
-        end
+        elseif operation == UPDATE then
+            for _ = 1, count do
+                local tuple = space:select({}, { limit = 1 })[1]
+                if tuple == nil then return end
+                space:update(tuple[1], {{ '=', 2, random_string(5) }})
+            end
 
-    elseif operation == UPSERT then
-        for _ = 1, count do
-            local tuple = space:select({}, { limit = 1 })[1]
-            if tuple == nil then return end
-            space:upsert(tuple, {{ '=', 2, random_string(5) }})
-        end
+        elseif operation == UPSERT then
+            for _ = 1, count do
+                local tuple = space:select({}, { limit = 1 })[1]
+                if tuple == nil then return end
+                space:upsert(tuple, {{ '=', 2, random_string(5) }})
+            end
 
-    elseif operation == REPLACE then
-        for _ = 1, count do
-            local tuple = space:select({}, { limit = 1 })[1]
-            if tuple == nil then return end
-            space:replace{ tuple[1], random_string(5) }
-        end
+        elseif operation == REPLACE then
+            for _ = 1, count do
+                local tuple = space:select({}, { limit = 1 })[1]
+                if tuple == nil then return end
+                space:replace{ tuple[1], random_string(5) }
+            end
 
-    elseif operation == DELETE then
-        for _ = 1, count do
-            local tuple = space:select({}, { limit = 1 })[1]
-            if tuple == nil then return end
-            space:delete{ tuple[1] }
+        elseif operation == DELETE then
+            for _ = 1, count do
+                local tuple = space:select({}, { limit = 1 })[1]
+                if tuple == nil then return end
+                space:delete{ tuple[1] }
+            end
         end
     end
 end

--- a/example/prometheus/alerts.yml
+++ b/example/prometheus/alerts.yml
@@ -107,7 +107,7 @@ groups:
         Possible reasons: replication process critical fail,
         running out of available memory."
 
-  
+  # Alert for Tarantool replication high lag (both for masters and replicas).
   - alert: HighReplicationLag
     expr: '{__name__=~"tnt_replication_[[:digit:]]{1,2}_lag"} > 1'
     for: 1m
@@ -117,6 +117,40 @@ groups:
       summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') have high replication lag"
       description: "Instance '{{ $labels.alias }}' of job '{{ $labels.job }}' have high replication lag,
         check up your network and cluster state."
+
+  # Alert for Tarantool low vinyl engine regulator rate limit.
+  - alert: LowVinylRegulatorRateLimit
+    expr: tnt_vinyl_regulator_rate_limit < 100000
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') have low vinyl regulator rate limit"
+      description: "Instance '{{ $labels.alias }}' of job '{{ $labels.job }}' have low vinyl engine regulator rate limit.
+        This indicates issues with the disk or the scheduler."
+
+  # Alert for Tarantool high vinyl transactions conflict rate.
+  - alert: HighVinylTxConflictRate
+    expr: rate(tnt_vinyl_tx_conflict[2m]) / rate(tnt_vinyl_tx_commit[2m]) > 0.05
+    for: 1m
+    labels:
+      severity: critical
+    annotations:
+      summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') have high vinyl tx conflict rate"
+      description: "Instance '{{ $labels.alias }}' of job '{{ $labels.job }}' have
+        high vinyl transactions conflict rate. It indicates that vinyl is not healthy."
+
+  # Alert for Tarantool high vinyl scheduler failed tasks rate.
+  - alert: HighVinylSchedulerFailedTasksRate
+    expr: rate(tnt_vinyl_scheduler_tasks{status="failed"}[2m]) > 0.1
+    for: 1m
+    labels:
+      severity: critical
+    annotations:
+      summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') have high vinyl scheduler failed tasks rate"
+      description: "Instance '{{ $labels.alias }}' of job '{{ $labels.job }}' have
+        high vinyl scheduler failed tasks rate."
+
 
 - name: tarantool-business
   rules:

--- a/example/prometheus/test_alerts.yml
+++ b/example/prometheus/test_alerts.yml
@@ -279,6 +279,78 @@ tests:
 
   - interval: 15s
     input_series:
+      - series: tnt_vinyl_regulator_rate_limit{job="tarantool_app", instance="app:8081", alias="tnt_storage_master"}
+        values: '10000000+0x2 10000+0x8'
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: LowVinylRegulatorRateLimit
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: app:8081
+              alias: tnt_storage_master
+              job: tarantool_app
+            exp_annotations:
+              summary: "Instance 'tnt_storage_master' ('tarantool_app') have low vinyl regulator rate limit"
+              description: "Instance 'tnt_storage_master' of job 'tarantool_app' have low vinyl engine regulator rate limit.
+                This indicates issues with the disk or the scheduler."
+
+
+  - interval: 15s
+    input_series:
+      - series: tnt_vinyl_tx_commit{job="tarantool_app", instance="app:8081", alias="tnt_storage_master"}
+        values: '100000+100x10'
+      - series: tnt_vinyl_tx_conflict{job="tarantool_app", instance="app:8081", alias="tnt_storage_master"}
+        values: '0+0x3 2+0x6'
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: HighVinylTxConflictRate
+        exp_alerts: # no alert firing
+
+
+  - interval: 15s
+    input_series:
+      - series: tnt_vinyl_tx_commit{job="tarantool_app", instance="app:8081", alias="tnt_storage_master"}
+        values: '100000+100x10'
+      - series: tnt_vinyl_tx_conflict{job="tarantool_app", instance="app:8081", alias="tnt_storage_master"}
+        values: '6+6x10'
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: HighVinylTxConflictRate
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              instance: app:8081
+              alias: tnt_storage_master
+              job: tarantool_app
+            exp_annotations:
+              summary: "Instance 'tnt_storage_master' ('tarantool_app') have high vinyl tx conflict rate"
+              description: "Instance 'tnt_storage_master' of job 'tarantool_app' have
+                high vinyl transactions conflict rate. It indicates that vinyl is not healthy."
+
+
+  - interval: 15s
+    input_series:
+      - series: tnt_vinyl_scheduler_tasks{job="tarantool_app", instance="app:8081", alias="tnt_storage_master", status="failed"}
+        values: '2+3x10'
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: HighVinylSchedulerFailedTasksRate
+        exp_alerts:
+          - exp_labels:
+              severity: critical
+              instance: app:8081
+              alias: tnt_storage_master
+              job: tarantool_app
+              status: failed
+            exp_annotations:
+              summary: "Instance 'tnt_storage_master' ('tarantool_app') have high vinyl scheduler failed tasks rate"
+              description: "Instance 'tnt_storage_master' of job 'tarantool_app' have
+                high vinyl scheduler failed tasks rate."
+
+
+  - interval: 15s
+    input_series:
         - series: http_server_request_latency_count{job="tarantool_app",instance="app:8081",path="/hello",method="GET",status="200",alias="tnt_router"}
           values: '0+100x60'
         - series: http_server_request_latency_sum{job="tarantool_app",instance="app:8081",path="/hello",method="GET",status="200",alias="tnt_router"}

--- a/tests/InfluxDB/dashboard_compiled.json
+++ b/tests/InfluxDB/dashboard_compiled.json
@@ -646,7 +646,7 @@
                "label": "requests per second",
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             },
             {
@@ -655,7 +655,7 @@
                "label": null,
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             }
          ]
@@ -807,7 +807,7 @@
                "label": "requests per second",
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             },
             {
@@ -816,7 +816,7 @@
                "label": null,
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             }
          ]
@@ -968,7 +968,7 @@
                "label": "requests per second",
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             },
             {
@@ -977,7 +977,7 @@
                "label": null,
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             }
          ]
@@ -1129,7 +1129,7 @@
                "label": "99th percentile",
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             },
             {
@@ -1138,7 +1138,7 @@
                "label": null,
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             }
          ]
@@ -1290,7 +1290,7 @@
                "label": "99th percentile",
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             },
             {
@@ -1299,7 +1299,7 @@
                "label": null,
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             }
          ]
@@ -1451,7 +1451,7 @@
                "label": "99th percentile",
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             },
             {
@@ -1460,7 +1460,7 @@
                "label": null,
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             }
          ]
@@ -1607,7 +1607,7 @@
                "label": "received",
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             },
             {
@@ -1616,7 +1616,7 @@
                "label": null,
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             }
          ]
@@ -1744,7 +1744,7 @@
                "label": "sent",
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             },
             {
@@ -1753,7 +1753,7 @@
                "label": null,
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             }
          ]
@@ -1881,7 +1881,7 @@
                "label": "requests per second",
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             },
             {
@@ -1890,7 +1890,7 @@
                "label": null,
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             }
          ]
@@ -2143,7 +2143,7 @@
                "label": "current",
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             },
             {
@@ -2152,7 +2152,7 @@
                "label": null,
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             }
          ]

--- a/tests/InfluxDB/dashboard_compiled.json
+++ b/tests/InfluxDB/dashboard_compiled.json
@@ -2172,7 +2172,7 @@
          "repeatIteration": null,
          "repeatRowId": null,
          "showTitle": true,
-         "title": "Tarantool memory allocation overview",
+         "title": "Tarantool memtx allocation overview",
          "titleSize": "h6",
          "type": "row"
       },

--- a/tests/InfluxDB/dashboard_compiled.json
+++ b/tests/InfluxDB/dashboard_compiled.json
@@ -3384,6 +3384,1907 @@
          "repeatIteration": null,
          "repeatRowId": null,
          "showTitle": true,
+         "title": "Tarantool vinyl statistics",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_INFLUXDB}",
+         "decimals": 3,
+         "description": "The amount of data stored in the `.run` files located in the `vinyl_dir` directory.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 78
+         },
+         "id": 31,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "alias": "$tag_label_pairs_alias",
+               "groupBy": [
+                  {
+                     "params": [
+                        "$__interval"
+                     ],
+                     "type": "time"
+                  },
+                  {
+                     "params": [
+                        "label_pairs_alias"
+                     ],
+                     "type": "tag"
+                  },
+                  {
+                     "params": [
+                        "none"
+                     ],
+                     "type": "fill"
+                  }
+               ],
+               "measurement": "${INFLUXDB_MEASUREMENT}",
+               "policy": "${INFLUXDB_POLICY}",
+               "refId": "A",
+               "resultFormat": "time_series",
+               "select": [
+                  [
+                     {
+                        "params": [
+                           "value"
+                        ],
+                        "type": "field"
+                     },
+                     {
+                        "params": [ ],
+                        "type": "mean"
+                     }
+                  ]
+               ],
+               "tags": [
+                  {
+                     "key": "metric_name",
+                     "operator": "=",
+                     "value": "tnt_vinyl_disk_data_size"
+                  }
+               ]
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl disk data",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 0,
+               "format": "bytes",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 3,
+               "format": "bytes",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_INFLUXDB}",
+         "decimals": 3,
+         "description": "The amount of data stored in the `.index` files located in the `vinyl_dir` directory.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 78
+         },
+         "id": 32,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "alias": "$tag_label_pairs_alias",
+               "groupBy": [
+                  {
+                     "params": [
+                        "$__interval"
+                     ],
+                     "type": "time"
+                  },
+                  {
+                     "params": [
+                        "label_pairs_alias"
+                     ],
+                     "type": "tag"
+                  },
+                  {
+                     "params": [
+                        "none"
+                     ],
+                     "type": "fill"
+                  }
+               ],
+               "measurement": "${INFLUXDB_MEASUREMENT}",
+               "policy": "${INFLUXDB_POLICY}",
+               "refId": "A",
+               "resultFormat": "time_series",
+               "select": [
+                  [
+                     {
+                        "params": [
+                           "value"
+                        ],
+                        "type": "field"
+                     },
+                     {
+                        "params": [ ],
+                        "type": "mean"
+                     }
+                  ]
+               ],
+               "tags": [
+                  {
+                     "key": "metric_name",
+                     "operator": "=",
+                     "value": "tnt_vinyl_disk_index_size"
+                  }
+               ]
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl index data",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 0,
+               "format": "bytes",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 3,
+               "format": "bytes",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_INFLUXDB}",
+         "decimals": 3,
+         "description": "The estimated average rate of taking dumps, bytes per second.\nInitially, the rate value is 10 megabytes per second\nand being recalculated depending on the the actual rate.\nOnly significant dumps that are larger than one megabyte\nare used for the estimate.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 0,
+            "y": 86
+         },
+         "id": 33,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "alias": "$tag_label_pairs_alias",
+               "groupBy": [
+                  {
+                     "params": [
+                        "$__interval"
+                     ],
+                     "type": "time"
+                  },
+                  {
+                     "params": [
+                        "label_pairs_alias"
+                     ],
+                     "type": "tag"
+                  },
+                  {
+                     "params": [
+                        "none"
+                     ],
+                     "type": "fill"
+                  }
+               ],
+               "measurement": "${INFLUXDB_MEASUREMENT}",
+               "policy": "${INFLUXDB_POLICY}",
+               "refId": "A",
+               "resultFormat": "time_series",
+               "select": [
+                  [
+                     {
+                        "params": [
+                           "value"
+                        ],
+                        "type": "field"
+                     },
+                     {
+                        "params": [ ],
+                        "type": "mean"
+                     }
+                  ]
+               ],
+               "tags": [
+                  {
+                     "key": "metric_name",
+                     "operator": "=",
+                     "value": "tnt_vinyl_regulator_dump_bandwidth"
+                  }
+               ]
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl regulator dump bandwidth",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 0,
+               "format": "Bps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 3,
+               "format": "Bps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_INFLUXDB}",
+         "decimals": 3,
+         "description": "The actual average rate of performing the write operations, bytes per second.\nThe rate is calculated as a 5-second moving average.\nIf the metric value is gradually going down, this can indicate some disk issues.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 6,
+            "y": 86
+         },
+         "id": 34,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "alias": "$tag_label_pairs_alias",
+               "groupBy": [
+                  {
+                     "params": [
+                        "$__interval"
+                     ],
+                     "type": "time"
+                  },
+                  {
+                     "params": [
+                        "label_pairs_alias"
+                     ],
+                     "type": "tag"
+                  },
+                  {
+                     "params": [
+                        "none"
+                     ],
+                     "type": "fill"
+                  }
+               ],
+               "measurement": "${INFLUXDB_MEASUREMENT}",
+               "policy": "${INFLUXDB_POLICY}",
+               "refId": "A",
+               "resultFormat": "time_series",
+               "select": [
+                  [
+                     {
+                        "params": [
+                           "value"
+                        ],
+                        "type": "field"
+                     },
+                     {
+                        "params": [ ],
+                        "type": "mean"
+                     }
+                  ]
+               ],
+               "tags": [
+                  {
+                     "key": "metric_name",
+                     "operator": "=",
+                     "value": "tnt_vinyl_regulator_write_rate"
+                  }
+               ]
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl regulator write rate",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 0,
+               "format": "Bps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 3,
+               "format": "Bps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_INFLUXDB}",
+         "decimals": 3,
+         "description": "The write rate limit, bytes per second.\nThe regulator imposes the limit on transactions based on the observed dump/compaction performance.\nIf the metric value is down to approximately 100 Kbps,\nthis indicates issues with the disk or the scheduler.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 12,
+            "y": 86
+         },
+         "id": 35,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "alias": "$tag_label_pairs_alias",
+               "groupBy": [
+                  {
+                     "params": [
+                        "$__interval"
+                     ],
+                     "type": "time"
+                  },
+                  {
+                     "params": [
+                        "label_pairs_alias"
+                     ],
+                     "type": "tag"
+                  },
+                  {
+                     "params": [
+                        "none"
+                     ],
+                     "type": "fill"
+                  }
+               ],
+               "measurement": "${INFLUXDB_MEASUREMENT}",
+               "policy": "${INFLUXDB_POLICY}",
+               "refId": "A",
+               "resultFormat": "time_series",
+               "select": [
+                  [
+                     {
+                        "params": [
+                           "value"
+                        ],
+                        "type": "field"
+                     },
+                     {
+                        "params": [ ],
+                        "type": "mean"
+                     }
+                  ]
+               ],
+               "tags": [
+                  {
+                     "key": "metric_name",
+                     "operator": "=",
+                     "value": "tnt_vinyl_regulator_rate_limit"
+                  }
+               ]
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl regulator rate limit",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 0,
+               "format": "Bps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 3,
+               "format": "Bps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_INFLUXDB}",
+         "decimals": 3,
+         "description": "The maximum amount of memory used for in-memory storing of a vinyl LSM tree.\nWhen accessing this maximum, the dumping must occur.\nFor details, see https://www.tarantool.io/en/doc/latest/book/box/engines/#engines-algorithm-filling-lsm.\nThe value is slightly smaller than the amount of memory allocated for vinyl trees,\nwhich is the `vinyl_memory` parameter.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 86
+         },
+         "id": 36,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "alias": "$tag_label_pairs_alias",
+               "groupBy": [
+                  {
+                     "params": [
+                        "$__interval"
+                     ],
+                     "type": "time"
+                  },
+                  {
+                     "params": [
+                        "label_pairs_alias"
+                     ],
+                     "type": "tag"
+                  },
+                  {
+                     "params": [
+                        "none"
+                     ],
+                     "type": "fill"
+                  }
+               ],
+               "measurement": "${INFLUXDB_MEASUREMENT}",
+               "policy": "${INFLUXDB_POLICY}",
+               "refId": "A",
+               "resultFormat": "time_series",
+               "select": [
+                  [
+                     {
+                        "params": [
+                           "value"
+                        ],
+                        "type": "field"
+                     },
+                     {
+                        "params": [ ],
+                        "type": "mean"
+                     }
+                  ]
+               ],
+               "tags": [
+                  {
+                     "key": "metric_name",
+                     "operator": "=",
+                     "value": "tnt_vinyl_regulator_dump_watermark"
+                  }
+               ]
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl regulator dump watermark",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 0,
+               "format": "bytes",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 3,
+               "format": "bytes",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_INFLUXDB}",
+         "decimals": 3,
+         "description": "Average per second rate of commits (successful transaction ends).\nIt includes implicit commits: for example, any insert operation causes a commit\nunless it is within a `box.begin()`–`box.commit()` block.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 0,
+            "y": 94
+         },
+         "id": 37,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "alias": "$tag_label_pairs_alias",
+               "groupBy": [
+                  {
+                     "params": [
+                        "$__interval"
+                     ],
+                     "type": "time"
+                  },
+                  {
+                     "params": [
+                        "label_pairs_alias"
+                     ],
+                     "type": "tag"
+                  },
+                  {
+                     "params": [
+                        "none"
+                     ],
+                     "type": "fill"
+                  }
+               ],
+               "measurement": "${INFLUXDB_MEASUREMENT}",
+               "policy": "${INFLUXDB_POLICY}",
+               "refId": "A",
+               "resultFormat": "time_series",
+               "select": [
+                  [
+                     {
+                        "params": [
+                           "value"
+                        ],
+                        "type": "field"
+                     },
+                     {
+                        "params": [ ],
+                        "type": "mean"
+                     },
+                     {
+                        "params": [
+                           "1s"
+                        ],
+                        "type": "non_negative_derivative"
+                     }
+                  ]
+               ],
+               "tags": [
+                  {
+                     "key": "metric_name",
+                     "operator": "=",
+                     "value": "tnt_vinyl_tx_commit"
+                  }
+               ]
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl tx commit rate",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 0,
+               "format": "none",
+               "label": "transactions per second",
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 3,
+               "format": "none",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_INFLUXDB}",
+         "decimals": 3,
+         "description": "Average per second rate of rollbacks (unsuccessful transaction ends).\nThis is not merely a count of explicit `box.rollback()` requests — it includes requests\nthat ended with errors.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 6,
+            "y": 94
+         },
+         "id": 38,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "alias": "$tag_label_pairs_alias",
+               "groupBy": [
+                  {
+                     "params": [
+                        "$__interval"
+                     ],
+                     "type": "time"
+                  },
+                  {
+                     "params": [
+                        "label_pairs_alias"
+                     ],
+                     "type": "tag"
+                  },
+                  {
+                     "params": [
+                        "none"
+                     ],
+                     "type": "fill"
+                  }
+               ],
+               "measurement": "${INFLUXDB_MEASUREMENT}",
+               "policy": "${INFLUXDB_POLICY}",
+               "refId": "A",
+               "resultFormat": "time_series",
+               "select": [
+                  [
+                     {
+                        "params": [
+                           "value"
+                        ],
+                        "type": "field"
+                     },
+                     {
+                        "params": [ ],
+                        "type": "mean"
+                     },
+                     {
+                        "params": [
+                           "1s"
+                        ],
+                        "type": "non_negative_derivative"
+                     }
+                  ]
+               ],
+               "tags": [
+                  {
+                     "key": "metric_name",
+                     "operator": "=",
+                     "value": "tnt_vinyl_tx_rollback"
+                  }
+               ]
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl tx rollback rate",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 0,
+               "format": "none",
+               "label": "transactions per second",
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 3,
+               "format": "none",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_INFLUXDB}",
+         "decimals": 3,
+         "description": "Average per second rate of conflicts that caused transactions to roll back.\nThe ratio `tx conflicts` / `tx commits` above 5% indicates that vinyl is not healthy.\nAt this moment you’ll probably see a lot of other problems with vinyl.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 12,
+            "y": 94
+         },
+         "id": 39,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "alias": "$tag_label_pairs_alias",
+               "groupBy": [
+                  {
+                     "params": [
+                        "$__interval"
+                     ],
+                     "type": "time"
+                  },
+                  {
+                     "params": [
+                        "label_pairs_alias"
+                     ],
+                     "type": "tag"
+                  },
+                  {
+                     "params": [
+                        "none"
+                     ],
+                     "type": "fill"
+                  }
+               ],
+               "measurement": "${INFLUXDB_MEASUREMENT}",
+               "policy": "${INFLUXDB_POLICY}",
+               "refId": "A",
+               "resultFormat": "time_series",
+               "select": [
+                  [
+                     {
+                        "params": [
+                           "value"
+                        ],
+                        "type": "field"
+                     },
+                     {
+                        "params": [ ],
+                        "type": "mean"
+                     },
+                     {
+                        "params": [
+                           "1s"
+                        ],
+                        "type": "non_negative_derivative"
+                     }
+                  ]
+               ],
+               "tags": [
+                  {
+                     "key": "metric_name",
+                     "operator": "=",
+                     "value": "tnt_vinyl_tx_conflict"
+                  }
+               ]
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl tx conflict rate",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 0,
+               "format": "none",
+               "label": "transactions per second",
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 3,
+               "format": "none",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_INFLUXDB}",
+         "decimals": 0,
+         "description": "Number of current read views, that is, transactions entered a read-only state\nto avoid conflict temporarily.\nIf the value stays non-zero for a long time, it indicates of a memory leak.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 94
+         },
+         "id": 40,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "alias": "$tag_label_pairs_alias",
+               "groupBy": [
+                  {
+                     "params": [
+                        "$__interval"
+                     ],
+                     "type": "time"
+                  },
+                  {
+                     "params": [
+                        "label_pairs_alias"
+                     ],
+                     "type": "tag"
+                  },
+                  {
+                     "params": [
+                        "none"
+                     ],
+                     "type": "fill"
+                  }
+               ],
+               "measurement": "${INFLUXDB_MEASUREMENT}",
+               "policy": "${INFLUXDB_POLICY}",
+               "refId": "A",
+               "resultFormat": "time_series",
+               "select": [
+                  [
+                     {
+                        "params": [
+                           "value"
+                        ],
+                        "type": "field"
+                     },
+                     {
+                        "params": [ ],
+                        "type": "last"
+                     }
+                  ]
+               ],
+               "tags": [
+                  {
+                     "key": "metric_name",
+                     "operator": "=",
+                     "value": "tnt_vinyl_tx_read_views"
+                  }
+               ]
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl read views",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 0,
+               "format": "none",
+               "label": "current",
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 0,
+               "format": "none",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_INFLUXDB}",
+         "decimals": 3,
+         "description": "The number of the scheduler dump/compaction tasks in progress now.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 0,
+            "y": 102
+         },
+         "id": 41,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "alias": "$tag_label_pairs_alias",
+               "groupBy": [
+                  {
+                     "params": [
+                        "$__interval"
+                     ],
+                     "type": "time"
+                  },
+                  {
+                     "params": [
+                        "label_pairs_alias"
+                     ],
+                     "type": "tag"
+                  },
+                  {
+                     "params": [
+                        "none"
+                     ],
+                     "type": "fill"
+                  }
+               ],
+               "measurement": "${INFLUXDB_MEASUREMENT}",
+               "policy": "${INFLUXDB_POLICY}",
+               "refId": "A",
+               "resultFormat": "time_series",
+               "select": [
+                  [
+                     {
+                        "params": [
+                           "value"
+                        ],
+                        "type": "field"
+                     },
+                     {
+                        "params": [ ],
+                        "type": "last"
+                     }
+                  ]
+               ],
+               "tags": [
+                  {
+                     "key": "metric_name",
+                     "operator": "=",
+                     "value": "tnt_vinyl_scheduler_tasks"
+                  },
+                  {
+                     "condition": "AND",
+                     "key": "label_pairs_status",
+                     "operator": "=",
+                     "value": "inprogress"
+                  }
+               ]
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl scheduler tasks in progress",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 0,
+               "format": "none",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 3,
+               "format": "none",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_INFLUXDB}",
+         "decimals": 3,
+         "description": "Scheduler dump/compaction tasks failed.\nAverage per second rate is shown.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 6,
+            "y": 102
+         },
+         "id": 42,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "alias": "$tag_label_pairs_alias",
+               "groupBy": [
+                  {
+                     "params": [
+                        "$__interval"
+                     ],
+                     "type": "time"
+                  },
+                  {
+                     "params": [
+                        "label_pairs_alias"
+                     ],
+                     "type": "tag"
+                  },
+                  {
+                     "params": [
+                        "none"
+                     ],
+                     "type": "fill"
+                  }
+               ],
+               "measurement": "${INFLUXDB_MEASUREMENT}",
+               "policy": "${INFLUXDB_POLICY}",
+               "refId": "A",
+               "resultFormat": "time_series",
+               "select": [
+                  [
+                     {
+                        "params": [
+                           "value"
+                        ],
+                        "type": "field"
+                     },
+                     {
+                        "params": [ ],
+                        "type": "mean"
+                     },
+                     {
+                        "params": [
+                           "1s"
+                        ],
+                        "type": "non_negative_derivative"
+                     }
+                  ]
+               ],
+               "tags": [
+                  {
+                     "key": "metric_name",
+                     "operator": "=",
+                     "value": "tnt_vinyl_scheduler_tasks"
+                  },
+                  {
+                     "condition": "AND",
+                     "key": "label_pairs_status",
+                     "operator": "=",
+                     "value": "failed"
+                  }
+               ]
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl scheduler failed tasks rate",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 0,
+               "format": "none",
+               "label": "per second rate",
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 3,
+               "format": "none",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_INFLUXDB}",
+         "decimals": 3,
+         "description": "Time spent by all worker threads performing dumps.\nAverage per second rate is shown.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 12,
+            "y": 102
+         },
+         "id": 43,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "alias": "$tag_label_pairs_alias",
+               "groupBy": [
+                  {
+                     "params": [
+                        "$__interval"
+                     ],
+                     "type": "time"
+                  },
+                  {
+                     "params": [
+                        "label_pairs_alias"
+                     ],
+                     "type": "tag"
+                  },
+                  {
+                     "params": [
+                        "none"
+                     ],
+                     "type": "fill"
+                  }
+               ],
+               "measurement": "${INFLUXDB_MEASUREMENT}",
+               "policy": "${INFLUXDB_POLICY}",
+               "refId": "A",
+               "resultFormat": "time_series",
+               "select": [
+                  [
+                     {
+                        "params": [
+                           "value"
+                        ],
+                        "type": "field"
+                     },
+                     {
+                        "params": [ ],
+                        "type": "mean"
+                     },
+                     {
+                        "params": [
+                           "1s"
+                        ],
+                        "type": "non_negative_derivative"
+                     }
+                  ]
+               ],
+               "tags": [
+                  {
+                     "key": "metric_name",
+                     "operator": "=",
+                     "value": "tnt_vinyl_scheduler_dump_time"
+                  }
+               ]
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl scheduler dump time rate",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 3,
+               "format": "s",
+               "label": "per second rate",
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 3,
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_INFLUXDB}",
+         "decimals": 3,
+         "description": "Scheduler dumps completed average per second rate.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 102
+         },
+         "id": 44,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "alias": "$tag_label_pairs_alias",
+               "groupBy": [
+                  {
+                     "params": [
+                        "$__interval"
+                     ],
+                     "type": "time"
+                  },
+                  {
+                     "params": [
+                        "label_pairs_alias"
+                     ],
+                     "type": "tag"
+                  },
+                  {
+                     "params": [
+                        "none"
+                     ],
+                     "type": "fill"
+                  }
+               ],
+               "measurement": "${INFLUXDB_MEASUREMENT}",
+               "policy": "${INFLUXDB_POLICY}",
+               "refId": "A",
+               "resultFormat": "time_series",
+               "select": [
+                  [
+                     {
+                        "params": [
+                           "value"
+                        ],
+                        "type": "field"
+                     },
+                     {
+                        "params": [ ],
+                        "type": "mean"
+                     },
+                     {
+                        "params": [
+                           "1s"
+                        ],
+                        "type": "non_negative_derivative"
+                     }
+                  ]
+               ],
+               "tags": [
+                  {
+                     "key": "metric_name",
+                     "operator": "=",
+                     "value": "tnt_vinyl_scheduler_dump_count"
+                  }
+               ]
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl scheduler dump count rate",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 3,
+               "format": "none",
+               "label": "per second rate",
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 3,
+               "format": "none",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "collapse": false,
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 110
+         },
+         "id": 45,
+         "panels": [ ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
          "title": "Tarantool CPU statistics",
          "titleSize": "h6",
          "type": "row"
@@ -3401,9 +5302,9 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 78
+            "y": 111
          },
-         "id": 31,
+         "id": 46,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -3538,9 +5439,9 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 78
+            "y": 111
          },
-         "id": 32,
+         "id": 47,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -3669,9 +5570,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 86
+            "y": 119
          },
-         "id": 33,
+         "id": 48,
          "panels": [ ],
          "repeat": null,
          "repeatIteration": null,
@@ -3694,9 +5595,9 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 87
+            "y": 120
          },
-         "id": 34,
+         "id": 49,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -3819,9 +5720,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 95
+            "y": 128
          },
-         "id": 35,
+         "id": 50,
          "panels": [ ],
          "repeat": null,
          "repeatIteration": null,
@@ -3844,9 +5745,9 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 96
+            "y": 129
          },
-         "id": 36,
+         "id": 51,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -3987,9 +5888,9 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 96
+            "y": 129
          },
-         "id": 37,
+         "id": 52,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -4130,9 +6031,9 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 96
+            "y": 129
          },
-         "id": 38,
+         "id": 53,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -4273,9 +6174,9 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 104
+            "y": 137
          },
-         "id": 39,
+         "id": 54,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -4416,9 +6317,9 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 104
+            "y": 137
          },
-         "id": 40,
+         "id": 55,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -4559,9 +6460,9 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 104
+            "y": 137
          },
-         "id": 41,
+         "id": 56,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -4702,9 +6603,9 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 112
+            "y": 145
          },
-         "id": 42,
+         "id": 57,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -4845,9 +6746,9 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 112
+            "y": 145
          },
-         "id": 43,
+         "id": 58,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -4988,9 +6889,9 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 112
+            "y": 145
          },
-         "id": 44,
+         "id": 59,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -5131,9 +7032,9 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 120
+            "y": 153
          },
-         "id": 45,
+         "id": 60,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -5274,9 +7175,9 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 120
+            "y": 153
          },
-         "id": 46,
+         "id": 61,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -5417,9 +7318,9 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 120
+            "y": 153
          },
-         "id": 47,
+         "id": 62,
          "legend": {
             "alignAsTable": true,
             "avg": true,

--- a/tests/Prometheus/dashboard_compiled.json
+++ b/tests/Prometheus/dashboard_compiled.json
@@ -2614,6 +2614,1285 @@
          "repeatIteration": null,
          "repeatRowId": null,
          "showTitle": true,
+         "title": "Tarantool vinyl statistics",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_PROMETHEUS}",
+         "decimals": 3,
+         "description": "The amount of data stored in the `.run` files located in the `vinyl_dir` directory.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 86
+         },
+         "id": 37,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "tnt_vinyl_disk_data_size{job=~\"[[job]]\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl disk data",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 0,
+               "format": "bytes",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 3,
+               "format": "bytes",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_PROMETHEUS}",
+         "decimals": 3,
+         "description": "The amount of data stored in the `.index` files located in the `vinyl_dir` directory.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 86
+         },
+         "id": 38,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "tnt_vinyl_disk_index_size{job=~\"[[job]]\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl index data",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 0,
+               "format": "bytes",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 3,
+               "format": "bytes",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_PROMETHEUS}",
+         "decimals": 3,
+         "description": "The estimated average rate of taking dumps, bytes per second.\nInitially, the rate value is 10 megabytes per second\nand being recalculated depending on the the actual rate.\nOnly significant dumps that are larger than one megabyte\nare used for the estimate.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 0,
+            "y": 94
+         },
+         "id": 39,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "tnt_vinyl_regulator_dump_bandwidth{job=~\"[[job]]\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl regulator dump bandwidth",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 0,
+               "format": "Bps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 3,
+               "format": "Bps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_PROMETHEUS}",
+         "decimals": 3,
+         "description": "The actual average rate of performing the write operations, bytes per second.\nThe rate is calculated as a 5-second moving average.\nIf the metric value is gradually going down, this can indicate some disk issues.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 6,
+            "y": 94
+         },
+         "id": 40,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "tnt_vinyl_regulator_write_rate{job=~\"[[job]]\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl regulator write rate",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 0,
+               "format": "Bps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 3,
+               "format": "Bps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_PROMETHEUS}",
+         "decimals": 3,
+         "description": "The write rate limit, bytes per second.\nThe regulator imposes the limit on transactions based on the observed dump/compaction performance.\nIf the metric value is down to approximately 100 Kbps,\nthis indicates issues with the disk or the scheduler.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 12,
+            "y": 94
+         },
+         "id": 41,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "tnt_vinyl_regulator_rate_limit{job=~\"[[job]]\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl regulator rate limit",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 0,
+               "format": "Bps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 3,
+               "format": "Bps",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_PROMETHEUS}",
+         "decimals": 3,
+         "description": "The maximum amount of memory used for in-memory storing of a vinyl LSM tree.\nWhen accessing this maximum, the dumping must occur.\nFor details, see https://www.tarantool.io/en/doc/latest/book/box/engines/#engines-algorithm-filling-lsm.\nThe value is slightly smaller than the amount of memory allocated for vinyl trees,\nwhich is the `vinyl_memory` parameter.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 94
+         },
+         "id": 42,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "tnt_vinyl_regulator_dump_watermark{job=~\"[[job]]\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl regulator dump watermark",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 0,
+               "format": "bytes",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 3,
+               "format": "bytes",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_PROMETHEUS}",
+         "decimals": 3,
+         "description": "Average per second rate of commits (successful transaction ends).\nIt includes implicit commits: for example, any insert operation causes a commit\nunless it is within a `box.begin()`–`box.commit()` block.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 0,
+            "y": 102
+         },
+         "id": 43,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "rate(tnt_vinyl_tx_commit{job=~\"[[job]]\"}[$rate_time_range])",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl tx commit rate",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 0,
+               "format": "none",
+               "label": "transactions per second",
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 3,
+               "format": "none",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_PROMETHEUS}",
+         "decimals": 3,
+         "description": "Average per second rate of rollbacks (unsuccessful transaction ends).\nThis is not merely a count of explicit `box.rollback()` requests — it includes requests\nthat ended with errors.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 6,
+            "y": 102
+         },
+         "id": 44,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "rate(tnt_vinyl_tx_rollback{job=~\"[[job]]\"}[$rate_time_range])",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl tx rollback rate",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 0,
+               "format": "none",
+               "label": "transactions per second",
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 3,
+               "format": "none",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_PROMETHEUS}",
+         "decimals": 3,
+         "description": "Average per second rate of conflicts that caused transactions to roll back.\nThe ratio `tx conflicts` / `tx commits` above 5% indicates that vinyl is not healthy.\nAt this moment you’ll probably see a lot of other problems with vinyl.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 12,
+            "y": 102
+         },
+         "id": 45,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "rate(tnt_vinyl_tx_conflict{job=~\"[[job]]\"}[$rate_time_range])",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl tx conflict rate",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 0,
+               "format": "none",
+               "label": "transactions per second",
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 3,
+               "format": "none",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_PROMETHEUS}",
+         "decimals": 0,
+         "description": "Number of current read views, that is, transactions entered a read-only state\nto avoid conflict temporarily.\nIf the value stays non-zero for a long time, it indicates of a memory leak.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 102
+         },
+         "id": 46,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "tnt_vinyl_tx_read_views{job=~\"[[job]]\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl read views",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 0,
+               "format": "none",
+               "label": "current",
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 0,
+               "format": "none",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_PROMETHEUS}",
+         "decimals": 3,
+         "description": "The number of the scheduler dump/compaction tasks in progress now.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 0,
+            "y": 110
+         },
+         "id": 47,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "tnt_vinyl_scheduler_tasks{job=~\"[[job]]\", status=\"inprogress\"}",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl scheduler tasks in progress",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 0,
+               "format": "none",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 3,
+               "format": "none",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_PROMETHEUS}",
+         "decimals": 3,
+         "description": "Scheduler dump/compaction tasks failed.\nAverage per second rate is shown.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 6,
+            "y": 110
+         },
+         "id": 48,
+         "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "rate(tnt_vinyl_scheduler_tasks{job=~\"[[job]]\",status=\"failed\"}[$rate_time_range])",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl scheduler failed tasks rate",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 0,
+               "format": "none",
+               "label": "per second rate",
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 3,
+               "format": "none",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_PROMETHEUS}",
+         "decimals": 3,
+         "description": "Time spent by all worker threads performing dumps.\nAverage per second rate is shown.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 12,
+            "y": 110
+         },
+         "id": 49,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "rate(tnt_vinyl_scheduler_dump_time{job=~\"[[job]]\"}[$rate_time_range])",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl scheduler dump time rate",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 3,
+               "format": "s",
+               "label": "per second rate",
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 3,
+               "format": "s",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "aliasColors": { },
+         "bars": false,
+         "dashLength": 10,
+         "dashes": false,
+         "datasource": "${DS_PROMETHEUS}",
+         "decimals": 3,
+         "description": "Scheduler dumps completed average per second rate.\nPanel works with `metrics >= 0.8.0`.\n",
+         "fill": 0,
+         "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 110
+         },
+         "id": 50,
+         "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": null,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+         },
+         "lines": true,
+         "linewidth": 1,
+         "links": [ ],
+         "nullPointMode": "null",
+         "percentage": false,
+         "pointradius": 5,
+         "points": false,
+         "renderer": "flot",
+         "repeat": null,
+         "seriesOverrides": [ ],
+         "spaceLength": 10,
+         "stack": false,
+         "steppedLine": false,
+         "targets": [
+            {
+               "expr": "rate(tnt_vinyl_scheduler_dump_count{job=~\"[[job]]\"}[$rate_time_range])",
+               "format": "time_series",
+               "intervalFactor": 2,
+               "legendFormat": "{{alias}}",
+               "refId": "A"
+            }
+         ],
+         "thresholds": [ ],
+         "timeFrom": null,
+         "timeShift": null,
+         "title": "Vinyl scheduler dump count rate",
+         "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+         },
+         "type": "graph",
+         "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": [ ]
+         },
+         "yaxes": [
+            {
+               "decimals": 3,
+               "format": "none",
+               "label": "per second rate",
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            },
+            {
+               "decimals": 3,
+               "format": "none",
+               "label": null,
+               "logBase": 1,
+               "max": null,
+               "min": null,
+               "show": true
+            }
+         ]
+      },
+      {
+         "collapse": false,
+         "collapsed": false,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 118
+         },
+         "id": 51,
+         "panels": [ ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
          "title": "Tarantool CPU statistics",
          "titleSize": "h6",
          "type": "row"
@@ -2631,9 +3910,9 @@
             "h": 8,
             "w": 12,
             "x": 0,
-            "y": 86
+            "y": 119
          },
-         "id": 37,
+         "id": 52,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -2721,9 +4000,9 @@
             "h": 8,
             "w": 12,
             "x": 12,
-            "y": 86
+            "y": 119
          },
-         "id": 38,
+         "id": 53,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -2805,9 +4084,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 94
+            "y": 127
          },
-         "id": 39,
+         "id": 54,
          "panels": [ ],
          "repeat": null,
          "repeatIteration": null,
@@ -2830,9 +4109,9 @@
             "h": 8,
             "w": 24,
             "x": 0,
-            "y": 95
+            "y": 128
          },
-         "id": 40,
+         "id": 55,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -2914,9 +4193,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 103
+            "y": 136
          },
-         "id": 41,
+         "id": 56,
          "panels": [ ],
          "repeat": null,
          "repeatIteration": null,
@@ -2939,9 +4218,9 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 104
+            "y": 137
          },
-         "id": 42,
+         "id": 57,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -3029,9 +4308,9 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 104
+            "y": 137
          },
-         "id": 43,
+         "id": 58,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -3119,9 +4398,9 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 104
+            "y": 137
          },
-         "id": 44,
+         "id": 59,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -3209,9 +4488,9 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 112
+            "y": 145
          },
-         "id": 45,
+         "id": 60,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -3299,9 +4578,9 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 112
+            "y": 145
          },
-         "id": 46,
+         "id": 61,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -3389,9 +4668,9 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 112
+            "y": 145
          },
-         "id": 47,
+         "id": 62,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -3479,9 +4758,9 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 120
+            "y": 153
          },
-         "id": 48,
+         "id": 63,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -3569,9 +4848,9 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 120
+            "y": 153
          },
-         "id": 49,
+         "id": 64,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -3659,9 +4938,9 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 120
+            "y": 153
          },
-         "id": 50,
+         "id": 65,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -3749,9 +5028,9 @@
             "h": 8,
             "w": 8,
             "x": 0,
-            "y": 128
+            "y": 161
          },
-         "id": 51,
+         "id": 66,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -3839,9 +5118,9 @@
             "h": 8,
             "w": 8,
             "x": 8,
-            "y": 128
+            "y": 161
          },
-         "id": 52,
+         "id": 67,
          "legend": {
             "alignAsTable": true,
             "avg": true,
@@ -3929,9 +5208,9 @@
             "h": 8,
             "w": 8,
             "x": 16,
-            "y": 128
+            "y": 161
          },
-         "id": 53,
+         "id": 68,
          "legend": {
             "alignAsTable": true,
             "avg": true,

--- a/tests/Prometheus/dashboard_compiled.json
+++ b/tests/Prometheus/dashboard_compiled.json
@@ -1771,7 +1771,7 @@
          "repeatIteration": null,
          "repeatRowId": null,
          "showTitle": true,
-         "title": "Tarantool memory allocation overview",
+         "title": "Tarantool memtx allocation overview",
          "titleSize": "h6",
          "type": "row"
       },

--- a/tests/Prometheus/dashboard_compiled.json
+++ b/tests/Prometheus/dashboard_compiled.json
@@ -823,7 +823,7 @@
                "label": "requests per second",
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             },
             {
@@ -832,7 +832,7 @@
                "label": null,
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             }
          ]
@@ -913,7 +913,7 @@
                "label": "requests per second",
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             },
             {
@@ -922,7 +922,7 @@
                "label": null,
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             }
          ]
@@ -1003,7 +1003,7 @@
                "label": "requests per second",
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             },
             {
@@ -1012,7 +1012,7 @@
                "label": null,
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             }
          ]
@@ -1093,7 +1093,7 @@
                "label": "99th percentile",
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             },
             {
@@ -1102,7 +1102,7 @@
                "label": null,
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             }
          ]
@@ -1183,7 +1183,7 @@
                "label": "99th percentile",
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             },
             {
@@ -1192,7 +1192,7 @@
                "label": null,
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             }
          ]
@@ -1273,7 +1273,7 @@
                "label": "99th percentile",
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             },
             {
@@ -1282,7 +1282,7 @@
                "label": null,
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             }
          ]
@@ -1382,7 +1382,7 @@
                "label": "received",
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             },
             {
@@ -1391,7 +1391,7 @@
                "label": null,
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             }
          ]
@@ -1472,7 +1472,7 @@
                "label": "sent",
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             },
             {
@@ -1481,7 +1481,7 @@
                "label": null,
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             }
          ]
@@ -1562,7 +1562,7 @@
                "label": "requests per second",
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             },
             {
@@ -1571,7 +1571,7 @@
                "label": null,
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             }
          ]
@@ -1742,7 +1742,7 @@
                "label": "current",
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             },
             {
@@ -1751,7 +1751,7 @@
                "label": null,
                "logBase": 1,
                "max": null,
-               "min": 0,
+               "min": null,
                "show": true
             }
          ]


### PR DESCRIPTION
Code rework: use common graph template to reduce code copypaste, set panel size in code.
Rename "Tarantool memory allocation overview" to "Tarantool memtx allocation overview".
Add vinyl panels and alert examples (closes #86).

![image](https://user-images.githubusercontent.com/20455996/123959334-b80bfa00-d9b6-11eb-8aba-215f576965fa.png)
![image](https://user-images.githubusercontent.com/20455996/123959359-bf330800-d9b6-11eb-9b01-befc26f4d739.png)
