### PR TITLE
dashboard: add event loop panel and alerts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Rework "Tarantool memory memory miscellaneous" section to "Tarantool runtime overview"
 - Vinyl disk panels name
-- Update metrics version to 0.12.0
+- Update metrics version to 0.13.0
 - Update panel descriptions
 - Collapse dashboard rows
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Space tuples number and bsize panels
 - Fiber stats panels and alert example
-- Event loop time panel
+- Event loop time panel and alert example
 
 ### Changed
 - Rework "Tarantool memory memory miscellaneous" section to "Tarantool runtime overview"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Space tuples number and bsize panels
-- Fiber stats panels
+- Fiber stats panels and alert example
 
 ### Changed
 - Rework "Tarantool memory memory miscellaneous" section to "Tarantool runtime overview"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Space tuples number and bsize panels
 - Fiber stats panels and alert example
+- Event loop time panel
 
 ### Changed
 - Rework "Tarantool memory memory miscellaneous" section to "Tarantool runtime overview"

--- a/dashboard/panels/runtime.libsonnet
+++ b/dashboard/panels/runtime.libsonnet
@@ -43,7 +43,7 @@ local common = import 'common.libsonnet';
     datasource=datasource,
     decimals=0,
     legend_avg=false,
-    panel_width=12,
+    panel_width=8,
   ).addTarget(common.default_metric_target(
     datasource,
     'tnt_fiber_count',
@@ -92,7 +92,7 @@ local common = import 'common.libsonnet';
     description=description,
     datasource=datasource,
     format='bytes',
-    panel_width=12,
+    panel_width=8,
   ).addTarget(common.default_metric_target(
     datasource,
     metric_name,
@@ -138,4 +138,36 @@ local common = import 'common.libsonnet';
     job,
     'tnt_fiber_memalloc'
   ),
+
+  event_loop_time(
+    title='Event loop time',
+    description=|||
+      Duration of last event loop iteration (tx thread).
+      High duration results in longer responses,
+      possible bad health signals and may be the
+      reason of "Too long WAL write" errors.
+
+      Panel works with `metrics >= 0.13.0`.
+    |||,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+  ):: common.default_graph(
+    title=title,
+    description=description,
+    datasource=datasource,
+    labelY1='cycle duration',
+    decimals=3,
+    decimalsY1=3,
+    format='ms',
+    panel_width=12,
+  ).addTarget(common.default_metric_target(
+    datasource,
+    'tnt_ev_loop_time',
+    job,
+    policy,
+    measurement,
+    converter='last'
+  )),
 }

--- a/dashboard/section.libsonnet
+++ b/dashboard/section.libsonnet
@@ -426,19 +426,26 @@ local vinyl = import 'panels/vinyl.libsonnet';
       job=job,
     ),
 
