### PR TITLE
Lost & Found panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Event loop time panel and alert example
 - LuaJit statistics panels
 - Transactions memory panel
+- Net memory and new binary connections panels
 
 ### Changed
 - Rework "Tarantool memory memory miscellaneous" section to "Tarantool runtime overview"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - LuaJit statistics panels
 - Transactions memory panel
 - Net memory and new binary connections panels
+- Vinyl index and bloom filter memory panels
 
 ### Changed
 - Rework "Tarantool memory memory miscellaneous" section to "Tarantool runtime overview"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fiber stats panels and alert example
 - Event loop time panel and alert example
 - LuaJit statistics panels
+- Transactions memory panel
 
 ### Changed
 - Rework "Tarantool memory memory miscellaneous" section to "Tarantool runtime overview"

--- a/dashboard/panels/net.libsonnet
+++ b/dashboard/panels/net.libsonnet
@@ -3,6 +3,30 @@ local common = import 'common.libsonnet';
 {
   row:: common.row('Tarantool network activity'),
 
+  net_memory(
+    title='Net memory',
+    description=|||
+      Memory used for network input/output buffers.
+    |||,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+  ):: common.default_graph(
+    title=title,
+    description=description,
+    datasource=datasource,
+    format='bytes',
+    labelY1='in bytes',
+    panel_width=8,
+  ).addTarget(common.default_metric_target(
+    datasource,
+    'tnt_info_memory_net',
+    job,
+    policy,
+    measurement
+  )),
+
   local bytes_per_second_graph(
     title,
     description,
@@ -19,7 +43,7 @@ local common = import 'common.libsonnet';
     datasource=datasource,
     format='Bps',
     labelY1=labelY1,
-    panel_width=12,
+    panel_width=8,
   ).addTarget(common.default_rps_target(
     datasource,
     metric_name,
@@ -91,6 +115,7 @@ local common = import 'common.libsonnet';
     description=common.rate_warning(description, datasource),
     datasource=datasource,
     labelY1='requests per second',
+    panel_width=12,
   ).addTarget(common.default_rps_target(
     datasource,
     'tnt_net_requests_total',
@@ -116,6 +141,7 @@ local common = import 'common.libsonnet';
     decimals=0,
     labelY1='pending',
     min=0,
+    panel_width=12,
   ).addTarget(common.default_metric_target(
     datasource,
     'tnt_net_requests_current',
@@ -124,10 +150,35 @@ local common = import 'common.libsonnet';
     measurement
   )),
 
-  current_connections(
-    title='Binary protocol connections',
+  connections_per_second(
+    title='New binary connections',
     description=|||
-      Number of current active network connections.
+      Average number of new binary protocol connections per second.
+    |||,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+    rate_time_range=null,
+  ):: common.default_graph(
+    title=title,
+    description=description,
+    datasource=datasource,
+    labelY1='new per second',
+    panel_width=12,
+  ).addTarget(common.default_rps_target(
+    datasource,
+    'tnt_net_connections_total',
+    job,
+    rate_time_range,
+    policy,
+    measurement,
+  )),
+
+  current_connections(
+    title='Current binary connections',
+    description=|||
+      Number of current active binary protocol connections.
     |||,
     datasource=null,
     policy=null,
@@ -139,6 +190,7 @@ local common = import 'common.libsonnet';
     datasource=datasource,
     decimals=0,
     labelY1='current',
+    panel_width=12,
   ).addTarget(common.default_metric_target(
     datasource,
     'tnt_net_connections_current',

--- a/dashboard/panels/runtime.libsonnet
+++ b/dashboard/panels/runtime.libsonnet
@@ -19,10 +19,37 @@ local common = import 'common.libsonnet';
     datasource=datasource,
     format='bytes',
     labelY1='in bytes',
-    panel_width=24,
+    panel_width=12,
   ).addTarget(common.default_metric_target(
     datasource,
     'tnt_info_memory_lua',
+    job,
+    policy,
+    measurement
+  )),
+
+  memory_tx(
+    title='Transactions memory',
+    description=|||
+      Memory in use by active transactions.
+      For the vinyl storage engine, this is the total size of
+      all allocated objects (struct txv, struct vy_tx, struct vy_read_interval)
+      and tuples pinned for those objects. 
+    |||,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+  ):: common.default_graph(
+    title=title,
+    description=description,
+    datasource=datasource,
+    format='bytes',
+    labelY1='in bytes',
+    panel_width=12,
+  ).addTarget(common.default_metric_target(
+    datasource,
+    'tnt_info_memory_tx',
     job,
     policy,
     measurement

--- a/dashboard/panels/vinyl.libsonnet
+++ b/dashboard/panels/vinyl.libsonnet
@@ -73,6 +73,56 @@ local prometheus = grafana.prometheus;
     metric_name='tnt_vinyl_disk_index_size',
   ),
 
+  index_memory(
+    title='Index memory',
+    description=|||
+      Amount of memory in bytes currently used to store indexes.
+      If the metric value is close to box.cfg.vinyl_memory, this
+      indicates that vinyl_page_size was chosen incorrectly.
+    |||,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+  ):: common.default_graph(
+    title=title,
+    description=description,
+    datasource=datasource,
+    format='bytes',
+    labelY1='in bytes',
+    panel_width=12,
+  ).addTarget(common.default_metric_target(
+    datasource,
+    'tnt_vinyl_memory_page_index',
+    job,
+    policy,
+    measurement
+  )),
+
+  bloom_filter_memory(
+    title='Bloom filter memory',
+    description=|||
+      Amount of memory in bytes used by bloom filters.
+    |||,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+  ):: common.default_graph(
+    title=title,
+    description=description,
+    datasource=datasource,
+    format='bytes',
+    labelY1='in bytes',
+    panel_width=12,
+  ).addTarget(common.default_metric_target(
+    datasource,
+    'tnt_vinyl_memory_bloom_filter',
+    job,
+    policy,
+    measurement
+  )),
+
   local regulator_bps(
     title=null,
     description=null,

--- a/dashboard/section.libsonnet
+++ b/dashboard/section.libsonnet
@@ -321,6 +321,20 @@ local vinyl = import 'panels/vinyl.libsonnet';
       job=job,
     ),
 
+    vinyl.index_memory(
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+    ),
+
+    vinyl.bloom_filter_memory(
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+    ),
+
     vinyl.regulator_dump_bandwidth(
       datasource=datasource,
       policy=policy,

--- a/dashboard/section.libsonnet
+++ b/dashboard/section.libsonnet
@@ -142,6 +142,13 @@ local vinyl = import 'panels/vinyl.libsonnet';
   net(datasource, policy=null, measurement=null, job=null, rate_time_range=null):: [
     net.row,
 
+    net.net_memory(
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+    ),
+
     net.bytes_received_per_second(
       datasource=datasource,
       policy=policy,
@@ -171,6 +178,14 @@ local vinyl = import 'panels/vinyl.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+    ),
+
+    net.connections_per_second(
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+      rate_time_range=rate_time_range,
     ),
 
     net.current_connections(

--- a/dashboard/section.libsonnet
+++ b/dashboard/section.libsonnet
@@ -427,6 +427,13 @@ local vinyl = import 'panels/vinyl.libsonnet';
       job=job,
     ),
 
+    runtime.memory_tx(
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+    ),
+
     runtime.fiber_csw_rps(
       datasource=datasource,
       policy=policy,

--- a/tests/InfluxDB/dashboard_compiled.json
+++ b/tests/InfluxDB/dashboard_compiled.json
@@ -6326,7 +6326,7 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 24,
+                  "w": 12,
                   "x": 0,
                   "y": 137
                },
@@ -6453,6 +6453,137 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 3,
+               "description": "Memory in use by active transactions.\nFor the vinyl storage engine, this is the total size of\nall allocated objects (struct txv, struct vy_tx, struct vy_read_interval)\nand tuples pinned for those objects. \n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 137
+               },
+               "id": 56,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_info_memory_tx"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Transactions memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 3,
                "description": "Average rate of fiber context switches.\nContext switches are counted over all current fibers.\n",
                "fill": 0,
                "gridPos": {
@@ -6461,7 +6592,7 @@
                   "x": 0,
                   "y": 145
                },
-               "id": 56,
+               "id": 57,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6598,7 +6729,7 @@
                   "x": 12,
                   "y": 145
                },
-               "id": 57,
+               "id": 58,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6729,7 +6860,7 @@
                   "x": 0,
                   "y": 153
                },
-               "id": 58,
+               "id": 59,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6860,7 +6991,7 @@
                   "x": 8,
                   "y": 153
                },
-               "id": 59,
+               "id": 60,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6991,7 +7122,7 @@
                   "x": 16,
                   "y": 153
                },
-               "id": 60,
+               "id": 61,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7125,7 +7256,7 @@
             "x": 0,
             "y": 161
          },
-         "id": 61,
+         "id": 62,
          "panels": [
             {
                "aliasColors": { },
@@ -7142,7 +7273,7 @@
                   "x": 0,
                   "y": 162
                },
-               "id": 62,
+               "id": 63,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7279,7 +7410,7 @@
                   "x": 6,
                   "y": 162
                },
-               "id": 63,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7416,7 +7547,7 @@
                   "x": 12,
                   "y": 162
                },
-               "id": 64,
+               "id": 65,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7553,7 +7684,7 @@
                   "x": 18,
                   "y": 162
                },
-               "id": 65,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7684,7 +7815,7 @@
                   "x": 0,
                   "y": 170
                },
-               "id": 66,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7821,7 +7952,7 @@
                   "x": 12,
                   "y": 170
                },
-               "id": 67,
+               "id": 68,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7958,7 +8089,7 @@
                   "x": 0,
                   "y": 178
                },
-               "id": 68,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8095,7 +8226,7 @@
                   "x": 8,
                   "y": 178
                },
-               "id": 69,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8232,7 +8363,7 @@
                   "x": 16,
                   "y": 178
                },
-               "id": 70,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8369,7 +8500,7 @@
                   "x": 0,
                   "y": 186
                },
-               "id": 71,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8506,7 +8637,7 @@
                   "x": 8,
                   "y": 186
                },
-               "id": 72,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8643,7 +8774,7 @@
                   "x": 16,
                   "y": 186
                },
-               "id": 73,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8780,7 +8911,7 @@
                   "x": 0,
                   "y": 194
                },
-               "id": 74,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8911,7 +9042,7 @@
                   "x": 6,
                   "y": 194
                },
-               "id": 75,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9042,7 +9173,7 @@
                   "x": 12,
                   "y": 194
                },
-               "id": 76,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9173,7 +9304,7 @@
                   "x": 18,
                   "y": 194
                },
-               "id": 77,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9304,7 +9435,7 @@
                   "x": 0,
                   "y": 202
                },
-               "id": 78,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9435,7 +9566,7 @@
                   "x": 8,
                   "y": 202
                },
-               "id": 79,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9572,7 +9703,7 @@
                   "x": 16,
                   "y": 202
                },
-               "id": 80,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9712,7 +9843,7 @@
             "x": 0,
             "y": 210
          },
-         "id": 81,
+         "id": 82,
          "panels": [
             {
                "aliasColors": { },
@@ -9729,7 +9860,7 @@
                   "x": 0,
                   "y": 211
                },
-               "id": 82,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9872,7 +10003,7 @@
                   "x": 8,
                   "y": 211
                },
-               "id": 83,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10015,7 +10146,7 @@
                   "x": 16,
                   "y": 211
                },
-               "id": 84,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10158,7 +10289,7 @@
                   "x": 0,
                   "y": 219
                },
-               "id": 85,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10301,7 +10432,7 @@
                   "x": 8,
                   "y": 219
                },
-               "id": 86,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10444,7 +10575,7 @@
                   "x": 16,
                   "y": 219
                },
-               "id": 87,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10587,7 +10718,7 @@
                   "x": 0,
                   "y": 227
                },
-               "id": 88,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10730,7 +10861,7 @@
                   "x": 8,
                   "y": 227
                },
