### PR TITLE
Release 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [1.2.0] - 2022-06-08
+Grafana revisions: [InfluxDB revision 12](https://grafana.com/api/dashboards/12567/revisions/12/download),
+[Prometheus revision 12](https://grafana.com/api/dashboards/13054/revisions/12/download),
+[InfluxDB TDG revision 1](https://grafana.com/api/dashboards/16405/revisions/1/download),
+[Prometheus TDG revision 1](https://grafana.com/api/dashboards/16406/revisions/1/download),
 
 ### Added
 - TDG (ver. 2) example cluster draft

--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 Dashboard for Tarantool application and database server monitoring, based on [grafonnet](https://github.com/grafana/grafonnet-lib) library.
 
-Our pages on Grafana Official & community built dashboards: [InfluxDB version](https://grafana.com/grafana/dashboards/12567), [Prometheus version](https://grafana.com/grafana/dashboards/13054).
+Our pages on Grafana Official & community built dashboards:
+[InfluxDB version](https://grafana.com/grafana/dashboards/12567),
+[Prometheus version](https://grafana.com/grafana/dashboards/13054)
+[InfluxDB TDG version](https://grafana.com/grafana/dashboards/16405),
+[Prometheus TDG version](https://grafana.com/grafana/dashboards/16406).
 
 Refer to dashboard [documentation page](https://www.tarantool.io/en/doc/latest/book/monitoring/grafana_dashboard/) for prerequirements and installation guide.
 
@@ -26,9 +30,13 @@ Refer to dashboard [documentation page](https://www.tarantool.io/en/doc/latest/b
 
 2. To import a specific dashboard, choose one of the following options:
 
-    - paste the dashboard id (``12567`` for InfluxDB dashboard, ``13054`` for Prometheus dashboard), or
-    - paste a link to the dashboard (https://grafana.com/grafana/dashboards/12567 for InfluxDB dashboard,
-  https://grafana.com/grafana/dashboards/13054 for Prometheus dashboard), or
+    - paste the dashboard id (``12567`` for InfluxDB dashboard, ``13054`` for Prometheus dashboard,
+      ``16405`` for InfluxDB TDG dashboard, ``16406`` for Prometheus TDG dashboard), or
+    - paste a link to the dashboard (
+      https://grafana.com/grafana/dashboards/12567 for InfluxDB dashboard,
+      https://grafana.com/grafana/dashboards/13054 for Prometheus dashboard,
+      https://grafana.com/grafana/dashboards/16405 for InfluxDB TDG dashboard,
+      https://grafana.com/grafana/dashboards/16406 for Prometheus TDG dashboard), or
     - paste the dashboard JSON file contents, or
     - upload the dashboard JSON file.
 

--- a/doc/monitoring/grafana_dashboard.rst
+++ b/doc/monitoring/grafana_dashboard.rst
@@ -9,6 +9,9 @@ Tarantool Grafana dashboard is available as part of
 There's a version
 `for Prometheus data source <https://grafana.com/grafana/dashboards/13054>`_
 and one `for InfluxDB data source <https://grafana.com/grafana/dashboards/12567>`_.
+There are also separate dashboards for TDG applications:
+`for Prometheus data source <https://grafana.com/grafana/dashboards/16406>`_
+and `for InfluxDB data source <https://grafana.com/grafana/dashboards/16405>`_.
 Tarantool Grafana dashboard is a ready for import template with basic memory,
 space operations, and HTTP load panels, based on default `metrics <https://github.com/tarantool/metrics>`_
 package functionality.
@@ -127,6 +130,51 @@ Be sure to include each label key as ``label_pairs_<key>`` so it will be
 extracted with plugin. For example, if you use :code:`{ state = 'ready' }` labels
 somewhere in metric collectors, add ``label_pairs_state`` tag key.
 
+For TDG dashboard, please use
+
+..  code-block:: toml
+
+    [[inputs.http]]
+        urls = [
+            "http://example_tdg_project:8081/metrics/json",
+            "http://example_tdg_project:8082/metrics/json",
+            "http://example_tdg_project:8083/metrics/json"
+        ]
+        timeout = "30s"
+        tag_keys = [
+            "metric_name",
+            "label_pairs_alias",
+            "label_pairs_quantile",
+            "label_pairs_path",
+            "label_pairs_method",
+            "label_pairs_status",
+            "label_pairs_operation",
+            "label_pairs_level",
+            "label_pairs_id",
+            "label_pairs_engine",
+            "label_pairs_name",
+            "label_pairs_index_name",
+            "label_pairs_delta",
+            "label_pairs_stream",
+            "label_pairs_type",
+            "label_pairs_connector_name",
+            "label_pairs_broker_name",
+            "label_pairs_topic",
+            "label_pairs_request",
+            "label_pairs_kind",
+            "label_pairs_thread_name",
+            "label_pairs_type_name",
+            "label_pairs_operation_name",
+            "label_pairs_schema",
+            "label_pairs_entity",
+            "label_pairs_status_code"
+        ]
+        insecure_skip_verify = true
+        interval = "10s"
+        data_format = "json"
+        name_prefix = "example_project_"
+        fieldpass = ["value"]
+
 If you connect Telegraf instance to InfluxDB storage, metrics will be stored
 with ``"<name_prefix>http"`` measurement (``"example_project_http"`` in our example).
 
@@ -142,9 +190,13 @@ Open Grafana import menu.
 
 To import a specific dashboard, choose one of the following options:
 
-- paste the dashboard id (``12567`` for InfluxDB dashboard, ``13054`` for Prometheus dashboard), or
-- paste a link to the dashboard (https://grafana.com/grafana/dashboards/12567 for InfluxDB dashboard,
-  https://grafana.com/grafana/dashboards/13054 for Prometheus dashboard), or
+- paste the dashboard id (``12567`` for InfluxDB dashboard, ``13054`` for Prometheus dashboard,
+  ``16405`` for InfluxDB TDG dashboard, ``16406`` for Prometheus TDG dashboard), or
+- paste a link to the dashboard (
+  https://grafana.com/grafana/dashboards/12567 for InfluxDB dashboard,
+  https://grafana.com/grafana/dashboards/13054 for Prometheus dashboard,
+  https://grafana.com/grafana/dashboards/16405 for InfluxDB TDG dashboard,
+  https://grafana.com/grafana/dashboards/16406 for Prometheus TDG dashboard), or
 - paste the dashboard JSON file contents, or
 - upload the dashboard JSON file.
 

--- a/example_cluster/project/app.Dockerfile
+++ b/example_cluster/project/app.Dockerfile
@@ -16,7 +16,6 @@ RUN curl -L https://tarantool.io/OtKysgx/pre-release/2/installer.sh | bash
 RUN yum install -y tarantool tarantool-devel
 
 # https://github.com/tarantool/cartridge-cli#installation
-RUN set -o pipefail && curl -L https://tarantool.io/installer.sh | bash -s -- --repo-only
 RUN yum install -y cartridge-cli
 RUN cartridge build
 


### PR DESCRIPTION
Grafana revisions:
- InfluxDB revision 12 [1]
- Prometheus revision 12 [2]
- InfluxDB TDG revision 1 [3]
- Prometheus TDG revision 1 [4]

Added:
- TDG (ver. 2) example cluster draft
- Dashboard templates for TDG (ver. 2)
- Kafka metrics panels for TDG dashboard
- Thread CPU panels for TDG dashboard
- expirationd panels for TDG dashboard
- Tuples panels for TDG dashboard
- File connectors panels for TDG dashboard
- GraphQL requests panels for TDG dashboard
- IProto requests panels for TDG dashboard
- REST API requests panels for TDG dashboard
- Task statistics panels for TDG dashboard

Changed:
- Change replication status panel labels

Fixed:
- Remove rate from fiber context switches panel
- Remove fiber context switches alert example

1. https://grafana.com/api/dashboards/12567/revisions/12/download
2. https://grafana.com/api/dashboards/13054/revisions/12/download
3. https://grafana.com/api/dashboards/16405/revisions/1/download
4. https://grafana.com/api/dashboards/16406/revisions/1/download