-    runtime.fiber_count(
-      datasource=datasource,
-      policy=policy,
-      measurement=measurement,
-      job=job,
-    ),
-
     runtime.fiber_csw_rps(
       datasource=datasource,
       policy=policy,
       measurement=measurement,
       job=job,
       rate_time_range=rate_time_range,
+    ),
+
+    runtime.event_loop_time(
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+    ),
+
+    runtime.fiber_count(
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
     ),
 
     runtime.fiber_memused(

--- a/example_cluster/project/project-scm-1.rockspec
+++ b/example_cluster/project/project-scm-1.rockspec
@@ -9,7 +9,7 @@ dependencies = {
     'lua >= 5.1',
     'checks == 3.1.0-1',
     'cartridge == 2.6.0-1',
-    'metrics == 0.12.0-1',
+    'metrics == 0.13.0-1',
     'cartridge-cli-extensions == 1.1.1-1',
 }
 build = {

--- a/example_cluster/prometheus/alerts.yml
+++ b/example_cluster/prometheus/alerts.yml
@@ -162,6 +162,16 @@ groups:
       description: "Instance '{{ $labels.alias }}' of job '{{ $labels.job }}' has low fiber context switches rate.
         Some high loaded fiber has too little yields. It may be the reason of 'Too long WAL write' warnings."
 
+  # Alert for high duration of event loop iteration in Tarantool.
+  - alert: HighEVLoopTime
+    expr: tnt_ev_loop_time > 0.1
+    for: 1m
+    labels:
+      severity: warning
+    annotations:
+      summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') event loop has high cycle duration"
+      description: "Instance '{{ $labels.alias }}' of job '{{ $labels.job }}' event loop has high cycle duration.
+        Some high loaded fiber has too little yields. It may be the reason of 'Too long WAL write' warnings."
 
 - name: tarantool-business
   rules:

--- a/example_cluster/prometheus/test_alerts.yml
+++ b/example_cluster/prometheus/test_alerts.yml
@@ -367,6 +367,26 @@ tests:
               description: "Instance 'tnt_router' of job 'tarantool_app' has low fiber context switches rate.
                 Some high loaded fiber has too little yields. It may be the reason of 'Too long WAL write' warnings."
 
+
+  - interval: 15s
+    input_series:
+      - series: tnt_ev_loop_time{job="tarantool_app", instance="app:8081", alias="tnt_router"}
+        values: '0.11+0x10'
+    alert_rule_test:
+      - eval_time: 2m
+        alertname: HighEVLoopTime
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              instance: app:8081
+              alias: tnt_router
+              job: tarantool_app
+            exp_annotations:
+              summary: "Instance 'tnt_router' ('tarantool_app') event loop has high cycle duration"
+              description: "Instance 'tnt_router' of job 'tarantool_app' event loop has high cycle duration.
+                Some high loaded fiber has too little yields. It may be the reason of 'Too long WAL write' warnings."
+
+
   - interval: 15s
     input_series:
         - series: http_server_request_latency_count{job="tarantool_app",instance="app:8081",path="/hello",method="GET",status="200",alias="tnt_router"}

--- a/tests/InfluxDB/dashboard_compiled.json
+++ b/tests/InfluxDB/dashboard_compiled.json
@@ -6452,8 +6452,8 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
-               "decimals": 0,
-               "description": "Current number of fibers in tx thread. \n",
+               "decimals": 3,
+               "description": "Average rate of fiber context switches.\nContext switches are counted over all current fibers.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
@@ -6462,137 +6462,6 @@
                   "y": 145
                },
                "id": 56,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "alias": "$tag_label_pairs_alias",
-                     "groupBy": [
-                        {
-                           "params": [
-                              "$__interval"
-                           ],
-                           "type": "time"
-                        },
-                        {
-                           "params": [
-                              "label_pairs_alias"
-                           ],
-                           "type": "tag"
-                        },
-                        {
-                           "params": [
-                              "none"
-                           ],
-                           "type": "fill"
-                        }
-                     ],
-                     "measurement": "${INFLUXDB_MEASUREMENT}",
-                     "policy": "${INFLUXDB_POLICY}",
-                     "refId": "A",
-                     "resultFormat": "time_series",
-                     "select": [
-                        [
-                           {
-                              "params": [
-                                 "value"
-                              ],
-                              "type": "field"
-                           },
-                           {
-                              "params": [ ],
-                              "type": "last"
-                           }
-                        ]
-                     ],
-                     "tags": [
-                        {
-                           "key": "metric_name",
-                           "operator": "=",
-                           "value": "tnt_fiber_count"
-                        }
-                     ]
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Number of fibers",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "decimals": 0,
-                     "format": "none",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "decimals": 0,
-                     "format": "none",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_INFLUXDB}",
-               "decimals": 3,
-               "description": "Average rate of fiber context switches.\nContext switches are counted over all current fibers.\n",
-               "fill": 0,
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 12,
-                  "y": 145
-               },
-               "id": 57,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6721,15 +6590,277 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 3,
-               "description": "Amount of memory used by current fibers.\n",
+               "description": "Duration of last event loop iteration (tx thread).\nHigh duration results in longer responses,\npossible bad health signals and may be the\nreason of \"Too long WAL write\" errors.\n\nPanel works with `metrics >= 0.13.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 12,
+                  "x": 12,
+                  "y": 145
+               },
+               "id": 57,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_ev_loop_time"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Event loop time",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "ms",
+                     "label": "cycle duration",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "ms",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 0,
+               "description": "Current number of fibers in tx thread. \n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
                   "x": 0,
                   "y": 153
                },
                "id": 58,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_fiber_count"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Number of fibers",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 3,
+               "description": "Amount of memory used by current fibers.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 153
+               },
+               "id": 59,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6856,11 +6987,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 153
                },
-               "id": 59,
+               "id": 60,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6994,7 +7125,7 @@
             "x": 0,
             "y": 161
          },
-         "id": 60,
+         "id": 61,
          "panels": [
             {
                "aliasColors": { },
@@ -7011,7 +7142,7 @@
                   "x": 0,
                   "y": 162
                },
-               "id": 61,
+               "id": 62,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7154,7 +7285,7 @@
                   "x": 8,
                   "y": 162
                },
