### PR TITLE
Fix context switches monitoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Remove rate from fiber context switches panel
+- Remove fiber context switches alert example
 
 
 ## [1.1.0] - 2022-05-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Change replication status panel labels
 
+### Fixed
+- Remove rate from fiber context switches panel
+
 
 ## [1.1.0] - 2022-05-17
 Grafana revisions: [InfluxDB revision 10](https://grafana.com/api/dashboards/12567/revisions/10/download), [Prometheus revision 11](https://grafana.com/api/dashboards/13054/revisions/11/download)

--- a/dashboard/panels/runtime.libsonnet
+++ b/dashboard/panels/runtime.libsonnet
@@ -82,28 +82,26 @@ local common = import 'common.libsonnet';
     'last'
   )),
 
-  fiber_csw_rps(
+  fiber_csw(
     title='Fiber context switches',
     description=|||
-      Average rate of fiber context switches.
+      Number of fiber context switches.
       Context switches are counted over all current fibers.
     |||,
     datasource=null,
     policy=null,
     measurement=null,
     job=null,
-    rate_time_range=null,
   ):: common.default_graph(
     title=title,
-    description=common.rate_warning(description, datasource),
+    description=description,
     datasource=datasource,
-    labelY1='switches per second',
+    labelY1='switches',
     panel_width=12,
-  ).addTarget(common.default_rps_target(
+  ).addTarget(common.default_metric_target(
     datasource,
     'tnt_fiber_csw',
     job,
-    rate_time_range,
     policy,
     measurement
   )),

--- a/dashboard/section.libsonnet
+++ b/dashboard/section.libsonnet
@@ -583,12 +583,11 @@ local tdg_tuples = import 'panels/tdg/tuples.libsonnet';
       job=job,
     ),
 
-    runtime.fiber_csw_rps(
+    runtime.fiber_csw(
       datasource=datasource,
       policy=policy,
       measurement=measurement,
       job=job,
-      rate_time_range=rate_time_range,
     ),
 
     runtime.event_loop_time(

--- a/example_cluster/prometheus/alerts.yml
+++ b/example_cluster/prometheus/alerts.yml
@@ -151,17 +151,6 @@ groups:
       description: "Instance '{{ $labels.alias }}' of job '{{ $labels.job }}' have
         high vinyl scheduler failed tasks rate."
 
-  # Alert for Tarantool low context switches rate.
-  - alert: LowFiberCSWRate
-    expr: rate(tnt_fiber_csw[2m]) < 10
-    for: 1m
-    labels:
-      severity: warning
-    annotations:
-      summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') has low fiber context switches rate"
-      description: "Instance '{{ $labels.alias }}' of job '{{ $labels.job }}' has low fiber context switches rate.
-        Some high loaded fiber has too little yields. It may be the reason of 'Too long WAL write' warnings."
-
   # Alert for high duration of event loop iteration in Tarantool.
   - alert: HighEVLoopTime
     expr: tnt_ev_loop_time > 0.1

--- a/example_cluster/prometheus/test_alerts.yml
+++ b/example_cluster/prometheus/test_alerts.yml
@@ -351,25 +351,6 @@ tests:
 
   - interval: 15s
     input_series:
-      - series: tnt_fiber_csw{job="tarantool_app", instance="app:8081", alias="tnt_router"}
-        values: '15000+1x10'
-    alert_rule_test:
-      - eval_time: 2m
-        alertname: LowFiberCSWRate
-        exp_alerts:
-          - exp_labels:
-              severity: warning
-              instance: app:8081
-              alias: tnt_router
-              job: tarantool_app
-            exp_annotations:
-              summary: "Instance 'tnt_router' ('tarantool_app') has low fiber context switches rate"
-              description: "Instance 'tnt_router' of job 'tarantool_app' has low fiber context switches rate.
-                Some high loaded fiber has too little yields. It may be the reason of 'Too long WAL write' warnings."
-
-
-  - interval: 15s
-    input_series:
       - series: tnt_ev_loop_time{job="tarantool_app", instance="app:8081", alias="tnt_router"}
         values: '0.11+0x10'
     alert_rule_test:

--- a/tests/InfluxDB/dashboard_compiled.json
+++ b/tests/InfluxDB/dashboard_compiled.json
@@ -8239,7 +8239,7 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 3,
-               "description": "Average rate of fiber context switches.\nContext switches are counted over all current fibers.\n",
+               "description": "Number of fiber context switches.\nContext switches are counted over all current fibers.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
@@ -8313,12 +8313,6 @@
                            {
                               "params": [ ],
                               "type": "mean"
-                           },
-                           {
-                              "params": [
-                                 "1s"
-                              ],
-                              "type": "non_negative_derivative"
                            }
                         ]
                      ],
@@ -8352,7 +8346,7 @@
                   {
                      "decimals": 0,
                      "format": "none",
-                     "label": "switches per second",
+                     "label": "switches",
                      "logBase": 1,
                      "max": null,
                      "min": null,

--- a/tests/InfluxDB/dashboard_tdg_compiled.json
+++ b/tests/InfluxDB/dashboard_tdg_compiled.json
@@ -7551,7 +7551,7 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 3,
-               "description": "Average rate of fiber context switches.\nContext switches are counted over all current fibers.\n",
+               "description": "Number of fiber context switches.\nContext switches are counted over all current fibers.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
@@ -7625,12 +7625,6 @@
                            {
                               "params": [ ],
                               "type": "mean"
-                           },
-                           {
-                              "params": [
-                                 "1s"
-                              ],
-                              "type": "non_negative_derivative"
                            }
                         ]
                      ],
