### PR TITLE
tdg_dashboard: fix Kafka partitions metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Fixed
 - TDG dashboard file connectors processed panel name changed to "Total files processed"
+- Set valid metrics name to TDG dashboard Kafka partitions panels
+
 
 ## [1.2.0] - 2022-06-08
 Grafana revisions: [InfluxDB revision 12](https://grafana.com/api/dashboards/12567/revisions/12/download), [Prometheus revision 12](https://grafana.com/api/dashboards/13054/revisions/12/download), [InfluxDB TDG revision 1](https://grafana.com/api/dashboards/16405/revisions/1/download), [Prometheus TDG revision 1](https://grafana.com/api/dashboards/16406/revisions/1/download).

--- a/dashboard/panels/tdg/kafka/topics.libsonnet
+++ b/dashboard/panels/tdg/kafka/topics.libsonnet
@@ -368,7 +368,7 @@ local prometheus = grafana.prometheus;
     panel_width=6,
   ).addTarget(partitions_rps_target(
     datasource,
-    'tdg_kafka_partition_txmsgs',
+    'tdg_kafka_topic_partitions_txmsgs',
     job,
     rate_time_range,
     policy,
@@ -395,7 +395,7 @@ local prometheus = grafana.prometheus;
     panel_width=6,
   ).addTarget(partitions_rps_target(
     datasource,
-    'tdg_kafka_partition_txbytes',
+    'tdg_kafka_topic_partitions_txbytes',
     job,
     rate_time_range,
     policy,
@@ -422,7 +422,7 @@ local prometheus = grafana.prometheus;
     panel_width=6,
   ).addTarget(partitions_rps_target(
     datasource,
-    'tdg_kafka_partition_rxmsgs',
+    'tdg_kafka_topic_partitions_rxmsgs',
     job,
     rate_time_range,
     policy,
@@ -450,7 +450,7 @@ local prometheus = grafana.prometheus;
     panel_width=6,
   ).addTarget(partitions_rps_target(
     datasource,
-    'tdg_kafka_partition_rxbytes',
+    'tdg_kafka_topic_partitions_rxbytes',
     job,
     rate_time_range,
     policy,
@@ -476,7 +476,7 @@ local prometheus = grafana.prometheus;
     panel_width=12,
   ).addTarget(partitions_rps_target(
     datasource,
-    'tdg_kafka_partition_rx_ver_drops',
+    'tdg_kafka_topic_partitions_rx_ver_drops',
     job,
     rate_time_range,
     policy,
@@ -501,7 +501,7 @@ local prometheus = grafana.prometheus;
     panel_width=12,
   ).addTarget(partitions_target(
     datasource,
-    'tdg_kafka_partition_msgs_inflight',
+    'tdg_kafka_topic_partitions_msgs_inflight',
     job,
     policy,
     measurement,

--- a/tests/InfluxDB/dashboard_tdg_compiled.json
+++ b/tests/InfluxDB/dashboard_tdg_compiled.json
@@ -19980,7 +19980,7 @@
                         {
                            "key": "metric_name",
                            "operator": "=",
-                           "value": "tdg_kafka_partition_txmsgs"
+                           "value": "tdg_kafka_topic_partitions_txmsgs"
                         }
                      ]
                   }
@@ -20147,7 +20147,7 @@
                         {
                            "key": "metric_name",
                            "operator": "=",
-                           "value": "tdg_kafka_partition_txbytes"
+                           "value": "tdg_kafka_topic_partitions_txbytes"
                         }
                      ]
                   }
@@ -20314,7 +20314,7 @@
                         {
                            "key": "metric_name",
                            "operator": "=",
-                           "value": "tdg_kafka_partition_rxmsgs"
+                           "value": "tdg_kafka_topic_partitions_rxmsgs"
                         }
                      ]
                   }
@@ -20481,7 +20481,7 @@
                         {
                            "key": "metric_name",
                            "operator": "=",
-                           "value": "tdg_kafka_partition_rxbytes"
+                           "value": "tdg_kafka_topic_partitions_rxbytes"
                         }
                      ]
                   }
@@ -20648,7 +20648,7 @@
                         {
                            "key": "metric_name",
                            "operator": "=",
-                           "value": "tdg_kafka_partition_rx_ver_drops"
+                           "value": "tdg_kafka_topic_partitions_rx_ver_drops"
                         }
                      ]
                   }
@@ -20809,7 +20809,7 @@
                         {
                            "key": "metric_name",
                            "operator": "=",
-                           "value": "tdg_kafka_partition_msgs_inflight"
+                           "value": "tdg_kafka_topic_partitions_msgs_inflight"
                         }
                      ]
                   }

--- a/tests/Prometheus/dashboard_tdg_compiled.json
+++ b/tests/Prometheus/dashboard_tdg_compiled.json
@@ -13044,7 +13044,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_partition_txmsgs{job=~\"$job\"}[$rate_time_range])",
+                     "expr": "rate(tdg_kafka_topic_partitions_txmsgs{job=~\"$job\"}[$rate_time_range])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -13134,7 +13134,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_partition_txbytes{job=~\"$job\"}[$rate_time_range])",
+                     "expr": "rate(tdg_kafka_topic_partitions_txbytes{job=~\"$job\"}[$rate_time_range])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -13224,7 +13224,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_partition_rxmsgs{job=~\"$job\"}[$rate_time_range])",
+                     "expr": "rate(tdg_kafka_topic_partitions_rxmsgs{job=~\"$job\"}[$rate_time_range])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -13314,7 +13314,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_partition_rxbytes{job=~\"$job\"}[$rate_time_range])",
+                     "expr": "rate(tdg_kafka_topic_partitions_rxbytes{job=~\"$job\"}[$rate_time_range])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -13404,7 +13404,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_partition_rx_ver_drops{job=~\"$job\"}[$rate_time_range])",
+                     "expr": "rate(tdg_kafka_topic_partitions_rx_ver_drops{job=~\"$job\"}[$rate_time_range])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -13494,7 +13494,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_partition_msgs_inflight{job=~\"$job\"}",
+                     "expr": "tdg_kafka_topic_partitions_msgs_inflight{job=~\"$job\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",


### PR DESCRIPTION
Fix metrics name for "TDG Kafka topics statistics" panels:
- "Partition messages sent"
  (tdg_kafka_topic_partitions_txmsgs),
- "Partition message bytes sent"
  (tdg_kafka_topic_partitions_txbytes),
- "Partition messages consumed"
  (tdg_kafka_topic_partitions_rxmsgs),
- "Partition message bytes consumed"
  (tdg_kafka_topic_partitions_rxbytes),
- "Partition messages dropped"
  (tdg_kafka_topic_partitions_rx_ver_drops),
- "Partition messages in flight"
  (tdg_kafka_topic_partitions_msgs_inflight).

Closes #155