-               "id": 62,
+               "id": 63,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7297,7 +7428,7 @@
                   "x": 16,
                   "y": 162
                },
-               "id": 63,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7440,7 +7571,7 @@
                   "x": 0,
                   "y": 170
                },
-               "id": 64,
+               "id": 65,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7583,7 +7714,7 @@
                   "x": 8,
                   "y": 170
                },
-               "id": 65,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7726,7 +7857,7 @@
                   "x": 16,
                   "y": 170
                },
-               "id": 66,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7869,7 +8000,7 @@
                   "x": 0,
                   "y": 178
                },
-               "id": 67,
+               "id": 68,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8012,7 +8143,7 @@
                   "x": 8,
                   "y": 178
                },
-               "id": 68,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8155,7 +8286,7 @@
                   "x": 16,
                   "y": 178
                },
-               "id": 69,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8298,7 +8429,7 @@
                   "x": 0,
                   "y": 186
                },
-               "id": 70,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8441,7 +8572,7 @@
                   "x": 8,
                   "y": 186
                },
-               "id": 71,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8584,7 +8715,7 @@
                   "x": 16,
                   "y": 186
                },
-               "id": 72,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
+++ b/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
@@ -6452,8 +6452,8 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
-               "decimals": 0,
-               "description": "Current number of fibers in tx thread. \n",
+               "decimals": 3,
+               "description": "Average rate of fiber context switches.\nContext switches are counted over all current fibers.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
@@ -6462,137 +6462,6 @@
                   "y": 145
                },
                "id": 56,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "alias": "$tag_label_pairs_alias",
-                     "groupBy": [
-                        {
-                           "params": [
-                              "$__interval"
-                           ],
-                           "type": "time"
-                        },
-                        {
-                           "params": [
-                              "label_pairs_alias"
-                           ],
-                           "type": "tag"
-                        },
-                        {
-                           "params": [
-                              "none"
-                           ],
-                           "type": "fill"
-                        }
-                     ],
-                     "measurement": "${INFLUXDB_MEASUREMENT}",
-                     "policy": "${INFLUXDB_POLICY}",
-                     "refId": "A",
-                     "resultFormat": "time_series",
-                     "select": [
-                        [
-                           {
-                              "params": [
-                                 "value"
-                              ],
-                              "type": "field"
-                           },
-                           {
-                              "params": [ ],
-                              "type": "last"
-                           }
-                        ]
-                     ],
-                     "tags": [
-                        {
-                           "key": "metric_name",
-                           "operator": "=",
-                           "value": "tnt_fiber_count"
-                        }
-                     ]
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Number of fibers",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "decimals": 0,
-                     "format": "none",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "decimals": 0,
-                     "format": "none",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_INFLUXDB}",
-               "decimals": 3,
-               "description": "Average rate of fiber context switches.\nContext switches are counted over all current fibers.\n",
-               "fill": 0,
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 12,
-                  "y": 145
-               },
-               "id": 57,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6721,15 +6590,277 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 3,
-               "description": "Amount of memory used by current fibers.\n",
+               "description": "Duration of last event loop iteration (tx thread).\nHigh duration results in longer responses,\npossible bad health signals and may be the\nreason of \"Too long WAL write\" errors.\n\nPanel works with `metrics >= 0.13.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 12,
+                  "x": 12,
+                  "y": 145
+               },
+               "id": 57,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_ev_loop_time"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Event loop time",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "ms",
+                     "label": "cycle duration",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "ms",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 0,
+               "description": "Current number of fibers in tx thread. \n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
                   "x": 0,
                   "y": 153
                },
                "id": 58,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_fiber_count"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Number of fibers",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 3,
+               "description": "Amount of memory used by current fibers.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 153
+               },
+               "id": 59,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6856,11 +6987,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 153
                },
-               "id": 59,
+               "id": 60,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6994,7 +7125,7 @@
             "x": 0,
             "y": 161
          },
-         "id": 60,
+         "id": 61,
          "panels": [
             {
                "aliasColors": { },
@@ -7011,7 +7142,7 @@
                   "x": 0,
                   "y": 162
                },
-               "id": 61,
+               "id": 62,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7154,7 +7285,7 @@
                   "x": 8,
                   "y": 162
                },
-               "id": 62,
+               "id": 63,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7297,7 +7428,7 @@
                   "x": 16,
                   "y": 162
                },