-               "id": 89,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10873,7 +11004,7 @@
                   "x": 16,
                   "y": 227
                },
-               "id": 90,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11016,7 +11147,7 @@
                   "x": 0,
                   "y": 235
                },
-               "id": 91,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11159,7 +11290,7 @@
                   "x": 8,
                   "y": 235
                },
-               "id": 92,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11302,7 +11433,7 @@
                   "x": 16,
                   "y": 235
                },
-               "id": 93,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/InfluxDB/dashboard_compiled.json
+++ b/tests/InfluxDB/dashboard_compiled.json
@@ -4656,15 +4656,277 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 3,
+               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 111
+               },
+               "id": 41,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_memory_page_index"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Index memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 3,
+               "description": "Amount of memory in bytes used by bloom filters.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 111
+               },
+               "id": 42,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_memory_bloom_filter"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Bloom filter memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 3,
                "description": "The estimated average rate of taking dumps, bytes per second.\nInitially, the rate value is 10 megabytes per second\nand being recalculated depending on the the actual rate.\nOnly significant dumps that are larger than one megabyte\nare used for the estimate.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 111
+                  "y": 119
                },
-               "id": 41,
+               "id": 43,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4793,9 +5055,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 111
+                  "y": 119
                },
-               "id": 42,
+               "id": 44,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4924,9 +5186,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 111
+                  "y": 119
                },
-               "id": 43,
+               "id": 45,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5055,9 +5317,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 111
+                  "y": 119
                },
-               "id": 44,
+               "id": 46,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5186,9 +5448,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 119
+                  "y": 127
                },
-               "id": 45,
+               "id": 47,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5323,9 +5585,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 119
+                  "y": 127
                },
-               "id": 46,
+               "id": 48,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5460,9 +5722,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 119
+                  "y": 127
                },
-               "id": 47,
+               "id": 49,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5597,9 +5859,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 119
+                  "y": 127
                },
-               "id": 48,
+               "id": 50,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5728,9 +5990,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 127
+                  "y": 135
                },
-               "id": 49,
+               "id": 51,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5865,9 +6127,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 127
+                  "y": 135
                },
-               "id": 50,
+               "id": 52,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6008,9 +6270,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 127
+                  "y": 135
                },
-               "id": 51,
+               "id": 53,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6145,9 +6407,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 127
+                  "y": 135
                },
-               "id": 52,
+               "id": 54,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6285,9 +6547,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 135
+            "y": 143
          },
-         "id": 53,
+         "id": 55,
          "panels": [
             {
                "aliasColors": { },
@@ -6302,9 +6564,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 136
+                  "y": 144
                },
-               "id": 54,
+               "id": 56,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6439,9 +6701,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 136
+                  "y": 144
                },
-               "id": 55,
+               "id": 57,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6579,9 +6841,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 144
+            "y": 152
          },
-         "id": 56,
+         "id": 58,
          "panels": [
             {
                "aliasColors": { },
@@ -6596,9 +6858,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 145
+                  "y": 153
                },
-               "id": 57,
+               "id": 59,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6727,9 +6989,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 145
+                  "y": 153
                },
-               "id": 58,
+               "id": 60,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6858,9 +7120,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 153
+                  "y": 161
                },
-               "id": 59,
+               "id": 61,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6995,9 +7257,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 153
+                  "y": 161
                },
-               "id": 60,
+               "id": 62,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7126,9 +7388,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 161
+                  "y": 169
                },
-               "id": 61,
+               "id": 63,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -7257,9 +7519,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 161
+                  "y": 169
                },
-               "id": 62,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7388,9 +7650,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 161
+                  "y": 169
                },
-               "id": 63,
+               "id": 65,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7522,9 +7784,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 169
+            "y": 177
          },
-         "id": 64,
+         "id": 66,
          "panels": [
             {
                "aliasColors": { },
@@ -7539,9 +7801,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 170
+                  "y": 178
                },
-               "id": 65,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7676,9 +7938,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 170
+                  "y": 178
                },
-               "id": 66,
+               "id": 68,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7813,9 +8075,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 170
+                  "y": 178
                },
-               "id": 67,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7950,9 +8212,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 170
+                  "y": 178
                },
-               "id": 68,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8081,9 +8343,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 178
+                  "y": 186
                },
-               "id": 69,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8218,9 +8480,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 178
+                  "y": 186
                },
-               "id": 70,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8355,9 +8617,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 186
+                  "y": 194
                },
-               "id": 71,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8492,9 +8754,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 186
+                  "y": 194
                },
-               "id": 72,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8629,9 +8891,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 186
+                  "y": 194
                },
-               "id": 73,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8766,9 +9028,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 194
+                  "y": 202
                },
-               "id": 74,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8903,9 +9165,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 194
+                  "y": 202
                },
-               "id": 75,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9040,9 +9302,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 194
+                  "y": 202
                },
-               "id": 76,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9177,9 +9439,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 202
+                  "y": 210
                },
-               "id": 77,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9308,9 +9570,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 202
+                  "y": 210
                },
-               "id": 78,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9439,9 +9701,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 202
+                  "y": 210
                },
-               "id": 79,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9570,9 +9832,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 202
+                  "y": 210
                },
-               "id": 80,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9701,9 +9963,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 210
+                  "y": 218
                },
-               "id": 81,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9832,9 +10094,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 210
+                  "y": 218
                },
-               "id": 82,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9969,9 +10231,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 210
+                  "y": 218
                },
-               "id": 83,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10109,9 +10371,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 218
+            "y": 226
          },
-         "id": 84,
+         "id": 86,
          "panels": [
             {
                "aliasColors": { },
@@ -10126,9 +10388,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 219
+                  "y": 227
                },
-               "id": 85,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10269,9 +10531,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 219
+                  "y": 227
                },
-               "id": 86,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10412,9 +10674,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 219
+                  "y": 227
                },
-               "id": 87,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10555,9 +10817,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 227
+                  "y": 235
                },
-               "id": 88,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10698,9 +10960,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 227
+                  "y": 235
                },
-               "id": 89,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10841,9 +11103,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 227
+                  "y": 235
                },
-               "id": 90,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10984,9 +11246,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 235
+                  "y": 243
                },
-               "id": 91,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11127,9 +11389,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 235
+                  "y": 243
                },
-               "id": 92,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11270,9 +11532,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 235
+                  "y": 243
                },
-               "id": 93,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11413,9 +11675,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 243
+                  "y": 251
                },
-               "id": 94,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11556,9 +11818,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 243
+                  "y": 251
                },
-               "id": 95,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11699,9 +11961,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 243
+                  "y": 251
                },
-               "id": 96,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/InfluxDB/dashboard_compiled.json
+++ b/tests/InfluxDB/dashboard_compiled.json
@@ -1485,15 +1485,146 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 3,
-               "description": "Data received by instance from binary protocol connections.\nGraph shows average bytes per second.\n",
+               "description": "Memory used for network input/output buffers.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 33
                },
                "id": 14,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_info_memory_net"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Net memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 3,
+               "description": "Data received by instance from binary protocol connections.\nGraph shows average bytes per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 33
+               },
+               "id": 15,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1626,11 +1757,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 33
                },
-               "id": 15,
+               "id": 16,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1763,11 +1894,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 8,
+                  "w": 12,
                   "x": 0,
                   "y": 41
                },
-               "id": 16,
+               "id": 17,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1900,11 +2031,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 8,
-                  "x": 8,
+                  "w": 12,
+                  "x": 12,
                   "y": 41
                },
-               "id": 17,
+               "id": 18,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -2026,16 +2157,153 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
-               "decimals": 0,
-               "description": "Number of current active network connections.\n",
+               "decimals": 3,
+               "description": "Average number of new binary protocol connections per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 8,
-                  "x": 16,
-                  "y": 41
+                  "w": 12,
+                  "x": 0,
+                  "y": 49
                },
-               "id": 18,
+               "id": 19,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_net_connections_total"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "New binary connections",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "new per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 0,
+               "description": "Number of current active binary protocol connections.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 49
+               },
+               "id": 20,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -2116,7 +2384,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Binary protocol connections",
+               "title": "Current binary connections",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -2167,9 +2435,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 49
+            "y": 57
          },
-         "id": 19,
+         "id": 21,
          "panels": [
             {
                "content": "`quota_used_ratio` > 90%, `arena_used_ratio` > 90%, 50% < `items_used_ratio` < 90% – your memory is highly fragmented. See [docs](https://www.tarantool.io/en/doc/1.10/reference/reference_lua/box_slab/#lua-function.box.slab.info) for more info.\n\n`quota_used_ratio` > 90%, `arena_used_ratio` > 90%, `items_used_ratio` > 90% – you are running out of memory. You should consider increasing Tarantool’s memory limit (*box.cfg.memtx_memory*).\n",
@@ -2178,9 +2446,9 @@
                   "h": 3,
                   "w": 24,
                   "x": 0,
-                  "y": 50
+                  "y": 58
                },
-               "id": 20,
+               "id": 22,
                "mode": "markdown",
                "title": "Slab allocator monitoring information",
                "type": "text"
@@ -2198,9 +2466,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 53
+                  "y": 61
                },
-               "id": 21,
+               "id": 23,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2329,9 +2597,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 53
+                  "y": 61
                },
-               "id": 22,
+               "id": 24,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2460,9 +2728,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 53
+                  "y": 61
                },
-               "id": 23,
+               "id": 25,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2591,9 +2859,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 61
+                  "y": 69
                },
-               "id": 24,
+               "id": 26,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2722,9 +2990,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 61
+                  "y": 69
                },
-               "id": 25,
+               "id": 27,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2853,9 +3121,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 61
+                  "y": 69
                },
-               "id": 26,
+               "id": 28,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2984,9 +3252,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 69
+                  "y": 77
                },
-               "id": 27,
+               "id": 29,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3115,9 +3383,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 69
+                  "y": 77
                },
-               "id": 28,
+               "id": 30,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3246,9 +3514,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 69
+                  "y": 77
                },
-               "id": 29,
+               "id": 31,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3380,9 +3648,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 77
+            "y": 85
          },
-         "id": 30,
+         "id": 32,
          "panels": [
             {
                "aliasColors": { },
@@ -3397,9 +3665,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 78
+                  "y": 86
                },
-               "id": 31,
+               "id": 33,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3540,9 +3808,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 78
+                  "y": 86
                },
-               "id": 32,
+               "id": 34,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3683,9 +3951,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 86
+                  "y": 94
                },
-               "id": 33,
+               "id": 35,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3826,9 +4094,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 86
+                  "y": 94
                },
-               "id": 34,
+               "id": 36,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3969,9 +4237,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 86
+                  "y": 94
                },
-               "id": 35,
+               "id": 37,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4115,9 +4383,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 94
+            "y": 102
          },
-         "id": 36,
+         "id": 38,
          "panels": [
             {
                "aliasColors": { },
@@ -4132,9 +4400,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 95
+                  "y": 103
                },
-               "id": 37,
+               "id": 39,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4263,9 +4531,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 95
+                  "y": 103
                },
-               "id": 38,
+               "id": 40,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4394,9 +4662,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 103
+                  "y": 111
                },
-               "id": 39,
+               "id": 41,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4525,9 +4793,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 103
+                  "y": 111
                },
-               "id": 40,
+               "id": 42,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4656,9 +4924,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 103
+                  "y": 111
                },
-               "id": 41,
+               "id": 43,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4787,9 +5055,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 103
+                  "y": 111
                },
-               "id": 42,
+               "id": 44,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4918,9 +5186,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 111
+                  "y": 119
                },
-               "id": 43,
+               "id": 45,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5055,9 +5323,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 111
+                  "y": 119
                },
-               "id": 44,
+               "id": 46,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5192,9 +5460,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 111
+                  "y": 119
                },
-               "id": 45,
+               "id": 47,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5329,9 +5597,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 111
+                  "y": 119
                },
-               "id": 46,
+               "id": 48,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5460,9 +5728,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 119
+                  "y": 127
                },
