### PR TITLE
tdg_dashboard: display only 99th quantile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Fixed
 - TDG dashboard file connectors processed panel name changed to "Total files processed"
 - Set valid metrics name to TDG dashboard Kafka partitions panels
+- Display only 99th quantile for Prometheus TDG Kafka metrics
 
 
 ## [1.2.0] - 2022-06-08

--- a/dashboard/panels/tdg/kafka/brokers.libsonnet
+++ b/dashboard/panels/tdg/kafka/brokers.libsonnet
@@ -73,7 +73,7 @@ local prometheus = grafana.prometheus;
   ) =
     if datasource == '${DS_PROMETHEUS}' then
       prometheus.target(
-        expr=std.format('%s{job=~"%s"}',
+        expr=std.format('%s{job=~"%s",quantile="0.99"}',
                         [metric_name, job]),
         legendFormat='{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})',
       )

--- a/dashboard/panels/tdg/kafka/topics.libsonnet
+++ b/dashboard/panels/tdg/kafka/topics.libsonnet
@@ -102,7 +102,7 @@ local prometheus = grafana.prometheus;
   ) =
     if datasource == '${DS_PROMETHEUS}' then
       prometheus.target(
-        expr=std.format('%s{job=~"%s"}',
+        expr=std.format('%s{job=~"%s",quantile="0.99"}',
                         [metric_name, job]),
         legendFormat='{{name}} ({{topic}}) — {{alias}} ({{type}}, {{connector_name}})',
       )

--- a/tests/Prometheus/dashboard_tdg_compiled.json
+++ b/tests/Prometheus/dashboard_tdg_compiled.json
@@ -11764,7 +11764,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_int_latency{job=~\"$job\"}",
+                     "expr": "tdg_kafka_broker_int_latency{job=~\"$job\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -11854,7 +11854,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_outbuf_latency{job=~\"$job\"}",
+                     "expr": "tdg_kafka_broker_outbuf_latency{job=~\"$job\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -11944,7 +11944,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_rtt{job=~\"$job\"}",
+                     "expr": "tdg_kafka_broker_rtt{job=~\"$job\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -12034,7 +12034,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_throttle{job=~\"$job\"}",
+                     "expr": "tdg_kafka_broker_throttle{job=~\"$job\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -12324,7 +12324,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_batchsize{job=~\"$job\"}",
+                     "expr": "tdg_kafka_topic_batchsize{job=~\"$job\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -12414,7 +12414,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_batchcnt{job=~\"$job\"}",
+                     "expr": "tdg_kafka_topic_batchcnt{job=~\"$job\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}) — {{alias}} ({{type}}, {{connector_name}})",


### PR DESCRIPTION
Display only 99th quantile for Prometheus TDG Kafka metrics:
- "TDG Kafka brokers statistics" panels:
  - "Producer queue latency" (tdg_kafka_broker_int_latency),
  - "Request queue latency" (tdg_kafka_broker_outbuf_latency),
  - "Broker latency" (tdg_kafka_broker_rtt),
  - "Broker throttle" (tdg_kafka_broker_throttle);
- "TDG Kafka topics statistics" panels:
  - "Batch size" (tdg_kafka_topic_batchsize),
  - "Batch message count" (tdg_kafka_topic_batchcnt).

Closes #156