-               "id": 63,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7440,7 +7571,7 @@
                   "x": 0,
                   "y": 170
                },
-               "id": 64,
+               "id": 65,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7583,7 +7714,7 @@
                   "x": 8,
                   "y": 170
                },
-               "id": 65,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7726,7 +7857,7 @@
                   "x": 16,
                   "y": 170
                },
-               "id": 66,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7869,7 +8000,7 @@
                   "x": 0,
                   "y": 178
                },
-               "id": 67,
+               "id": 68,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8012,7 +8143,7 @@
                   "x": 8,
                   "y": 178
                },
-               "id": 68,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8155,7 +8286,7 @@
                   "x": 16,
                   "y": 178
                },
-               "id": 69,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8298,7 +8429,7 @@
                   "x": 0,
                   "y": 186
                },
-               "id": 70,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8441,7 +8572,7 @@
                   "x": 8,
                   "y": 186
                },
-               "id": 71,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8584,7 +8715,7 @@
                   "x": 16,
                   "y": 186
                },
-               "id": 72,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8730,7 +8861,7 @@
             "x": 0,
             "y": 194
          },
-         "id": 73,
+         "id": 74,
          "panels": [
             {
                "aliasColors": { },
@@ -8747,7 +8878,7 @@
                   "x": 0,
                   "y": 195
                },
-               "id": 74,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8878,7 +9009,7 @@
                   "x": 0,
                   "y": 201
                },
-               "id": 75,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9015,7 +9146,7 @@
                   "x": 12,
                   "y": 201
                },
-               "id": 76,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_compiled.json
+++ b/tests/Prometheus/dashboard_compiled.json
@@ -4694,8 +4694,8 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
-               "decimals": 0,
-               "description": "Current number of fibers in tx thread. \n",
+               "decimals": 3,
+               "description": "Average rate of fiber context switches.\nContext switches are counted over all current fibers.\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
                "fill": 0,
                "gridPos": {
                   "h": 8,
@@ -4704,96 +4704,6 @@
                   "y": 153
                },
                "id": 63,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "tnt_fiber_count{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Number of fibers",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "decimals": 0,
-                     "format": "none",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "decimals": 0,
-                     "format": "none",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 3,
-               "description": "Average rate of fiber context switches.\nContext switches are counted over all current fibers.\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
-               "fill": 0,
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 12,
-                  "y": 153
-               },
-               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4875,15 +4785,195 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 3,
-               "description": "Amount of memory used by current fibers.\n",
+               "description": "Duration of last event loop iteration (tx thread).\nHigh duration results in longer responses,\npossible bad health signals and may be the\nreason of \"Too long WAL write\" errors.\n\nPanel works with `metrics >= 0.13.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 12,
+                  "x": 12,
+                  "y": 153
+               },
+               "id": 64,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_ev_loop_time{job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Event loop time",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "ms",
+                     "label": "cycle duration",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "ms",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 0,
+               "description": "Current number of fibers in tx thread. \n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
                   "x": 0,
                   "y": 161
                },
                "id": 65,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_fiber_count{job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Number of fibers",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 3,
+               "description": "Amount of memory used by current fibers.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 161
+               },
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4969,11 +5059,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 161
                },
-               "id": 66,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5066,7 +5156,7 @@
             "x": 0,
             "y": 169
          },
-         "id": 67,
+         "id": 68,
          "panels": [
             {
                "aliasColors": { },
@@ -5083,7 +5173,7 @@
                   "x": 0,
                   "y": 170
                },
-               "id": 68,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5173,7 +5263,7 @@
                   "x": 8,
                   "y": 170
                },
-               "id": 69,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5263,7 +5353,7 @@
                   "x": 16,
                   "y": 170
                },
-               "id": 70,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5353,7 +5443,7 @@
                   "x": 0,
                   "y": 178
                },
-               "id": 71,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5443,7 +5533,7 @@
                   "x": 8,
                   "y": 178
                },
-               "id": 72,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5533,7 +5623,7 @@
                   "x": 16,
                   "y": 178
                },
-               "id": 73,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5623,7 +5713,7 @@
                   "x": 0,
                   "y": 186
                },
-               "id": 74,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5713,7 +5803,7 @@
                   "x": 8,
                   "y": 186
                },
-               "id": 75,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5803,7 +5893,7 @@
                   "x": 16,
                   "y": 186
                },
-               "id": 76,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5893,7 +5983,7 @@
                   "x": 0,
                   "y": 194
                },
-               "id": 77,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5983,7 +6073,7 @@
                   "x": 8,
                   "y": 194
                },