-               "id": 47,
+               "id": 49,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5597,9 +5865,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 119
+                  "y": 127
                },
-               "id": 48,
+               "id": 50,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5740,9 +6008,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 119
+                  "y": 127
                },
-               "id": 49,
+               "id": 51,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5877,9 +6145,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 119
+                  "y": 127
                },
-               "id": 50,
+               "id": 52,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6017,9 +6285,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 127
+            "y": 135
          },
-         "id": 51,
+         "id": 53,
          "panels": [
             {
                "aliasColors": { },
@@ -6034,9 +6302,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 128
+                  "y": 136
                },
-               "id": 52,
+               "id": 54,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6171,9 +6439,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 128
+                  "y": 136
                },
-               "id": 53,
+               "id": 55,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6311,9 +6579,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 136
+            "y": 144
          },
-         "id": 54,
+         "id": 56,
          "panels": [
             {
                "aliasColors": { },
@@ -6328,9 +6596,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 137
+                  "y": 145
                },
-               "id": 55,
+               "id": 57,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6459,9 +6727,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 137
+                  "y": 145
                },
-               "id": 56,
+               "id": 58,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6590,9 +6858,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 145
+                  "y": 153
                },
-               "id": 57,
+               "id": 59,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6727,9 +6995,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 145
+                  "y": 153
                },
-               "id": 58,
+               "id": 60,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6858,9 +7126,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 153
+                  "y": 161
                },
-               "id": 59,
+               "id": 61,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6989,9 +7257,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 153
+                  "y": 161
                },
-               "id": 60,
+               "id": 62,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7120,9 +7388,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 153
+                  "y": 161
                },
-               "id": 61,
+               "id": 63,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7254,9 +7522,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 161
+            "y": 169
          },
-         "id": 62,
+         "id": 64,
          "panels": [
             {
                "aliasColors": { },
@@ -7271,9 +7539,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 162
+                  "y": 170
                },
-               "id": 63,
+               "id": 65,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7408,9 +7676,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 162
+                  "y": 170
                },
-               "id": 64,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7545,9 +7813,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 162
+                  "y": 170
                },
-               "id": 65,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7682,9 +7950,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 162
+                  "y": 170
                },
-               "id": 66,
+               "id": 68,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7813,9 +8081,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 170
+                  "y": 178
                },
-               "id": 67,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7950,9 +8218,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 170
+                  "y": 178
                },
-               "id": 68,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8087,9 +8355,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 178
+                  "y": 186
                },
-               "id": 69,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8224,9 +8492,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 178
+                  "y": 186
                },
-               "id": 70,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8361,9 +8629,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 178
+                  "y": 186
                },
-               "id": 71,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8498,9 +8766,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 186
+                  "y": 194
                },
-               "id": 72,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8635,9 +8903,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 186
+                  "y": 194
                },
-               "id": 73,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8772,9 +9040,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 186
+                  "y": 194
                },
-               "id": 74,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8909,9 +9177,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 194
+                  "y": 202
                },
-               "id": 75,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9040,9 +9308,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 194
+                  "y": 202
                },
-               "id": 76,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9171,9 +9439,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 194
+                  "y": 202
                },
-               "id": 77,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9302,9 +9570,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 194
+                  "y": 202
                },
-               "id": 78,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9433,9 +9701,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 202
+                  "y": 210
                },
-               "id": 79,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9564,9 +9832,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 202
+                  "y": 210
                },
-               "id": 80,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9701,9 +9969,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 202
+                  "y": 210
                },
-               "id": 81,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9841,9 +10109,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 210
+            "y": 218
          },
-         "id": 82,
+         "id": 84,
          "panels": [
             {
                "aliasColors": { },
@@ -9858,9 +10126,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 211
+                  "y": 219
                },
-               "id": 83,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10001,9 +10269,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 211
+                  "y": 219
                },
-               "id": 84,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10144,9 +10412,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 211
+                  "y": 219
                },
-               "id": 85,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10287,9 +10555,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 219
+                  "y": 227
                },
-               "id": 86,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10430,9 +10698,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 219
+                  "y": 227
                },
-               "id": 87,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10573,9 +10841,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 219
+                  "y": 227
                },
-               "id": 88,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10716,9 +10984,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 227
+                  "y": 235
                },
-               "id": 89,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10859,9 +11127,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 227
+                  "y": 235
                },
-               "id": 90,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11002,9 +11270,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 227
+                  "y": 235
                },
-               "id": 91,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11145,9 +11413,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 235
+                  "y": 243
                },
-               "id": 92,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11288,9 +11556,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 235
+                  "y": 243
                },
-               "id": 93,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11431,9 +11699,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 235
+                  "y": 243
                },
-               "id": 94,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
+++ b/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
@@ -1485,15 +1485,146 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 3,
-               "description": "Data received by instance from binary protocol connections.\nGraph shows average bytes per second.\n",
+               "description": "Memory used for network input/output buffers.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 33
                },
                "id": 14,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_info_memory_net"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Net memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 3,
+               "description": "Data received by instance from binary protocol connections.\nGraph shows average bytes per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 33
+               },
+               "id": 15,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1626,11 +1757,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 33
                },
-               "id": 15,
+               "id": 16,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1763,11 +1894,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 8,
+                  "w": 12,
                   "x": 0,
                   "y": 41
                },
-               "id": 16,
+               "id": 17,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1900,11 +2031,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 8,
-                  "x": 8,
+                  "w": 12,
+                  "x": 12,
                   "y": 41
                },
-               "id": 17,
+               "id": 18,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -2026,16 +2157,153 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
-               "decimals": 0,
-               "description": "Number of current active network connections.\n",
+               "decimals": 3,
+               "description": "Average number of new binary protocol connections per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 8,
-                  "x": 16,
-                  "y": 41
+                  "w": 12,
+                  "x": 0,
+                  "y": 49
                },
-               "id": 18,
+               "id": 19,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_net_connections_total"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "New binary connections",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "new per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 0,
+               "description": "Number of current active binary protocol connections.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 49
+               },
+               "id": 20,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -2116,7 +2384,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Binary protocol connections",
+               "title": "Current binary connections",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -2167,9 +2435,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 49
+            "y": 57
          },
-         "id": 19,
+         "id": 21,
          "panels": [
             {
                "content": "`quota_used_ratio` > 90%, `arena_used_ratio` > 90%, 50% < `items_used_ratio` < 90% – your memory is highly fragmented. See [docs](https://www.tarantool.io/en/doc/1.10/reference/reference_lua/box_slab/#lua-function.box.slab.info) for more info.\n\n`quota_used_ratio` > 90%, `arena_used_ratio` > 90%, `items_used_ratio` > 90% – you are running out of memory. You should consider increasing Tarantool’s memory limit (*box.cfg.memtx_memory*).\n",
@@ -2178,9 +2446,9 @@
                   "h": 3,
                   "w": 24,
                   "x": 0,
-                  "y": 50
+                  "y": 58
                },
-               "id": 20,
+               "id": 22,
                "mode": "markdown",
                "title": "Slab allocator monitoring information",
                "type": "text"
@@ -2198,9 +2466,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 53
+                  "y": 61
                },
-               "id": 21,
+               "id": 23,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2329,9 +2597,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 53
+                  "y": 61
                },
-               "id": 22,
+               "id": 24,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2460,9 +2728,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 53
+                  "y": 61
                },
-               "id": 23,
+               "id": 25,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2591,9 +2859,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 61
+                  "y": 69
                },
-               "id": 24,
+               "id": 26,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2722,9 +2990,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 61
+                  "y": 69
                },
-               "id": 25,
+               "id": 27,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2853,9 +3121,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 61
+                  "y": 69
                },
-               "id": 26,
+               "id": 28,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2984,9 +3252,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 69
+                  "y": 77
                },
-               "id": 27,
+               "id": 29,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3115,9 +3383,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 69
+                  "y": 77
                },
-               "id": 28,
+               "id": 30,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3246,9 +3514,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 69
+                  "y": 77
                },
-               "id": 29,
+               "id": 31,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3380,9 +3648,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 77
+            "y": 85
          },
-         "id": 30,
+         "id": 32,
          "panels": [
             {
                "aliasColors": { },
@@ -3397,9 +3665,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 78
+                  "y": 86
                },
-               "id": 31,
+               "id": 33,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3540,9 +3808,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 78
+                  "y": 86
                },
-               "id": 32,
+               "id": 34,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3683,9 +3951,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 86
+                  "y": 94
                },
-               "id": 33,
+               "id": 35,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3826,9 +4094,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 86
+                  "y": 94
                },
-               "id": 34,
+               "id": 36,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3969,9 +4237,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 86
+                  "y": 94
                },
-               "id": 35,
+               "id": 37,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4115,9 +4383,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 94
+            "y": 102
          },
-         "id": 36,
+         "id": 38,
          "panels": [
             {
                "aliasColors": { },
@@ -4132,9 +4400,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 95
+                  "y": 103
                },
-               "id": 37,
+               "id": 39,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4263,9 +4531,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 95
+                  "y": 103
                },
-               "id": 38,
+               "id": 40,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4394,9 +4662,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 103
+                  "y": 111
                },
-               "id": 39,
+               "id": 41,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4525,9 +4793,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 103
+                  "y": 111
                },
-               "id": 40,
+               "id": 42,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4656,9 +4924,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 103
+                  "y": 111
                },
-               "id": 41,
+               "id": 43,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4787,9 +5055,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 103
+                  "y": 111
                },
-               "id": 42,
+               "id": 44,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4918,9 +5186,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 111
+                  "y": 119
                },
-               "id": 43,
+               "id": 45,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5055,9 +5323,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 111
+                  "y": 119
                },
-               "id": 44,
+               "id": 46,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5192,9 +5460,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 111
+                  "y": 119
                },
-               "id": 45,
+               "id": 47,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5329,9 +5597,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 111
+                  "y": 119
                },
-               "id": 46,
+               "id": 48,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5460,9 +5728,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 119
+                  "y": 127
                },
-               "id": 47,
+               "id": 49,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5597,9 +5865,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 119
+                  "y": 127
                },
-               "id": 48,
+               "id": 50,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5740,9 +6008,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 119
+                  "y": 127
                },
-               "id": 49,
+               "id": 51,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5877,9 +6145,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 119
+                  "y": 127
                },
-               "id": 50,
+               "id": 52,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6017,9 +6285,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 127
+            "y": 135
          },
-         "id": 51,
+         "id": 53,
          "panels": [
             {
                "aliasColors": { },
@@ -6034,9 +6302,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 128
+                  "y": 136
                },
-               "id": 52,
+               "id": 54,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6171,9 +6439,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 128
+                  "y": 136
                },
-               "id": 53,
+               "id": 55,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6311,9 +6579,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 136
+            "y": 144
          },
-         "id": 54,
+         "id": 56,
          "panels": [
             {
                "aliasColors": { },
@@ -6328,9 +6596,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 137
+                  "y": 145
                },
-               "id": 55,
+               "id": 57,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6459,9 +6727,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 137
+                  "y": 145
                },
-               "id": 56,
+               "id": 58,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6590,9 +6858,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 145
+                  "y": 153
                },
-               "id": 57,
+               "id": 59,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6727,9 +6995,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 145
+                  "y": 153
                },
-               "id": 58,
+               "id": 60,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6858,9 +7126,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 153
+                  "y": 161
                },
-               "id": 59,
+               "id": 61,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6989,9 +7257,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 153
+                  "y": 161
                },
-               "id": 60,
+               "id": 62,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7120,9 +7388,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 153
+                  "y": 161
                },
-               "id": 61,
+               "id": 63,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7254,9 +7522,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 161
+            "y": 169
          },
-         "id": 62,
+         "id": 64,
          "panels": [
             {
                "aliasColors": { },
@@ -7271,9 +7539,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 162
+                  "y": 170
                },
-               "id": 63,
+               "id": 65,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7408,9 +7676,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 162
+                  "y": 170
                },
