### PR TITLE
dashboard: change replication status panel labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - REST API requests panels for TDG dashboard
 - Task statistics panels for TDG dashboard
 
+### Changed
+- Change replication status panel labels
+
 
 ## [1.1.0] - 2022-05-17
 Grafana revisions: [InfluxDB revision 10](https://grafana.com/api/dashboards/12567/revisions/10/download), [Prometheus revision 11](https://grafana.com/api/dashboards/13054/revisions/11/download)

--- a/dashboard/panels/cluster.libsonnet
+++ b/dashboard/panels/cluster.libsonnet
@@ -421,7 +421,7 @@ local prometheus = grafana.prometheus;
     title='Tarantool instance status',
     description=|||
       `master` status means instance is available for read and
-      write operations. `slave` status means instance is
+      write operations. `replica` status means instance is
       available only for read operations.
 
       Panel works with `metrics >= 0.11.0` and Grafana 8.x.
@@ -440,7 +440,7 @@ local prometheus = grafana.prometheus;
   ).addValueMapping(
     0, 'green', 'master'
   ).addValueMapping(
-    1, 'yellow', 'slave'
+    1, 'yellow', 'replica'
   ).addRangeMapping(
     0.001, 0.999, '-'
   ).addTarget(

--- a/tests/InfluxDB/dashboard_compiled.json
+++ b/tests/InfluxDB/dashboard_compiled.json
@@ -514,7 +514,7 @@
             },
             {
                "datasource": "${DS_INFLUXDB}",
-               "description": "`master` status means instance is available for read and\nwrite operations. `slave` status means instance is\navailable only for read operations.\n\nPanel works with `metrics >= 0.11.0` and Grafana 8.x.\n",
+               "description": "`master` status means instance is available for read and\nwrite operations. `replica` status means instance is\navailable only for read operations.\n\nPanel works with `metrics >= 0.11.0` and Grafana 8.x.\n",
                "fieldConfig": {
                   "defaults": {
                      "color": {
@@ -564,7 +564,7 @@
                               "1": {
                                  "color": "yellow",
                                  "index": 0,
-                                 "text": "slave"
+                                 "text": "replica"
                               }
                            },
                            "type": "value"

--- a/tests/InfluxDB/dashboard_tdg_compiled.json
+++ b/tests/InfluxDB/dashboard_tdg_compiled.json
@@ -514,7 +514,7 @@
             },
             {
                "datasource": "${DS_INFLUXDB}",
-               "description": "`master` status means instance is available for read and\nwrite operations. `slave` status means instance is\navailable only for read operations.\n\nPanel works with `metrics >= 0.11.0` and Grafana 8.x.\n",
+               "description": "`master` status means instance is available for read and\nwrite operations. `replica` status means instance is\navailable only for read operations.\n\nPanel works with `metrics >= 0.11.0` and Grafana 8.x.\n",
                "fieldConfig": {
                   "defaults": {
                      "color": {
@@ -564,7 +564,7 @@
                               "1": {
                                  "color": "yellow",
                                  "index": 0,
-                                 "text": "slave"
+                                 "text": "replica"
                               }
                            },
                            "type": "value"

--- a/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
+++ b/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
@@ -514,7 +514,7 @@
             },
             {
                "datasource": "${DS_INFLUXDB}",
-               "description": "`master` status means instance is available for read and\nwrite operations. `slave` status means instance is\navailable only for read operations.\n\nPanel works with `metrics >= 0.11.0` and Grafana 8.x.\n",
+               "description": "`master` status means instance is available for read and\nwrite operations. `replica` status means instance is\navailable only for read operations.\n\nPanel works with `metrics >= 0.11.0` and Grafana 8.x.\n",
                "fieldConfig": {
                   "defaults": {
                      "color": {
@@ -564,7 +564,7 @@
                               "1": {
                                  "color": "yellow",
                                  "index": 0,
-                                 "text": "slave"
+                                 "text": "replica"
                               }
                            },
                            "type": "value"

--- a/tests/Prometheus/dashboard_compiled.json
+++ b/tests/Prometheus/dashboard_compiled.json
@@ -784,7 +784,7 @@
             },
             {
                "datasource": "${DS_PROMETHEUS}",
-               "description": "`master` status means instance is available for read and\nwrite operations. `slave` status means instance is\navailable only for read operations.\n\nPanel works with `metrics >= 0.11.0` and Grafana 8.x.\n",
+               "description": "`master` status means instance is available for read and\nwrite operations. `replica` status means instance is\navailable only for read operations.\n\nPanel works with `metrics >= 0.11.0` and Grafana 8.x.\n",
                "fieldConfig": {
                   "defaults": {
                      "color": {
@@ -834,7 +834,7 @@
                               "1": {
                                  "color": "yellow",
                                  "index": 0,
-                                 "text": "slave"
+                                 "text": "replica"
                               }
                            },
                            "type": "value"

--- a/tests/Prometheus/dashboard_tdg_compiled.json
+++ b/tests/Prometheus/dashboard_tdg_compiled.json
@@ -784,7 +784,7 @@
             },
             {
                "datasource": "${DS_PROMETHEUS}",
-               "description": "`master` status means instance is available for read and\nwrite operations. `slave` status means instance is\navailable only for read operations.\n\nPanel works with `metrics >= 0.11.0` and Grafana 8.x.\n",
+               "description": "`master` status means instance is available for read and\nwrite operations. `replica` status means instance is\navailable only for read operations.\n\nPanel works with `metrics >= 0.11.0` and Grafana 8.x.\n",
                "fieldConfig": {
                   "defaults": {
                      "color": {
@@ -834,7 +834,7 @@
                               "1": {
                                  "color": "yellow",
                                  "index": 0,
-                                 "text": "slave"
+                                 "text": "replica"
                               }
                            },
                            "type": "value"

--- a/tests/Prometheus/dashboard_with_custom_panels_compiled.json
+++ b/tests/Prometheus/dashboard_with_custom_panels_compiled.json
@@ -784,7 +784,7 @@
             },
             {
                "datasource": "${DS_PROMETHEUS}",
-               "description": "`master` status means instance is available for read and\nwrite operations. `slave` status means instance is\navailable only for read operations.\n\nPanel works with `metrics >= 0.11.0` and Grafana 8.x.\n",
+               "description": "`master` status means instance is available for read and\nwrite operations. `replica` status means instance is\navailable only for read operations.\n\nPanel works with `metrics >= 0.11.0` and Grafana 8.x.\n",
                "fieldConfig": {
                   "defaults": {
                      "color": {
@@ -834,7 +834,7 @@
                               "1": {
                                  "color": "yellow",
                                  "index": 0,
-                                 "text": "slave"
+                                 "text": "replica"
                               }
                            },
                            "type": "value"


### PR DESCRIPTION
Change replication status "slave" labels to "replica" to be consistent
with documentation.

Follows up #133