### PR TITLE
Release 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [1.1.0] - 2022-05-17
+Grafana revisions: [InfluxDB revision 10](https://grafana.com/api/dashboards/12567/revisions/10/download), [Prometheus revision 11](https://grafana.com/api/dashboards/13054/revisions/11/download)
 
 ### Added
 - Panels and alerts for CRUD module statistics
 
 ### Changed
 - Set default InfluxDB policy to `autogen`
-
-### Fixed
 
 
 ## [1.0.0] - 2022-05-06


### PR DESCRIPTION
Grafana revisions:
- InfluxDB revision 10 [1]
- Prometheus revision 11 [2]

Added:
- Panels and alerts for CRUD module statistics

Changed:
- Set default InfluxDB policy to `autogen`

1. https://grafana.com/api/dashboards/12567/revisions/10/download
2. https://grafana.com/api/dashboards/13054/revisions/11/download