-               "id": 64,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7545,9 +7813,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 162
+                  "y": 170
                },
-               "id": 65,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7682,9 +7950,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 162
+                  "y": 170
                },
-               "id": 66,
+               "id": 68,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7813,9 +8081,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 170
+                  "y": 178
                },
-               "id": 67,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7950,9 +8218,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 170
+                  "y": 178
                },
-               "id": 68,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8087,9 +8355,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 178
+                  "y": 186
                },
-               "id": 69,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8224,9 +8492,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 178
+                  "y": 186
                },
-               "id": 70,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8361,9 +8629,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 178
+                  "y": 186
                },
-               "id": 71,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8498,9 +8766,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 186
+                  "y": 194
                },
-               "id": 72,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8635,9 +8903,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 186
+                  "y": 194
                },
-               "id": 73,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8772,9 +9040,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 186
+                  "y": 194
                },
-               "id": 74,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8909,9 +9177,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 194
+                  "y": 202
                },
-               "id": 75,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9040,9 +9308,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 194
+                  "y": 202
                },
-               "id": 76,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9171,9 +9439,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 194
+                  "y": 202
                },
-               "id": 77,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9302,9 +9570,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 194
+                  "y": 202
                },
-               "id": 78,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9433,9 +9701,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 202
+                  "y": 210
                },
-               "id": 79,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9564,9 +9832,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 202
+                  "y": 210
                },
-               "id": 80,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9701,9 +9969,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 202
+                  "y": 210
                },
-               "id": 81,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9841,9 +10109,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 210
+            "y": 218
          },
-         "id": 82,
+         "id": 84,
          "panels": [
             {
                "aliasColors": { },
@@ -9858,9 +10126,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 211
+                  "y": 219
                },
-               "id": 83,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10001,9 +10269,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 211
+                  "y": 219
                },
-               "id": 84,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10144,9 +10412,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 211
+                  "y": 219
                },
-               "id": 85,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10287,9 +10555,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 219
+                  "y": 227
                },
-               "id": 86,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10430,9 +10698,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 219
+                  "y": 227
                },
-               "id": 87,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10573,9 +10841,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 219
+                  "y": 227
                },
-               "id": 88,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10716,9 +10984,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 227
+                  "y": 235
                },
-               "id": 89,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10859,9 +11127,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 227
+                  "y": 235
                },
-               "id": 90,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11002,9 +11270,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 227
+                  "y": 235
                },
-               "id": 91,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11145,9 +11413,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 235
+                  "y": 243
                },
-               "id": 92,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11288,9 +11556,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 235
+                  "y": 243
                },
-               "id": 93,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11431,9 +11699,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 235
+                  "y": 243
                },
-               "id": 94,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11577,9 +11845,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 243
+            "y": 251
          },
-         "id": 95,
+         "id": 97,
          "panels": [
             {
                "aliasColors": { },
@@ -11594,9 +11862,9 @@
                   "h": 6,
                   "w": 24,
                   "x": 0,
-                  "y": 244
+                  "y": 252
                },
-               "id": 96,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11725,9 +11993,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 250
+                  "y": 258
                },
-               "id": 97,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11862,9 +12130,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 250
+                  "y": 258
                },
-               "id": 98,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
+++ b/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
@@ -4656,15 +4656,277 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 3,
+               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 111
+               },
+               "id": 41,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_memory_page_index"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Index memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 3,
+               "description": "Amount of memory in bytes used by bloom filters.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 111
+               },
+               "id": 42,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_memory_bloom_filter"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Bloom filter memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 3,
                "description": "The estimated average rate of taking dumps, bytes per second.\nInitially, the rate value is 10 megabytes per second\nand being recalculated depending on the the actual rate.\nOnly significant dumps that are larger than one megabyte\nare used for the estimate.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 111
+                  "y": 119
                },
-               "id": 41,
+               "id": 43,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4793,9 +5055,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 111
+                  "y": 119
                },
-               "id": 42,
+               "id": 44,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4924,9 +5186,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 111
+                  "y": 119
                },
-               "id": 43,
+               "id": 45,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5055,9 +5317,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 111
+                  "y": 119
                },
-               "id": 44,
+               "id": 46,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5186,9 +5448,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 119
+                  "y": 127
                },
-               "id": 45,
+               "id": 47,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5323,9 +5585,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 119
+                  "y": 127
                },
-               "id": 46,
+               "id": 48,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5460,9 +5722,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 119
+                  "y": 127
                },
-               "id": 47,
+               "id": 49,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5597,9 +5859,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 119
+                  "y": 127
                },
-               "id": 48,
+               "id": 50,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5728,9 +5990,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 127
+                  "y": 135
                },
-               "id": 49,
+               "id": 51,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5865,9 +6127,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 127
+                  "y": 135
                },
-               "id": 50,
+               "id": 52,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6008,9 +6270,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 127
+                  "y": 135
                },
-               "id": 51,
+               "id": 53,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6145,9 +6407,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 127
+                  "y": 135
                },
-               "id": 52,
+               "id": 54,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6285,9 +6547,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 135
+            "y": 143
          },
-         "id": 53,
+         "id": 55,
          "panels": [
             {
                "aliasColors": { },
@@ -6302,9 +6564,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 136
+                  "y": 144
                },
-               "id": 54,
+               "id": 56,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6439,9 +6701,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 136
+                  "y": 144
                },
-               "id": 55,
+               "id": 57,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6579,9 +6841,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 144
+            "y": 152
          },
-         "id": 56,
+         "id": 58,
          "panels": [
             {
                "aliasColors": { },
@@ -6596,9 +6858,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 145
+                  "y": 153
                },
-               "id": 57,
+               "id": 59,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6727,9 +6989,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 145
+                  "y": 153
                },
-               "id": 58,
+               "id": 60,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6858,9 +7120,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 153
+                  "y": 161
                },
-               "id": 59,
+               "id": 61,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6995,9 +7257,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 153
+                  "y": 161
                },
-               "id": 60,
+               "id": 62,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7126,9 +7388,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 161
+                  "y": 169
                },
-               "id": 61,
+               "id": 63,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -7257,9 +7519,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 161
+                  "y": 169
                },
-               "id": 62,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7388,9 +7650,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 161
+                  "y": 169
                },
-               "id": 63,
+               "id": 65,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7522,9 +7784,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 169
+            "y": 177
          },
-         "id": 64,
+         "id": 66,
          "panels": [
             {
                "aliasColors": { },
@@ -7539,9 +7801,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 170
+                  "y": 178
                },
-               "id": 65,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7676,9 +7938,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 170
+                  "y": 178
                },
-               "id": 66,
+               "id": 68,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7813,9 +8075,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 170
+                  "y": 178
                },
-               "id": 67,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7950,9 +8212,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 170
+                  "y": 178
                },
-               "id": 68,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8081,9 +8343,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 178
+                  "y": 186
                },
-               "id": 69,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8218,9 +8480,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 178
+                  "y": 186
                },
-               "id": 70,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8355,9 +8617,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 186
+                  "y": 194
                },
-               "id": 71,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8492,9 +8754,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 186
+                  "y": 194
                },
-               "id": 72,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8629,9 +8891,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 186
+                  "y": 194
                },
-               "id": 73,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8766,9 +9028,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 194
+                  "y": 202
                },
-               "id": 74,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8903,9 +9165,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 194
+                  "y": 202
                },
-               "id": 75,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9040,9 +9302,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 194
+                  "y": 202
                },
-               "id": 76,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9177,9 +9439,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 202
+                  "y": 210
                },
-               "id": 77,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9308,9 +9570,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 202
+                  "y": 210
                },
-               "id": 78,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9439,9 +9701,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 202
+                  "y": 210
                },
-               "id": 79,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9570,9 +9832,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 202
+                  "y": 210
                },
-               "id": 80,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9701,9 +9963,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 210
+                  "y": 218
                },
-               "id": 81,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9832,9 +10094,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 210
+                  "y": 218
                },
-               "id": 82,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9969,9 +10231,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 210
+                  "y": 218
                },
-               "id": 83,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10109,9 +10371,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 218
+            "y": 226
          },
-         "id": 84,
+         "id": 86,
          "panels": [
             {
                "aliasColors": { },
@@ -10126,9 +10388,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 219
+                  "y": 227
                },
-               "id": 85,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10269,9 +10531,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 219
+                  "y": 227
                },
-               "id": 86,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10412,9 +10674,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 219
+                  "y": 227
                },
-               "id": 87,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10555,9 +10817,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 227
+                  "y": 235
                },
-               "id": 88,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10698,9 +10960,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 227
+                  "y": 235
                },
-               "id": 89,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10841,9 +11103,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 227
+                  "y": 235
                },
-               "id": 90,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10984,9 +11246,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 235
+                  "y": 243
                },
-               "id": 91,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11127,9 +11389,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 235
+                  "y": 243
                },
-               "id": 92,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11270,9 +11532,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 235
+                  "y": 243
                },
-               "id": 93,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11413,9 +11675,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 243
+                  "y": 251
                },
-               "id": 94,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11556,9 +11818,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 243
+                  "y": 251
                },
-               "id": 95,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11699,9 +11961,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 243
+                  "y": 251
                },
-               "id": 96,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11845,9 +12107,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 251
+            "y": 259
          },
-         "id": 97,
+         "id": 99,
          "panels": [
             {
                "aliasColors": { },
@@ -11862,9 +12124,9 @@
                   "h": 6,
                   "w": 24,
                   "x": 0,
-                  "y": 252
+                  "y": 260
                },
-               "id": 98,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11993,9 +12255,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 258
+                  "y": 266
                },
-               "id": 99,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12130,9 +12392,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 258
+                  "y": 266
                },
-               "id": 100,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
+++ b/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
@@ -6326,7 +6326,7 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 24,
+                  "w": 12,
                   "x": 0,
                   "y": 137
                },
@@ -6453,6 +6453,137 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 3,
+               "description": "Memory in use by active transactions.\nFor the vinyl storage engine, this is the total size of\nall allocated objects (struct txv, struct vy_tx, struct vy_read_interval)\nand tuples pinned for those objects. \n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 137
+               },
+               "id": 56,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_info_memory_tx"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Transactions memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 3,
                "description": "Average rate of fiber context switches.\nContext switches are counted over all current fibers.\n",
                "fill": 0,
                "gridPos": {
@@ -6461,7 +6592,7 @@
                   "x": 0,
                   "y": 145
                },
-               "id": 56,
+               "id": 57,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6598,7 +6729,7 @@
                   "x": 12,
                   "y": 145
                },
-               "id": 57,
+               "id": 58,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6729,7 +6860,7 @@
                   "x": 0,
                   "y": 153
                },
-               "id": 58,
+               "id": 59,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6860,7 +6991,7 @@
                   "x": 8,
                   "y": 153
                },
-               "id": 59,
+               "id": 60,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6991,7 +7122,7 @@
                   "x": 16,
                   "y": 153
                },
-               "id": 60,
+               "id": 61,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7125,7 +7256,7 @@
             "x": 0,
             "y": 161
          },
-         "id": 61,
+         "id": 62,
          "panels": [
             {
                "aliasColors": { },
@@ -7142,7 +7273,7 @@
                   "x": 0,
                   "y": 162
                },
-               "id": 62,
+               "id": 63,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7279,7 +7410,7 @@
                   "x": 6,
                   "y": 162
                },
-               "id": 63,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7416,7 +7547,7 @@
                   "x": 12,
                   "y": 162
                },
-               "id": 64,
+               "id": 65,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7553,7 +7684,7 @@
                   "x": 18,
                   "y": 162
                },
-               "id": 65,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7684,7 +7815,7 @@
                   "x": 0,
                   "y": 170
                },
-               "id": 66,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7821,7 +7952,7 @@
                   "x": 12,
                   "y": 170
                },
-               "id": 67,
+               "id": 68,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7958,7 +8089,7 @@
                   "x": 0,
                   "y": 178
                },
