### PR TITLE
Release 1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [1.2.1] - 2022-06-24
+Grafana revisions: [InfluxDB revision 12](https://grafana.com/api/dashboards/12567/revisions/12/download), [Prometheus revision 12](https://grafana.com/api/dashboards/13054/revisions/12/download), [InfluxDB TDG revision 2](https://grafana.com/api/dashboards/16405/revisions/2/download), [Prometheus TDG revision 2](https://grafana.com/api/dashboards/16406/revisions/2/download).
 
 ## Fixed
 - TDG dashboard file connectors processed panel name changed to "Total files processed"


### PR DESCRIPTION
Grafana revisions: [InfluxDB revision 12](https://grafana.com/api/dashboards/12567/revisions/12/download), [Prometheus revision 12](https://grafana.com/api/dashboards/13054/revisions/12/download), [InfluxDB TDG revision 2](https://grafana.com/api/dashboards/16405/revisions/2/download), [Prometheus TDG revision 2](https://grafana.com/api/dashboards/16406/revisions/2/download).

Fixed:
- TDG dashboard file connectors processed panel name changed to
  "Total files processed"
- Set valid metrics name to TDG dashboard Kafka partitions panels
- Display only 99th quantile for Prometheus TDG Kafka metrics