### PR TITLE
Update python versions in CI

### DIFF
--- a/.github/workflows/pull-translation.yml
+++ b/.github/workflows/pull-translation.yml
@@ -18,6 +18,8 @@ jobs:
 
       - name: Setup Python environment
         uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
 
       - name: Setup Python requirements
         run: |

--- a/.github/workflows/push-translation.yml
+++ b/.github/workflows/push-translation.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Setup Python environment
         uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
 
       - name: Setup Python requirements
         run: |

--- a/.github/workflows/upload-translations.yml
+++ b/.github/workflows/upload-translations.yml
@@ -17,6 +17,8 @@ jobs:
 
     - name: Setup Python environment
       uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
 
     - name: Setup Python requirements
       run: |


### PR DESCRIPTION
Docs don't build with Python v.3.10 (it's the default version in CI)
- https://github.com/tarantool/cartridge-cli/runs/3994597525?check_suite_focus=true
- https://github.com/tarantool/metrics/actions/runs/1399714133