-               "id": 68,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8095,7 +8226,7 @@
                   "x": 8,
                   "y": 178
                },
-               "id": 69,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8232,7 +8363,7 @@
                   "x": 16,
                   "y": 178
                },
-               "id": 70,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8369,7 +8500,7 @@
                   "x": 0,
                   "y": 186
                },
-               "id": 71,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8506,7 +8637,7 @@
                   "x": 8,
                   "y": 186
                },
-               "id": 72,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8643,7 +8774,7 @@
                   "x": 16,
                   "y": 186
                },
-               "id": 73,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8780,7 +8911,7 @@
                   "x": 0,
                   "y": 194
                },
-               "id": 74,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8911,7 +9042,7 @@
                   "x": 6,
                   "y": 194
                },
-               "id": 75,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9042,7 +9173,7 @@
                   "x": 12,
                   "y": 194
                },
-               "id": 76,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9173,7 +9304,7 @@
                   "x": 18,
                   "y": 194
                },
-               "id": 77,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9304,7 +9435,7 @@
                   "x": 0,
                   "y": 202
                },
-               "id": 78,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9435,7 +9566,7 @@
                   "x": 8,
                   "y": 202
                },
-               "id": 79,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9572,7 +9703,7 @@
                   "x": 16,
                   "y": 202
                },
-               "id": 80,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9712,7 +9843,7 @@
             "x": 0,
             "y": 210
          },
-         "id": 81,
+         "id": 82,
          "panels": [
             {
                "aliasColors": { },
@@ -9729,7 +9860,7 @@
                   "x": 0,
                   "y": 211
                },
-               "id": 82,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9872,7 +10003,7 @@
                   "x": 8,
                   "y": 211
                },
-               "id": 83,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10015,7 +10146,7 @@
                   "x": 16,
                   "y": 211
                },
-               "id": 84,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10158,7 +10289,7 @@
                   "x": 0,
                   "y": 219
                },
-               "id": 85,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10301,7 +10432,7 @@
                   "x": 8,
                   "y": 219
                },
-               "id": 86,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10444,7 +10575,7 @@
                   "x": 16,
                   "y": 219
                },
-               "id": 87,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10587,7 +10718,7 @@
                   "x": 0,
                   "y": 227
                },
-               "id": 88,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10730,7 +10861,7 @@
                   "x": 8,
                   "y": 227
                },
-               "id": 89,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10873,7 +11004,7 @@
                   "x": 16,
                   "y": 227
                },
-               "id": 90,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11016,7 +11147,7 @@
                   "x": 0,
                   "y": 235
                },
-               "id": 91,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11159,7 +11290,7 @@
                   "x": 8,
                   "y": 235
                },
-               "id": 92,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11302,7 +11433,7 @@
                   "x": 16,
                   "y": 235
                },
-               "id": 93,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11448,7 +11579,7 @@
             "x": 0,
             "y": 243
          },
-         "id": 94,
+         "id": 95,
          "panels": [
             {
                "aliasColors": { },
@@ -11465,7 +11596,7 @@
                   "x": 0,
                   "y": 244
                },
-               "id": 95,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11596,7 +11727,7 @@
                   "x": 0,
                   "y": 250
                },
-               "id": 96,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11733,7 +11864,7 @@
                   "x": 12,
                   "y": 250
                },
-               "id": 97,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_compiled.json
+++ b/tests/Prometheus/dashboard_compiled.json
@@ -3485,15 +3485,195 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 3,
+               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 119
+               },
+               "id": 48,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_vinyl_memory_page_index{job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Index memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 3,
+               "description": "Amount of memory in bytes used by bloom filters.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 119
+               },
+               "id": 49,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_vinyl_memory_bloom_filter{job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Bloom filter memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 3,
                "description": "The estimated average rate of taking dumps, bytes per second.\nInitially, the rate value is 10 megabytes per second\nand being recalculated depending on the the actual rate.\nOnly significant dumps that are larger than one megabyte\nare used for the estimate.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 119
+                  "y": 127
                },
-               "id": 48,
+               "id": 50,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3581,9 +3761,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 119
+                  "y": 127
                },
-               "id": 49,
+               "id": 51,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3671,9 +3851,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 119
+                  "y": 127
                },
-               "id": 50,
+               "id": 52,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3761,9 +3941,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 119
+                  "y": 127
                },
-               "id": 51,
+               "id": 53,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3851,9 +4031,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 127
+                  "y": 135
                },
-               "id": 52,
+               "id": 54,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3941,9 +4121,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 127
+                  "y": 135
                },
-               "id": 53,
+               "id": 55,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4031,9 +4211,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 127
+                  "y": 135
                },
-               "id": 54,
+               "id": 56,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4121,9 +4301,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 127
+                  "y": 135
                },
-               "id": 55,
+               "id": 57,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4211,9 +4391,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 135
+                  "y": 143
                },
-               "id": 56,
+               "id": 58,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4301,9 +4481,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 135
+                  "y": 143
                },
-               "id": 57,
+               "id": 59,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4391,9 +4571,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 135
+                  "y": 143
                },
-               "id": 58,
+               "id": 60,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4481,9 +4661,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 135
+                  "y": 143
                },
-               "id": 59,
+               "id": 61,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4574,9 +4754,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 143
+            "y": 151
          },
-         "id": 60,
+         "id": 62,
          "panels": [
             {
                "aliasColors": { },
@@ -4591,9 +4771,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 144
+                  "y": 152
                },
-               "id": 61,
+               "id": 63,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4681,9 +4861,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 144
+                  "y": 152
                },
-               "id": 62,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4774,9 +4954,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 152
+            "y": 160
          },
-         "id": 63,
+         "id": 65,
          "panels": [
             {
                "aliasColors": { },
@@ -4791,9 +4971,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 153
+                  "y": 161
                },
-               "id": 64,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4881,9 +5061,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 153
+                  "y": 161
                },
-               "id": 65,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4971,9 +5151,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 161
+                  "y": 169
                },
-               "id": 66,
+               "id": 68,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5061,9 +5241,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 161
+                  "y": 169
                },
-               "id": 67,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5151,9 +5331,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 169
+                  "y": 177
                },
-               "id": 68,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5241,9 +5421,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 169
+                  "y": 177
                },
-               "id": 69,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5331,9 +5511,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 169
+                  "y": 177
                },
-               "id": 70,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5424,9 +5604,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 177
+            "y": 185
          },
-         "id": 71,
+         "id": 73,
          "panels": [
             {
                "aliasColors": { },
@@ -5441,9 +5621,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 178
+                  "y": 186
                },
-               "id": 72,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5531,9 +5711,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 178
+                  "y": 186
                },
-               "id": 73,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5621,9 +5801,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 178
+                  "y": 186
                },
-               "id": 74,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5711,9 +5891,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 178
+                  "y": 186
                },
-               "id": 75,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5801,9 +5981,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 186
+                  "y": 194
                },
-               "id": 76,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5891,9 +6071,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 186
+                  "y": 194
                },
-               "id": 77,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5981,9 +6161,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 194
+                  "y": 202
                },
-               "id": 78,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6071,9 +6251,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 194
+                  "y": 202
                },
-               "id": 79,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6161,9 +6341,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 194
+                  "y": 202
                },
-               "id": 80,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6251,9 +6431,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 202
+                  "y": 210
                },
-               "id": 81,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6341,9 +6521,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 202
+                  "y": 210
                },
-               "id": 82,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6431,9 +6611,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 202
+                  "y": 210
                },
-               "id": 83,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6521,9 +6701,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 210
+                  "y": 218
                },
-               "id": 84,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6611,9 +6791,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 210
+                  "y": 218
                },
-               "id": 85,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6701,9 +6881,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 210
+                  "y": 218
                },
-               "id": 86,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6791,9 +6971,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 210
+                  "y": 218
                },
-               "id": 87,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6881,9 +7061,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 218
+                  "y": 226
                },
-               "id": 88,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6971,9 +7151,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 218
+                  "y": 226
                },
-               "id": 89,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7061,9 +7241,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 218
+                  "y": 226
                },
-               "id": 90,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7154,9 +7334,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 226
+            "y": 234
          },
-         "id": 91,
+         "id": 93,
          "panels": [
             {
                "aliasColors": { },
@@ -7171,9 +7351,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 227
+                  "y": 235
                },
-               "id": 92,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7261,9 +7441,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 227
+                  "y": 235
                },
-               "id": 93,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7351,9 +7531,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 227
+                  "y": 235
                },
-               "id": 94,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7441,9 +7621,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 235
+                  "y": 243
                },
-               "id": 95,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7531,9 +7711,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 235
+                  "y": 243
                },
-               "id": 96,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7621,9 +7801,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 235
+                  "y": 243
                },
-               "id": 97,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7711,9 +7891,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 243
+                  "y": 251
                },
-               "id": 98,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7801,9 +7981,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 243
+                  "y": 251
                },
-               "id": 99,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7891,9 +8071,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 243
+                  "y": 251
                },
-               "id": 100,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7981,9 +8161,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 251
+                  "y": 259
                },
-               "id": 101,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8071,9 +8251,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 251
+                  "y": 259
                },
-               "id": 102,
+               "id": 104,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8161,9 +8341,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 251
+                  "y": 259
                },
-               "id": 103,
+               "id": 105,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_compiled.json
+++ b/tests/Prometheus/dashboard_compiled.json
@@ -4609,7 +4609,7 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 24,
+                  "w": 12,
                   "x": 0,
                   "y": 145
                },
@@ -4695,6 +4695,96 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 3,
+               "description": "Memory in use by active transactions.\nFor the vinyl storage engine, this is the total size of\nall allocated objects (struct txv, struct vy_tx, struct vy_read_interval)\nand tuples pinned for those objects. \n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 145
+               },
+               "id": 63,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_info_memory_tx{job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Transactions memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 3,
                "description": "Average rate of fiber context switches.\nContext switches are counted over all current fibers.\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
                "fill": 0,
                "gridPos": {
@@ -4703,7 +4793,7 @@
                   "x": 0,
                   "y": 153
                },
-               "id": 63,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4793,7 +4883,7 @@
                   "x": 12,
                   "y": 153
                },
-               "id": 64,
+               "id": 65,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4883,7 +4973,7 @@
                   "x": 0,
                   "y": 161
                },
-               "id": 65,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4973,7 +5063,7 @@
                   "x": 8,
                   "y": 161
                },
-               "id": 66,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5063,7 +5153,7 @@
                   "x": 16,
                   "y": 161
                },
-               "id": 67,
+               "id": 68,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5156,7 +5246,7 @@
             "x": 0,
             "y": 169
          },
-         "id": 68,
+         "id": 69,
          "panels": [
             {
                "aliasColors": { },
@@ -5173,7 +5263,7 @@
                   "x": 0,
                   "y": 170
                },
-               "id": 69,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5263,7 +5353,7 @@
                   "x": 6,
                   "y": 170
                },
-               "id": 70,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5353,7 +5443,7 @@
                   "x": 12,
                   "y": 170
                },
-               "id": 71,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5443,7 +5533,7 @@
                   "x": 18,
                   "y": 170
                },
-               "id": 72,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5533,7 +5623,7 @@
                   "x": 0,
                   "y": 178
                },
-               "id": 73,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5623,7 +5713,7 @@
                   "x": 12,
                   "y": 178
                },
-               "id": 74,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5713,7 +5803,7 @@
                   "x": 0,
                   "y": 186
                },
-               "id": 75,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5803,7 +5893,7 @@
                   "x": 8,
                   "y": 186
                },
-               "id": 76,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5893,7 +5983,7 @@
                   "x": 16,
                   "y": 186
                },
-               "id": 77,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5983,7 +6073,7 @@
                   "x": 0,
                   "y": 194
                },
-               "id": 78,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6073,7 +6163,7 @@
                   "x": 8,
                   "y": 194
                },
-               "id": 79,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6163,7 +6253,7 @@
                   "x": 16,
                   "y": 194
                },