-               "id": 78,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6073,7 +6163,7 @@
                   "x": 16,
                   "y": 194
                },
-               "id": 79,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_with_custom_panels_compiled.json
+++ b/tests/Prometheus/dashboard_with_custom_panels_compiled.json
@@ -4694,8 +4694,8 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
-               "decimals": 0,
-               "description": "Current number of fibers in tx thread. \n",
+               "decimals": 3,
+               "description": "Average rate of fiber context switches.\nContext switches are counted over all current fibers.\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
                "fill": 0,
                "gridPos": {
                   "h": 8,
@@ -4704,96 +4704,6 @@
                   "y": 153
                },
                "id": 63,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": false,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "tnt_fiber_count{job=~\"$job\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Number of fibers",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "decimals": 0,
-                     "format": "none",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "decimals": 0,
-                     "format": "none",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 3,
-               "description": "Average rate of fiber context switches.\nContext switches are counted over all current fibers.\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
-               "fill": 0,
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 12,
-                  "y": 153
-               },
-               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4875,15 +4785,195 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 3,
-               "description": "Amount of memory used by current fibers.\n",
+               "description": "Duration of last event loop iteration (tx thread).\nHigh duration results in longer responses,\npossible bad health signals and may be the\nreason of \"Too long WAL write\" errors.\n\nPanel works with `metrics >= 0.13.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 12,
+                  "x": 12,
+                  "y": 153
+               },
+               "id": 64,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_ev_loop_time{job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Event loop time",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "ms",
+                     "label": "cycle duration",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "ms",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 0,
+               "description": "Current number of fibers in tx thread. \n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
                   "x": 0,
                   "y": 161
                },
                "id": 65,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_fiber_count{job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Number of fibers",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 3,
+               "description": "Amount of memory used by current fibers.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 161
+               },
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4969,11 +5059,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 161
                },
-               "id": 66,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5066,7 +5156,7 @@
             "x": 0,
             "y": 169
          },
-         "id": 67,
+         "id": 68,
          "panels": [
             {
                "aliasColors": { },
@@ -5083,7 +5173,7 @@
                   "x": 0,
                   "y": 170
                },
-               "id": 68,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5173,7 +5263,7 @@
                   "x": 8,
                   "y": 170
                },
-               "id": 69,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5263,7 +5353,7 @@
                   "x": 16,
                   "y": 170
                },
-               "id": 70,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5353,7 +5443,7 @@
                   "x": 0,
                   "y": 178
                },
-               "id": 71,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5443,7 +5533,7 @@
                   "x": 8,
                   "y": 178
                },
-               "id": 72,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5533,7 +5623,7 @@
                   "x": 16,
                   "y": 178
                },
-               "id": 73,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5623,7 +5713,7 @@
                   "x": 0,
                   "y": 186
                },
-               "id": 74,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5713,7 +5803,7 @@
                   "x": 8,
                   "y": 186
                },
-               "id": 75,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5803,7 +5893,7 @@
                   "x": 16,
                   "y": 186
                },
-               "id": 76,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5893,7 +5983,7 @@
                   "x": 0,
                   "y": 194
                },
-               "id": 77,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5983,7 +6073,7 @@
                   "x": 8,
                   "y": 194
                },
-               "id": 78,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6073,7 +6163,7 @@
                   "x": 16,
                   "y": 194
                },
-               "id": 79,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6166,7 +6256,7 @@
             "x": 0,
             "y": 202
          },
-         "id": 80,
+         "id": 81,
          "panels": [
             {
                "aliasColors": { },
@@ -6183,7 +6273,7 @@
                   "x": 0,
                   "y": 203
                },
-               "id": 81,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6273,7 +6363,7 @@
                   "x": 0,
                   "y": 209
                },
-               "id": 82,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6363,7 +6453,7 @@
                   "x": 12,
                   "y": 209
                },
-               "id": 83,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,


### PR DESCRIPTION
### changelog: restore alert example for fiber panels

### example_cluster: bump metrics to 0.13.0

Bump metrics to 0.13.0 to test panels for event loop metrics.
See metrics CHANGELOG [1] for other updates.

1. https://github.com/tarantool/metrics/blob/master/CHANGELOG.md

### dashboard: add event loop panel
![image](https://user-images.githubusercontent.com/20455996/165713161-1d68f1c2-69f9-40c5-a0e5-d21b538100b0.png)

### alerts: add example warning for event loop time

Follows up #72
Closes #73