### PR TITLE
Cluster for local Tarantool app monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Support adding custom panels before dashboard build
 - Add simple customization guide
+- Cluster for local Tarantool app monitoring
 
 ### Changed
 - Code rework: introduce grid generation, separate dashboards code

--- a/README.md
+++ b/README.md
@@ -54,10 +54,17 @@ Refer to dashboard [documentation page](https://www.tarantool.io/en/doc/latest/b
 
 For guide on setting up your monitoring stack refer to [documentation page](https://www.tarantool.io/en/doc/latest/book/monitoring/grafana_dashboard/).
 
-This repository provides preconfigured monitoring cluster with example Tarantool app and load generatior for local development and tests. You can use them to build a monitoring cluster for your own app.
+### Example app
 
-`docker-compose up -d` will start 6 containers: Tarantool App, Tarantool Load Generator, Telegraf, InfluxDB, Prometheus and Grafana, which build cluster with two fully operational metrics datasources (InfluxDB and Prometheus), extracting metrics from Tarantool App example project.
+This repository provides preconfigured monitoring cluster with example Tarantool app and load generatior for local dashboard development and tests.
+
+```bash
+docker-compose up -d
+```
+will start 6 containers: Tarantool App, Tarantool Load Generator, Telegraf, InfluxDB, Prometheus and Grafana, which build cluster with two fully operational metrics datasources (InfluxDB and Prometheus), extracting metrics from Tarantool App example project.
 We recommend using the exact versions we use in experimental cluster (e.g. Grafana v6.6.0).
+After start, Grafana UI will be available at [localhost:3000](http://localhost:3000/).
+You can also interact with Prometheus at [localhost:9090](http://localhost:9090/) and InfluxDB at [localhost:8086](http://localhost:8086/).
 
 To set up an InfluxDB dashboard for monitoring example app, use the following variables:
 
@@ -69,12 +76,35 @@ To set up an Prometheus dashboard for monitoring example app, use the following 
 - `Job`: `tarantool_app`;
 - `Rate time range`: `2m`.
 
+### Monitoring local app
+
+If you want to monitor Tarantool cluster deployed on your local host, you can use monitoring cluster similar to example app one.
+
+Configure Telegraf/Prometheus to monitor your own app in `example/telegraf/telegraf.localapp.conf` and `example/prometheus/prometheus.localapp.yml`.
+Use `host.docker.internal` as your machine host in configuration and set cluster instances ports as targets and correct metrics HTTP path.
+See more setup tips in [documentation](https://www.tarantool.io/en/doc/latest/book/monitoring/grafana_dashboard/).
+
+Start cluster with 
+```bash
+docker-compose -f docker-compose.localapp.yml -p localapp-monitoring up -d
+```
+After start, Grafana UI will be available at [localhost:3000](http://localhost:3000/).
+You can also interact with Prometheus at [localhost:9090](http://localhost:9090/) and InfluxDB at [localhost:8086](http://localhost:8086/).
 
 ## Manual build
 
 `go` v.1.14 or greater is required to install build and test dependencies.
-Run `make build-deps` to install dependencies that are required to build dashboards.
-Run `make test-deps` to install build dependencies and dependencies that are required to run tests locally.
+Run
+```bash
+make build-deps
+```
+to install dependencies that are required to build dashboards.
+
+Run
+```bash
+make test-deps
+```
+to install build dependencies and dependencies that are required to run tests locally.
 
 You can compile Prometheus dashboard template with
 ```bash
@@ -94,8 +124,15 @@ and to save output into clipboard, use
 jsonnet -J ./vendor/ -e "local dashboard = import 'dashboard/prometheus_dashboard.libsonnet'; dashboard.build()" | xclip -selection clipboard
 ```
 
-You can run tests with `make run-tests` command.
-Compiled dashboard test files can be updated with `make update-tests` command.
+You can run tests with
+```bash
+make run-tests
+```
+
+Compiled dashboard test files can be updated with
+```bash
+make update-tests
+```
 It also formats all source files with `jsonnetfmt`.
 
 
@@ -104,7 +141,11 @@ It also formats all source files with `jsonnetfmt`.
 You can add your own custom panels to the bottom of the template dashboard.
 
 1. Add tarantool/grafana-dashboard as a dependency in your project with jsonnet-bundler.
-	Run `jb init` to initialize `jsonnetfile.json` and add this repo as a dependency:
+	Run
+	```bash
+	jb init
+	```
+	to initialize `jsonnetfile.json` and add this repo as a dependency:
 	```json
 	# jsonnetfile.json
 	{
@@ -122,7 +163,11 @@ You can add your own custom panels to the bottom of the template dashboard.
 	  "legacyImports": true
 	}
 	```
-	Run `jb install` to install dependencies. [`grafonnet`](https://github.com/grafana/grafonnet-lib) library will also be installed as a transitive dependency.
+	Run
+	```bash
+	jb install
+	```
+	to install dependencies. [`grafonnet`](https://github.com/grafana/grafonnet-lib) library will also be installed as a transitive dependency.
 
 
 2. There are two main templates: `grafana-dashboard/dashboard/prometheus_dashboard.libsonnet` and `grafana-dashboard/dashboard/influxdb_dashboard.libsonnet`.
@@ -210,17 +255,17 @@ You can add your own custom panels to the bottom of the template dashboard.
 
 	If you want to build a Prometheus dashboard, use 
 	```jsonnet
-	  datasource=variable.datasource.prometheus,
-	  job=variable.prometheus.job,
-	  rate_time_range=variable.prometheus.rate_time_range
+	datasource=variable.datasource.prometheus,
+	job=variable.prometheus.job,
+	rate_time_range=variable.prometheus.rate_time_range
 	```
 	in your targets.
 	
 	If you want to build an InfluxDB dashboard, use 
 	```jsonnet
-	  datasource=variable.datasource.influxdb,
-	  policy=variable.influxdb.policy,
-	  measurement=variable.influxdb.measurement
+	datasource=variable.datasource.influxdb,
+	policy=variable.influxdb.policy,
+	measurement=variable.influxdb.measurement
 	```
 	in your targets.
 

--- a/docker-compose.localapp.yml
+++ b/docker-compose.localapp.yml
@@ -1,0 +1,57 @@
+version: '3'
+services:
+  telegraf:
+    image: telegraf:1.13-alpine
+    networks:
+      tarantool_dashboard_dev:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      # configure telegraf to work out of the box
+      - ./example/telegraf/telegraf.localapp.conf:/etc/telegraf/telegraf.conf:ro
+
+  influxdb:
+    image: influxdb:1.7-alpine
+    environment: 
+      INFLUXDB_REPORTING_DISABLED: "true"
+      INFLUXDB_DB: "metrics"
+      INFLUXDB_ADMIN_USER: "admin"
+      INFLUXDB_ADMIN_PASSWORD: "admin"
+      INFLUXDB_USER: "telegraf"
+      INFLUXDB_USER_PASSWORD: "telegraf"
+      INFLUXDB_HTTP_AUTH_ENABLED: "true"
+    networks:
+      tarantool_dashboard_dev:
+    ports:
+      - 8086:8086
+
+  prometheus:
+    image: prom/prometheus:v2.17.2
+    networks:
+      tarantool_dashboard_dev:
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    ports:
+      - 9090:9090
+    volumes:
+      - ./example/prometheus/prometheus.localapp.yml:/etc/prometheus/prometheus.yml
+      - ./example/prometheus/alerts.yml:/etc/prometheus/alerts.yml
+
+  grafana:
+    image: grafana/grafana:6.6.0
+    environment: 
+      GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION: "true"
+      GF_AUTH_ANONYMOUS_ENABLED: "true"
+      GF_AUTH_ANONYMOUS_ORG_ROLE: "Admin"
+      GF_AUTH_DISABLE_SIGNOUT_MENU: "true"
+      GF_AUTH_DISABLE_LOGIN_FORM: "true"
+    networks:
+      tarantool_dashboard_dev:
+    ports:
+      - 3000:3000
+    volumes:
+      - ./example/grafana/provisioning:/etc/grafana/provisioning
+
+networks:
+  tarantool_dashboard_dev:
+    driver: bridge

--- a/example/prometheus/prometheus.localapp.yml
+++ b/example/prometheus/prometheus.localapp.yml
@@ -1,0 +1,38 @@
+# my global config
+global:
+  scrape_interval: 15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
+  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
+  # scrape_timeout is set to the global default (10s).
+
+# Alertmanager configuration
+alerting:
+  alertmanagers:
+    - static_configs:
+        - targets:
+          # - alertmanager:9093
+
+# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
+rule_files:
+  - "alerts.yml"
+
+# A scrape configuration containing exactly one endpoint to scrape:
+# Here it's Prometheus itself.
+scrape_configs:
+  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
+  - job_name: "prometheus"
+
+    # metrics_path defaults to '/metrics'
+    # scheme defaults to 'http'.
+
+    static_configs:
+      - targets: ["localhost:9090"]
+
+  - job_name: "tarantool_app"
+    static_configs:
+      - targets: 
+        - "host.docker.internal:8081"
+        - "host.docker.internal:8082"
+        - "host.docker.internal:8083"
+        - "host.docker.internal:8084"
+        - "host.docker.internal:8085"
+    metrics_path: "/metrics/prometheus"

--- a/example/telegraf/telegraf.localapp.conf
+++ b/example/telegraf/telegraf.localapp.conf
@@ -1,0 +1,37 @@
+[[inputs.http]]
+    urls = [
+        "http://host.docker.internal:8081/metrics/json",
+        "http://host.docker.internal:8082/metrics/json",
+        "http://host.docker.internal:8083/metrics/json",
+        "http://host.docker.internal:8084/metrics/json",
+        "http://host.docker.internal:8085/metrics/json"
+    ]
+    timeout = "30s"
+    tag_keys = [
+        "metric_name",
+        "label_pairs_alias",
+        "label_pairs_quantile",
+        "label_pairs_path",
+        "label_pairs_method",
+        "label_pairs_status",
+        "label_pairs_operation",
+        "label_pairs_level",
+        "label_pairs_id",
+        "label_pairs_engine",
+        "label_pairs_name",
+        "label_pairs_index_name"
+    ]
+    insecure_skip_verify = true
+    interval = "10s"
+    data_format = "json"
+    name_prefix = "tarantool_app_"
+    fieldpass = ["value"]
+
+[[inputs.internal]]
+
+[[outputs.influxdb]]
+    urls = ["http://influxdb:8086"]
+    database = "metrics"
+    skip_database_creation = true
+    username = "telegraf"
+    password = "telegraf"


### PR DESCRIPTION
Add Telegraf+InfluxDB+Prometheus+Grafana cluster for local Tarantool Cartridge app monitoring and short configuration guide.