@@ -7664,7 +7658,7 @@
                   {
                      "decimals": 0,
                      "format": "none",
-                     "label": "switches per second",
+                     "label": "switches",
                      "logBase": 1,
                      "max": null,
                      "min": null,

--- a/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
+++ b/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
@@ -8239,7 +8239,7 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 3,
-               "description": "Average rate of fiber context switches.\nContext switches are counted over all current fibers.\n",
+               "description": "Number of fiber context switches.\nContext switches are counted over all current fibers.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
@@ -8313,12 +8313,6 @@
                            {
                               "params": [ ],
                               "type": "mean"
-                           },
-                           {
-                              "params": [
-                                 "1s"
-                              ],
-                              "type": "non_negative_derivative"
                            }
                         ]
                      ],
@@ -8352,7 +8346,7 @@
                   {
                      "decimals": 0,
                      "format": "none",
-                     "label": "switches per second",
+                     "label": "switches",
                      "logBase": 1,
                      "max": null,
                      "min": null,

--- a/tests/Prometheus/dashboard_compiled.json
+++ b/tests/Prometheus/dashboard_compiled.json
@@ -5906,7 +5906,7 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 3,
-               "description": "Average rate of fiber context switches.\nContext switches are counted over all current fibers.\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
+               "description": "Number of fiber context switches.\nContext switches are counted over all current fibers.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
@@ -5944,7 +5944,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_fiber_csw{job=~\"$job\"}[$rate_time_range])",
+                     "expr": "tnt_fiber_csw{job=~\"$job\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5972,7 +5972,7 @@
                   {
                      "decimals": 0,
                      "format": "none",
-                     "label": "switches per second",
+                     "label": "switches",
                      "logBase": 1,
                      "max": null,
                      "min": null,

--- a/tests/Prometheus/dashboard_tdg_compiled.json
+++ b/tests/Prometheus/dashboard_tdg_compiled.json
@@ -5526,7 +5526,7 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 3,
-               "description": "Average rate of fiber context switches.\nContext switches are counted over all current fibers.\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
+               "description": "Number of fiber context switches.\nContext switches are counted over all current fibers.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
@@ -5564,7 +5564,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_fiber_csw{job=~\"$job\"}[$rate_time_range])",
+                     "expr": "tnt_fiber_csw{job=~\"$job\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5592,7 +5592,7 @@
                   {
                      "decimals": 0,
                      "format": "none",
-                     "label": "switches per second",
+                     "label": "switches",
                      "logBase": 1,
                      "max": null,
                      "min": null,

--- a/tests/Prometheus/dashboard_with_custom_panels_compiled.json
+++ b/tests/Prometheus/dashboard_with_custom_panels_compiled.json
@@ -5906,7 +5906,7 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 3,
-               "description": "Average rate of fiber context switches.\nContext switches are counted over all current fibers.\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
+               "description": "Number of fiber context switches.\nContext switches are counted over all current fibers.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
@@ -5944,7 +5944,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_fiber_csw{job=~\"$job\"}[$rate_time_range])",
+                     "expr": "tnt_fiber_csw{job=~\"$job\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5972,7 +5972,7 @@
                   {
                      "decimals": 0,
                      "format": "none",
-                     "label": "switches per second",
+                     "label": "switches",
                      "logBase": 1,
                      "max": null,
                      "min": null,


### PR DESCRIPTION
### dashboard: fix context switches panel

tnt_fiber_csw is not a monotonic metric since it summarize context
switches over all current fibers. If fiber is already dead, its share
is no more included. Thus, using rate on tnt_fiber_csw is incorrect.

### alerts: remove fiber csw example

Using rate with tnt_fiber_csw metric is incorrect.

Follows up #72