-               "id": 80,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6253,7 +6343,7 @@
                   "x": 0,
                   "y": 202
                },
-               "id": 81,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6343,7 +6433,7 @@
                   "x": 6,
                   "y": 202
                },
-               "id": 82,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6433,7 +6523,7 @@
                   "x": 12,
                   "y": 202
                },
-               "id": 83,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6523,7 +6613,7 @@
                   "x": 18,
                   "y": 202
                },
-               "id": 84,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6613,7 +6703,7 @@
                   "x": 0,
                   "y": 210
                },
-               "id": 85,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6703,7 +6793,7 @@
                   "x": 8,
                   "y": 210
                },
-               "id": 86,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6793,7 +6883,7 @@
                   "x": 16,
                   "y": 210
                },
-               "id": 87,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6886,7 +6976,7 @@
             "x": 0,
             "y": 218
          },
-         "id": 88,
+         "id": 89,
          "panels": [
             {
                "aliasColors": { },
@@ -6903,7 +6993,7 @@
                   "x": 0,
                   "y": 219
                },
-               "id": 89,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6993,7 +7083,7 @@
                   "x": 8,
                   "y": 219
                },
-               "id": 90,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7083,7 +7173,7 @@
                   "x": 16,
                   "y": 219
                },
-               "id": 91,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7173,7 +7263,7 @@
                   "x": 0,
                   "y": 227
                },
-               "id": 92,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7263,7 +7353,7 @@
                   "x": 8,
                   "y": 227
                },
-               "id": 93,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7353,7 +7443,7 @@
                   "x": 16,
                   "y": 227
                },
-               "id": 94,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7443,7 +7533,7 @@
                   "x": 0,
                   "y": 235
                },
-               "id": 95,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7533,7 +7623,7 @@
                   "x": 8,
                   "y": 235
                },
-               "id": 96,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7623,7 +7713,7 @@
                   "x": 16,
                   "y": 235
                },
-               "id": 97,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7713,7 +7803,7 @@
                   "x": 0,
                   "y": 243
                },
-               "id": 98,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7803,7 +7893,7 @@
                   "x": 8,
                   "y": 243
                },
-               "id": 99,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7893,7 +7983,7 @@
                   "x": 16,
                   "y": 243
                },
-               "id": 100,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_compiled.json
+++ b/tests/Prometheus/dashboard_compiled.json
@@ -1341,15 +1341,105 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 3,
-               "description": "Data received by instance from binary protocol connections.\nGraph shows average bytes per second.\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
+               "description": "Memory used for network input/output buffers.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 41
                },
                "id": 21,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_info_memory_net{job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Net memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 3,
+               "description": "Data received by instance from binary protocol connections.\nGraph shows average bytes per second.\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 41
+               },
+               "id": 22,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1435,11 +1525,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 41
                },
-               "id": 22,
+               "id": 23,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1525,11 +1615,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 8,
+                  "w": 12,
                   "x": 0,
                   "y": 49
                },
-               "id": 23,
+               "id": 24,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1615,11 +1705,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 8,
-                  "x": 8,
+                  "w": 12,
+                  "x": 12,
                   "y": 49
                },
-               "id": 24,
+               "id": 25,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1700,16 +1790,106 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
-               "decimals": 0,
-               "description": "Number of current active network connections.\n",
+               "decimals": 3,
+               "description": "Average number of new binary protocol connections per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 8,
-                  "x": 16,
-                  "y": 49
+                  "w": 12,
+                  "x": 0,
+                  "y": 57
                },
-               "id": 25,
+               "id": 26,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tnt_net_connections_total{job=~\"$job\"}[$rate_time_range])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "New binary connections",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "new per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 0,
+               "description": "Number of current active binary protocol connections.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 57
+               },
+               "id": 27,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1749,7 +1929,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Binary protocol connections",
+               "title": "Current binary connections",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -1800,9 +1980,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 57
+            "y": 65
          },
-         "id": 26,
+         "id": 28,
          "panels": [
             {
                "content": "`quota_used_ratio` > 90%, `arena_used_ratio` > 90%, 50% < `items_used_ratio` < 90% – your memory is highly fragmented. See [docs](https://www.tarantool.io/en/doc/1.10/reference/reference_lua/box_slab/#lua-function.box.slab.info) for more info.\n\n`quota_used_ratio` > 90%, `arena_used_ratio` > 90%, `items_used_ratio` > 90% – you are running out of memory. You should consider increasing Tarantool’s memory limit (*box.cfg.memtx_memory*).\n",
@@ -1811,9 +1991,9 @@
                   "h": 3,
                   "w": 24,
                   "x": 0,
-                  "y": 58
+                  "y": 66
                },
-               "id": 27,
+               "id": 29,
                "mode": "markdown",
                "title": "Slab allocator monitoring information",
                "type": "text"
@@ -1831,9 +2011,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 61
+                  "y": 69
                },
-               "id": 28,
+               "id": 30,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -1921,9 +2101,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 61
+                  "y": 69
                },
-               "id": 29,
+               "id": 31,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2011,9 +2191,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 61
+                  "y": 69
                },
-               "id": 30,
+               "id": 32,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2101,9 +2281,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 69
+                  "y": 77
                },
-               "id": 31,
+               "id": 33,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2191,9 +2371,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 69
+                  "y": 77
                },
-               "id": 32,
+               "id": 34,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2281,9 +2461,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 69
+                  "y": 77
                },
-               "id": 33,
+               "id": 35,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2371,9 +2551,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 77
+                  "y": 85
                },
-               "id": 34,
+               "id": 36,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2461,9 +2641,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 77
+                  "y": 85
                },
-               "id": 35,
+               "id": 37,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2551,9 +2731,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 77
+                  "y": 85
                },
-               "id": 36,
+               "id": 38,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2644,9 +2824,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 85
+            "y": 93
          },
-         "id": 37,
+         "id": 39,
          "panels": [
             {
                "aliasColors": { },
@@ -2661,9 +2841,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 86
+                  "y": 94
                },
-               "id": 38,
+               "id": 40,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2751,9 +2931,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 86
+                  "y": 94
                },
-               "id": 39,
+               "id": 41,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2841,9 +3021,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 94
+                  "y": 102
                },
-               "id": 40,
+               "id": 42,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2931,9 +3111,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 94
+                  "y": 102
                },
-               "id": 41,
+               "id": 43,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3021,9 +3201,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 94
+                  "y": 102
                },
-               "id": 42,
+               "id": 44,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3114,9 +3294,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 102
+            "y": 110
          },
-         "id": 43,
+         "id": 45,
          "panels": [
             {
                "aliasColors": { },
@@ -3131,9 +3311,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 103
+                  "y": 111
                },
-               "id": 44,
+               "id": 46,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3221,9 +3401,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 103
+                  "y": 111
                },
-               "id": 45,
+               "id": 47,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3311,9 +3491,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 111
+                  "y": 119
                },
-               "id": 46,
+               "id": 48,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3401,9 +3581,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 111
+                  "y": 119
                },
-               "id": 47,
+               "id": 49,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3491,9 +3671,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 111
+                  "y": 119
                },
-               "id": 48,
+               "id": 50,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3581,9 +3761,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 111
+                  "y": 119
                },
-               "id": 49,
+               "id": 51,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3671,9 +3851,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 119
+                  "y": 127
                },
-               "id": 50,
+               "id": 52,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3761,9 +3941,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 119
+                  "y": 127
                },
-               "id": 51,
+               "id": 53,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3851,9 +4031,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 119
+                  "y": 127
                },
-               "id": 52,
+               "id": 54,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3941,9 +4121,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 119
+                  "y": 127
                },
-               "id": 53,
+               "id": 55,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4031,9 +4211,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 127
+                  "y": 135
                },
-               "id": 54,
+               "id": 56,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4121,9 +4301,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 127
+                  "y": 135
                },
-               "id": 55,
+               "id": 57,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4211,9 +4391,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 127
+                  "y": 135
                },
-               "id": 56,
+               "id": 58,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4301,9 +4481,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 127
+                  "y": 135
                },
-               "id": 57,
+               "id": 59,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4394,9 +4574,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 135
+            "y": 143
          },
-         "id": 58,
+         "id": 60,
          "panels": [
             {
                "aliasColors": { },
@@ -4411,9 +4591,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 136
+                  "y": 144
                },
-               "id": 59,
+               "id": 61,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4501,9 +4681,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 136
+                  "y": 144
                },
-               "id": 60,
+               "id": 62,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4594,9 +4774,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 144
+            "y": 152
          },
-         "id": 61,
+         "id": 63,
          "panels": [
             {
                "aliasColors": { },
@@ -4611,9 +4791,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 145
+                  "y": 153
                },
-               "id": 62,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4701,9 +4881,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 145
+                  "y": 153
                },
-               "id": 63,
+               "id": 65,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4791,9 +4971,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 153
+                  "y": 161
                },
-               "id": 64,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4881,9 +5061,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 153
+                  "y": 161
                },
-               "id": 65,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4971,9 +5151,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 161
+                  "y": 169
                },
-               "id": 66,
+               "id": 68,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5061,9 +5241,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 161
+                  "y": 169
                },
-               "id": 67,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5151,9 +5331,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 161
+                  "y": 169
                },
-               "id": 68,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5244,9 +5424,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 169
+            "y": 177
          },
-         "id": 69,
+         "id": 71,
          "panels": [
             {
                "aliasColors": { },
@@ -5261,9 +5441,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 170
+                  "y": 178
                },
-               "id": 70,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5351,9 +5531,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 170
+                  "y": 178
                },
-               "id": 71,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5441,9 +5621,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 170
+                  "y": 178
                },
-               "id": 72,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5531,9 +5711,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 170
+                  "y": 178
                },
-               "id": 73,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5621,9 +5801,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 178
+                  "y": 186
                },
-               "id": 74,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5711,9 +5891,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 178
+                  "y": 186
                },
-               "id": 75,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5801,9 +5981,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 186
+                  "y": 194
                },
-               "id": 76,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5891,9 +6071,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 186
+                  "y": 194
                },
-               "id": 77,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5981,9 +6161,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 186
+                  "y": 194
                },
-               "id": 78,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6071,9 +6251,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 194
+                  "y": 202
                },
-               "id": 79,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6161,9 +6341,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 194
+                  "y": 202
                },
-               "id": 80,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6251,9 +6431,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 194
+                  "y": 202
                },
-               "id": 81,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6341,9 +6521,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 202
+                  "y": 210
                },
-               "id": 82,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6431,9 +6611,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 202
+                  "y": 210
                },
-               "id": 83,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6521,9 +6701,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 202
+                  "y": 210
                },
-               "id": 84,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6611,9 +6791,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 202
+                  "y": 210
                },
-               "id": 85,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6701,9 +6881,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 210
+                  "y": 218
                },
-               "id": 86,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6791,9 +6971,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 210
+                  "y": 218
                },
-               "id": 87,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6881,9 +7061,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 210
+                  "y": 218
                },
-               "id": 88,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6974,9 +7154,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 218
+            "y": 226
          },
-         "id": 89,
+         "id": 91,
          "panels": [
             {
                "aliasColors": { },
@@ -6991,9 +7171,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 219
+                  "y": 227
                },
-               "id": 90,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7081,9 +7261,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 219
+                  "y": 227
                },
-               "id": 91,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7171,9 +7351,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 219
+                  "y": 227
                },
-               "id": 92,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7261,9 +7441,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 227
+                  "y": 235
                },
-               "id": 93,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7351,9 +7531,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 227
+                  "y": 235
                },
-               "id": 94,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7441,9 +7621,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 227
+                  "y": 235
                },
-               "id": 95,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7531,9 +7711,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 235
+                  "y": 243
                },
-               "id": 96,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7621,9 +7801,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 235
+                  "y": 243
                },
-               "id": 97,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7711,9 +7891,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 235
+                  "y": 243
                },
-               "id": 98,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7801,9 +7981,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 243
+                  "y": 251
                },
-               "id": 99,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7891,9 +8071,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 243
+                  "y": 251
                },
