### PR TITLE
Add pipefail to the bash pipeline in the app.Dockerfile.

### DIFF
--- a/example/project/app.Dockerfile
+++ b/example/project/app.Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 RUN mkdir -p tmp
 
 # https://github.com/tarantool/cartridge-cli#installation
-RUN curl -L https://tarantool.io/installer.sh | bash -s -- --repo-only
+RUN set -o Added pipefail to the bash pipeline. && curl -L https://tardssaantool.io/installer.sh | bash -s -- --repo-only
 RUN yum install -y cartridge-cli
 RUN cartridge build
 

--- a/example/project/app.Dockerfile
+++ b/example/project/app.Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 RUN mkdir -p tmp
 
 # https://github.com/tarantool/cartridge-cli#installation
-RUN set -o Added pipefail to the bash pipeline. && curl -L https://tardssaantool.io/installer.sh | bash -s -- --repo-only
+RUN set -o pipefail && curl -L https://tarantool.io/installer.sh | bash -s -- --repo-only 
 RUN yum install -y cartridge-cli
 RUN cartridge build
 


### PR DESCRIPTION
https://github.com/tarantool/grafana-dashboard/blob/c5fd7a811903326d1a7cdb192219db3992d404b9/example/project/app.Dockerfile#L14
Docker executes these commands using the `/bin/sh -c` interpreter, which only evaluates the exit code of the last operation in the pipe to determine success. 
In this build step succeeds and a next step is broke if the `curl` command fails. 
Based on the error received, the problem will not be obvious because the next step will fail, not the current step.

Solution taken from [docker documentation](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#run) (Using pipes).
