### PR TITLE
tdg_dashboard: fix panel name typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+## Fixed
+- TDG dashboard file connectors processed panel name changed to "Total files processed"
+
 ## [1.2.0] - 2022-06-08
 Grafana revisions: [InfluxDB revision 12](https://grafana.com/api/dashboards/12567/revisions/12/download), [Prometheus revision 12](https://grafana.com/api/dashboards/13054/revisions/12/download), [InfluxDB TDG revision 1](https://grafana.com/api/dashboards/16405/revisions/1/download), [Prometheus TDG revision 1](https://grafana.com/api/dashboards/16406/revisions/1/download).
 

--- a/dashboard/panels/tdg/file_connectors.libsonnet
+++ b/dashboard/panels/tdg/file_connectors.libsonnet
@@ -33,7 +33,7 @@ local prometheus = grafana.prometheus;
       .selectField('value').addConverter('mean'),
 
   files_processed(
-    title='Total iles processed',
+    title='Total files processed',
     description=|||
       A number of files processed.
     |||,

--- a/tests/InfluxDB/dashboard_tdg_compiled.json
+++ b/tests/InfluxDB/dashboard_tdg_compiled.json
@@ -22990,7 +22990,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Total iles processed",
+               "title": "Total files processed",
                "tooltip": {
                   "shared": true,
                   "sort": 2,

--- a/tests/Prometheus/dashboard_tdg_compiled.json
+++ b/tests/Prometheus/dashboard_tdg_compiled.json
@@ -14954,7 +14954,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Total iles processed",
+               "title": "Total files processed",
                "tooltip": {
                   "shared": true,
                   "sort": 2,


### PR DESCRIPTION
Change TDG file connectors panel name from "Total iles processed" to
"Total files processed".

Closes #157