-               "id": 100,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7981,9 +8161,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 243
+                  "y": 251
                },
-               "id": 101,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_with_custom_panels_compiled.json
+++ b/tests/Prometheus/dashboard_with_custom_panels_compiled.json
@@ -4609,7 +4609,7 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 24,
+                  "w": 12,
                   "x": 0,
                   "y": 145
                },
@@ -4695,6 +4695,96 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 3,
+               "description": "Memory in use by active transactions.\nFor the vinyl storage engine, this is the total size of\nall allocated objects (struct txv, struct vy_tx, struct vy_read_interval)\nand tuples pinned for those objects. \n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 145
+               },
+               "id": 63,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_info_memory_tx{job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Transactions memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 3,
                "description": "Average rate of fiber context switches.\nContext switches are counted over all current fibers.\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
                "fill": 0,
                "gridPos": {
@@ -4703,7 +4793,7 @@
                   "x": 0,
                   "y": 153
                },
-               "id": 63,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4793,7 +4883,7 @@
                   "x": 12,
                   "y": 153
                },
-               "id": 64,
+               "id": 65,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4883,7 +4973,7 @@
                   "x": 0,
                   "y": 161
                },
-               "id": 65,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4973,7 +5063,7 @@
                   "x": 8,
                   "y": 161
                },
-               "id": 66,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5063,7 +5153,7 @@
                   "x": 16,
                   "y": 161
                },
-               "id": 67,
+               "id": 68,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5156,7 +5246,7 @@
             "x": 0,
             "y": 169
          },
-         "id": 68,
+         "id": 69,
          "panels": [
             {
                "aliasColors": { },
@@ -5173,7 +5263,7 @@
                   "x": 0,
                   "y": 170
                },
-               "id": 69,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5263,7 +5353,7 @@
                   "x": 6,
                   "y": 170
                },
-               "id": 70,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5353,7 +5443,7 @@
                   "x": 12,
                   "y": 170
                },
-               "id": 71,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5443,7 +5533,7 @@
                   "x": 18,
                   "y": 170
                },
-               "id": 72,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5533,7 +5623,7 @@
                   "x": 0,
                   "y": 178
                },
-               "id": 73,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5623,7 +5713,7 @@
                   "x": 12,
                   "y": 178
                },
-               "id": 74,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5713,7 +5803,7 @@
                   "x": 0,
                   "y": 186
                },
-               "id": 75,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5803,7 +5893,7 @@
                   "x": 8,
                   "y": 186
                },
-               "id": 76,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5893,7 +5983,7 @@
                   "x": 16,
                   "y": 186
                },
-               "id": 77,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5983,7 +6073,7 @@
                   "x": 0,
                   "y": 194
                },
-               "id": 78,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6073,7 +6163,7 @@
                   "x": 8,
                   "y": 194
                },
-               "id": 79,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6163,7 +6253,7 @@
                   "x": 16,
                   "y": 194
                },
-               "id": 80,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6253,7 +6343,7 @@
                   "x": 0,
                   "y": 202
                },
-               "id": 81,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6343,7 +6433,7 @@
                   "x": 6,
                   "y": 202
                },
-               "id": 82,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6433,7 +6523,7 @@
                   "x": 12,
                   "y": 202
                },
-               "id": 83,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6523,7 +6613,7 @@
                   "x": 18,
                   "y": 202
                },
-               "id": 84,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6613,7 +6703,7 @@
                   "x": 0,
                   "y": 210
                },
-               "id": 85,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6703,7 +6793,7 @@
                   "x": 8,
                   "y": 210
                },
-               "id": 86,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6793,7 +6883,7 @@
                   "x": 16,
                   "y": 210
                },
-               "id": 87,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6886,7 +6976,7 @@
             "x": 0,
             "y": 218
          },
-         "id": 88,
+         "id": 89,
          "panels": [
             {
                "aliasColors": { },
@@ -6903,7 +6993,7 @@
                   "x": 0,
                   "y": 219
                },
-               "id": 89,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6993,7 +7083,7 @@
                   "x": 8,
                   "y": 219
                },
-               "id": 90,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7083,7 +7173,7 @@
                   "x": 16,
                   "y": 219
                },
-               "id": 91,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7173,7 +7263,7 @@
                   "x": 0,
                   "y": 227
                },
-               "id": 92,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7263,7 +7353,7 @@
                   "x": 8,
                   "y": 227
                },
-               "id": 93,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7353,7 +7443,7 @@
                   "x": 16,
                   "y": 227
                },
-               "id": 94,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7443,7 +7533,7 @@
                   "x": 0,
                   "y": 235
                },
-               "id": 95,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7533,7 +7623,7 @@
                   "x": 8,
                   "y": 235
                },
-               "id": 96,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7623,7 +7713,7 @@
                   "x": 16,
                   "y": 235
                },
-               "id": 97,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7713,7 +7803,7 @@
                   "x": 0,
                   "y": 243
                },
-               "id": 98,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7803,7 +7893,7 @@
                   "x": 8,
                   "y": 243
                },
-               "id": 99,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7893,7 +7983,7 @@
                   "x": 16,
                   "y": 243
                },
-               "id": 100,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7986,7 +8076,7 @@
             "x": 0,
             "y": 251
          },
-         "id": 101,
+         "id": 102,
          "panels": [
             {
                "aliasColors": { },
@@ -8003,7 +8093,7 @@
                   "x": 0,
                   "y": 252
                },
-               "id": 102,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8093,7 +8183,7 @@
                   "x": 0,
                   "y": 258
                },
-               "id": 103,
+               "id": 104,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8183,7 +8273,7 @@
                   "x": 12,
                   "y": 258
                },
-               "id": 104,
+               "id": 105,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_with_custom_panels_compiled.json
+++ b/tests/Prometheus/dashboard_with_custom_panels_compiled.json
@@ -1341,15 +1341,105 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 3,
-               "description": "Data received by instance from binary protocol connections.\nGraph shows average bytes per second.\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
+               "description": "Memory used for network input/output buffers.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 41
                },
                "id": 21,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_info_memory_net{job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Net memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 3,
+               "description": "Data received by instance from binary protocol connections.\nGraph shows average bytes per second.\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 41
+               },
+               "id": 22,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1435,11 +1525,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 41
                },
-               "id": 22,
+               "id": 23,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1525,11 +1615,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 8,
+                  "w": 12,
                   "x": 0,
                   "y": 49
                },
-               "id": 23,
+               "id": 24,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1615,11 +1705,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 8,
-                  "x": 8,
+                  "w": 12,
+                  "x": 12,
                   "y": 49
                },
-               "id": 24,
+               "id": 25,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1700,16 +1790,106 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
-               "decimals": 0,
-               "description": "Number of current active network connections.\n",
+               "decimals": 3,
+               "description": "Average number of new binary protocol connections per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 8,
-                  "x": 16,
-                  "y": 49
+                  "w": 12,
+                  "x": 0,
+                  "y": 57
                },
-               "id": 25,
+               "id": 26,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tnt_net_connections_total{job=~\"$job\"}[$rate_time_range])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "New binary connections",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "new per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 0,
+               "description": "Number of current active binary protocol connections.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 57
+               },
+               "id": 27,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1749,7 +1929,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Binary protocol connections",
+               "title": "Current binary connections",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -1800,9 +1980,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 57
+            "y": 65
          },
-         "id": 26,
+         "id": 28,
          "panels": [
             {
                "content": "`quota_used_ratio` > 90%, `arena_used_ratio` > 90%, 50% < `items_used_ratio` < 90% – your memory is highly fragmented. See [docs](https://www.tarantool.io/en/doc/1.10/reference/reference_lua/box_slab/#lua-function.box.slab.info) for more info.\n\n`quota_used_ratio` > 90%, `arena_used_ratio` > 90%, `items_used_ratio` > 90% – you are running out of memory. You should consider increasing Tarantool’s memory limit (*box.cfg.memtx_memory*).\n",
@@ -1811,9 +1991,9 @@
                   "h": 3,
                   "w": 24,
                   "x": 0,
-                  "y": 58
+                  "y": 66
                },
-               "id": 27,
+               "id": 29,
                "mode": "markdown",
                "title": "Slab allocator monitoring information",
                "type": "text"
@@ -1831,9 +2011,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 61
+                  "y": 69
                },
-               "id": 28,
+               "id": 30,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -1921,9 +2101,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 61
+                  "y": 69
                },
-               "id": 29,
+               "id": 31,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2011,9 +2191,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 61
+                  "y": 69
                },
-               "id": 30,
+               "id": 32,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2101,9 +2281,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 69
+                  "y": 77
                },
-               "id": 31,
+               "id": 33,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2191,9 +2371,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 69
+                  "y": 77
                },
-               "id": 32,
+               "id": 34,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2281,9 +2461,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 69
+                  "y": 77
                },
-               "id": 33,
+               "id": 35,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2371,9 +2551,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 77
+                  "y": 85
                },
-               "id": 34,
+               "id": 36,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2461,9 +2641,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 77
+                  "y": 85
                },
-               "id": 35,
+               "id": 37,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2551,9 +2731,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 77
+                  "y": 85
                },
-               "id": 36,
+               "id": 38,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2644,9 +2824,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 85
+            "y": 93
          },
-         "id": 37,
+         "id": 39,
          "panels": [
             {
                "aliasColors": { },
@@ -2661,9 +2841,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 86
+                  "y": 94
                },
-               "id": 38,
+               "id": 40,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2751,9 +2931,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 86
+                  "y": 94
                },
-               "id": 39,
+               "id": 41,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2841,9 +3021,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 94
+                  "y": 102
                },
-               "id": 40,
+               "id": 42,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2931,9 +3111,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 94
+                  "y": 102
                },
-               "id": 41,
+               "id": 43,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3021,9 +3201,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 94
+                  "y": 102
                },
-               "id": 42,
+               "id": 44,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3114,9 +3294,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 102
+            "y": 110
          },
-         "id": 43,
+         "id": 45,
          "panels": [
             {
                "aliasColors": { },
@@ -3131,9 +3311,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 103
+                  "y": 111
                },
-               "id": 44,
+               "id": 46,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3221,9 +3401,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 103
+                  "y": 111
                },
-               "id": 45,
+               "id": 47,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3311,9 +3491,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 111
+                  "y": 119
                },
-               "id": 46,
+               "id": 48,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3401,9 +3581,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 111
+                  "y": 119
                },
-               "id": 47,
+               "id": 49,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3491,9 +3671,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 111
+                  "y": 119
                },
-               "id": 48,
+               "id": 50,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3581,9 +3761,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 111
+                  "y": 119
                },
-               "id": 49,
+               "id": 51,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3671,9 +3851,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 119
+                  "y": 127
                },
-               "id": 50,
+               "id": 52,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3761,9 +3941,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 119
+                  "y": 127
                },
-               "id": 51,
+               "id": 53,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3851,9 +4031,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 119
+                  "y": 127
                },
-               "id": 52,
+               "id": 54,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3941,9 +4121,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 119
+                  "y": 127
                },
-               "id": 53,
+               "id": 55,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4031,9 +4211,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 127
+                  "y": 135
                },
-               "id": 54,
+               "id": 56,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4121,9 +4301,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 127
+                  "y": 135
                },
-               "id": 55,
+               "id": 57,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4211,9 +4391,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 127
+                  "y": 135
                },
-               "id": 56,
+               "id": 58,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4301,9 +4481,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 127
+                  "y": 135
                },
-               "id": 57,
+               "id": 59,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4394,9 +4574,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 135
+            "y": 143
          },
-         "id": 58,
+         "id": 60,
          "panels": [
             {
                "aliasColors": { },
@@ -4411,9 +4591,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 136
+                  "y": 144
                },
-               "id": 59,
+               "id": 61,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4501,9 +4681,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 136
+                  "y": 144
                },
-               "id": 60,
+               "id": 62,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4594,9 +4774,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 144
+            "y": 152
          },
-         "id": 61,
+         "id": 63,
          "panels": [
             {
                "aliasColors": { },
@@ -4611,9 +4791,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 145
+                  "y": 153
                },
-               "id": 62,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4701,9 +4881,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 145
+                  "y": 153
                },
-               "id": 63,
+               "id": 65,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4791,9 +4971,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 153
+                  "y": 161
                },
-               "id": 64,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4881,9 +5061,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 153
+                  "y": 161
                },
-               "id": 65,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4971,9 +5151,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 161
+                  "y": 169
                },
-               "id": 66,
+               "id": 68,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5061,9 +5241,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 161
+                  "y": 169
                },
-               "id": 67,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5151,9 +5331,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 161
+                  "y": 169
                },
-               "id": 68,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5244,9 +5424,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 169
+            "y": 177
          },
-         "id": 69,
+         "id": 71,
          "panels": [
             {
                "aliasColors": { },
@@ -5261,9 +5441,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 170
+                  "y": 178
                },
-               "id": 70,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5351,9 +5531,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 170
+                  "y": 178
                },
-               "id": 71,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5441,9 +5621,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 170
+                  "y": 178
                },
-               "id": 72,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5531,9 +5711,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 170
+                  "y": 178
                },
-               "id": 73,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5621,9 +5801,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 178
+                  "y": 186
                },
-               "id": 74,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5711,9 +5891,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 178
+                  "y": 186
                },
-               "id": 75,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5801,9 +5981,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 186
+                  "y": 194
                },
-               "id": 76,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5891,9 +6071,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 186
+                  "y": 194
                },
-               "id": 77,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5981,9 +6161,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 186
+                  "y": 194
                },
-               "id": 78,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6071,9 +6251,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 194
+                  "y": 202
                },
-               "id": 79,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6161,9 +6341,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 194
+                  "y": 202
                },
-               "id": 80,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6251,9 +6431,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 194
+                  "y": 202
                },
-               "id": 81,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6341,9 +6521,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 202
+                  "y": 210
                },
-               "id": 82,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6431,9 +6611,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 202
+                  "y": 210
                },
-               "id": 83,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6521,9 +6701,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 202
+                  "y": 210
                },
-               "id": 84,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6611,9 +6791,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 202
+                  "y": 210
                },
-               "id": 85,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6701,9 +6881,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 210
+                  "y": 218
                },
-               "id": 86,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6791,9 +6971,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 210
+                  "y": 218
                },
-               "id": 87,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6881,9 +7061,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 210
+                  "y": 218
                },
-               "id": 88,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6974,9 +7154,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 218
+            "y": 226
          },
-         "id": 89,
+         "id": 91,
          "panels": [
             {
                "aliasColors": { },
@@ -6991,9 +7171,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 219
+                  "y": 227
                },
-               "id": 90,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7081,9 +7261,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 219
+                  "y": 227
                },
-               "id": 91,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7171,9 +7351,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 219
+                  "y": 227
                },
-               "id": 92,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7261,9 +7441,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 227
+                  "y": 235
                },
-               "id": 93,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7351,9 +7531,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 227
+                  "y": 235
                },
-               "id": 94,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7441,9 +7621,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 227
+                  "y": 235
                },
-               "id": 95,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7531,9 +7711,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 235
+                  "y": 243
                },
-               "id": 96,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7621,9 +7801,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 235
+                  "y": 243
                },
-               "id": 97,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7711,9 +7891,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 235
+                  "y": 243
                },
-               "id": 98,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7801,9 +7981,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 243
+                  "y": 251
                },
-               "id": 99,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7891,9 +8071,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 243
+                  "y": 251
                },
-               "id": 100,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7981,9 +8161,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 243
+                  "y": 251
                },
-               "id": 101,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8074,9 +8254,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 251
+            "y": 259
          },
-         "id": 102,
+         "id": 104,
          "panels": [
             {
                "aliasColors": { },
@@ -8091,9 +8271,9 @@
                   "h": 6,
                   "w": 24,
                   "x": 0,
-                  "y": 252
+                  "y": 260
                },
-               "id": 103,
+               "id": 105,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8181,9 +8361,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 258
+                  "y": 266
                },
-               "id": 104,
+               "id": 106,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8271,9 +8451,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 258
+                  "y": 266
                },
-               "id": 105,
+               "id": 107,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_with_custom_panels_compiled.json
+++ b/tests/Prometheus/dashboard_with_custom_panels_compiled.json
@@ -3485,15 +3485,195 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 3,
+               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 119
+               },
+               "id": 48,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_vinyl_memory_page_index{job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Index memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 3,
+               "description": "Amount of memory in bytes used by bloom filters.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 119
+               },
+               "id": 49,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_vinyl_memory_bloom_filter{job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Bloom filter memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 3,
                "description": "The estimated average rate of taking dumps, bytes per second.\nInitially, the rate value is 10 megabytes per second\nand being recalculated depending on the the actual rate.\nOnly significant dumps that are larger than one megabyte\nare used for the estimate.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 119
+                  "y": 127
                },
-               "id": 48,
+               "id": 50,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3581,9 +3761,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 119
+                  "y": 127
                },
-               "id": 49,
+               "id": 51,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3671,9 +3851,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 119
+                  "y": 127
                },
-               "id": 50,
+               "id": 52,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3761,9 +3941,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 119
+                  "y": 127
                },
-               "id": 51,
+               "id": 53,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3851,9 +4031,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 127
+                  "y": 135
                },
-               "id": 52,
+               "id": 54,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3941,9 +4121,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 127
+                  "y": 135
                },
-               "id": 53,
+               "id": 55,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4031,9 +4211,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 127
+                  "y": 135
                },
-               "id": 54,
+               "id": 56,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4121,9 +4301,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 127
+                  "y": 135
                },
-               "id": 55,
+               "id": 57,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4211,9 +4391,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 135
+                  "y": 143
                },
-               "id": 56,
+               "id": 58,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4301,9 +4481,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 135
+                  "y": 143
                },
-               "id": 57,
+               "id": 59,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4391,9 +4571,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 135
+                  "y": 143
                },
-               "id": 58,
+               "id": 60,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4481,9 +4661,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 135
+                  "y": 143
                },
-               "id": 59,
+               "id": 61,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4574,9 +4754,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 143
+            "y": 151
          },
-         "id": 60,
+         "id": 62,
          "panels": [
             {
                "aliasColors": { },
@@ -4591,9 +4771,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 144
+                  "y": 152
                },
-               "id": 61,
+               "id": 63,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4681,9 +4861,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 144
+                  "y": 152
                },
-               "id": 62,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4774,9 +4954,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 152
+            "y": 160
          },
-         "id": 63,
+         "id": 65,
          "panels": [
             {
                "aliasColors": { },
@@ -4791,9 +4971,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 153
+                  "y": 161
                },
-               "id": 64,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4881,9 +5061,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 153
+                  "y": 161
                },
-               "id": 65,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4971,9 +5151,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 161
+                  "y": 169
                },
-               "id": 66,
+               "id": 68,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5061,9 +5241,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 161
+                  "y": 169
                },
-               "id": 67,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5151,9 +5331,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 169
+                  "y": 177
                },
-               "id": 68,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5241,9 +5421,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 169
+                  "y": 177
                },
-               "id": 69,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5331,9 +5511,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 169
+                  "y": 177
                },
-               "id": 70,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5424,9 +5604,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 177
+            "y": 185
          },
-         "id": 71,
+         "id": 73,
          "panels": [
             {
                "aliasColors": { },
@@ -5441,9 +5621,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 178
+                  "y": 186
                },
-               "id": 72,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5531,9 +5711,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 178
+                  "y": 186
                },
-               "id": 73,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5621,9 +5801,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 178
+                  "y": 186
                },
-               "id": 74,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5711,9 +5891,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 178
+                  "y": 186
                },
-               "id": 75,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5801,9 +5981,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 186
+                  "y": 194
                },
-               "id": 76,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5891,9 +6071,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 186
+                  "y": 194
                },
-               "id": 77,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5981,9 +6161,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 194
+                  "y": 202
                },
-               "id": 78,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6071,9 +6251,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 194
+                  "y": 202
                },
-               "id": 79,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6161,9 +6341,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 194
+                  "y": 202
                },
-               "id": 80,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6251,9 +6431,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 202
+                  "y": 210
                },
-               "id": 81,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6341,9 +6521,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 202
+                  "y": 210
                },
-               "id": 82,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6431,9 +6611,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 202
+                  "y": 210
                },
-               "id": 83,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6521,9 +6701,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 210
+                  "y": 218
                },
-               "id": 84,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6611,9 +6791,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 210
+                  "y": 218
                },
-               "id": 85,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6701,9 +6881,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 210
+                  "y": 218
                },
-               "id": 86,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6791,9 +6971,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 210
+                  "y": 218
                },
-               "id": 87,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6881,9 +7061,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 218
+                  "y": 226
                },
-               "id": 88,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6971,9 +7151,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 218
+                  "y": 226
                },
-               "id": 89,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7061,9 +7241,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 218
+                  "y": 226
                },
-               "id": 90,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7154,9 +7334,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 226
+            "y": 234
          },
-         "id": 91,
+         "id": 93,
          "panels": [
             {
                "aliasColors": { },
@@ -7171,9 +7351,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 227
+                  "y": 235
                },
-               "id": 92,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7261,9 +7441,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 227
+                  "y": 235
                },
-               "id": 93,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7351,9 +7531,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 227
+                  "y": 235
                },
-               "id": 94,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7441,9 +7621,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 235
+                  "y": 243
                },
-               "id": 95,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7531,9 +7711,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 235
+                  "y": 243
                },
-               "id": 96,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7621,9 +7801,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 235
+                  "y": 243
                },
-               "id": 97,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7711,9 +7891,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 243
+                  "y": 251
                },
-               "id": 98,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7801,9 +7981,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 243
+                  "y": 251
                },
-               "id": 99,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7891,9 +8071,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 243
+                  "y": 251
                },
-               "id": 100,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7981,9 +8161,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 251
+                  "y": 259
                },
-               "id": 101,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8071,9 +8251,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 251
+                  "y": 259
                },
-               "id": 102,
+               "id": 104,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8161,9 +8341,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 251
+                  "y": 259
                },
-               "id": 103,
+               "id": 105,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8254,9 +8434,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 259
+            "y": 267
          },
-         "id": 104,
+         "id": 106,
          "panels": [
             {
                "aliasColors": { },
@@ -8271,9 +8451,9 @@
                   "h": 6,
                   "w": 24,
                   "x": 0,
-                  "y": 260
+                  "y": 268
                },
-               "id": 105,
+               "id": 107,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8361,9 +8541,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 266
+                  "y": 274
                },
-               "id": 106,
+               "id": 108,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8451,9 +8631,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 266
+                  "y": 274
                },
-               "id": 107,
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,


### PR DESCRIPTION
### dashboard: add transactions memory panel

Add a panel for tnt_info_memory_tx metrics
to "Tarantool runtime overview" section.

![image](https://user-images.githubusercontent.com/20455996/166660820-a63dc0b0-046f-4cd5-8adf-ada036654887.png)

### dashboard: add net memory, new connections panels

Add panels for tnt_info_memory_net and tnt_net_connections_total
metrics to "Tarantool network activity" section. Rework some current
"Tarantool network activity" panels to be more consistent with new
panels.

![image](https://user-images.githubusercontent.com/20455996/166660851-7b7bb810-5e92-460d-bebd-4cc547b52376.png)
![image](https://user-images.githubusercontent.com/20455996/166660948-ab221456-2fce-470d-b09a-efd2fb861b0a.png)

### dashboard: add vinyl index and bloom filter memory panels

Add panels for tnt_vinyl_memory_page_index and
tnt_vinyl_memory_bloom_filter metrics to "Tarantool vinyl statistics"
section.

![image](https://user-images.githubusercontent.com/20455996/166661064-2d7c3e90-672d-4f7c-88ac-e9fc2c3bf9e4.png)

Closes #137