### PR TITLE
CRUD many panels

### DIFF
--- a/dashboard/panels/crud.libsonnet
+++ b/dashboard/panels/crud.libsonnet
@@ -4,410 +4,413 @@ local grafana = import 'grafonnet/grafana.libsonnet';
 local influxdb = grafana.influxdb;
 local prometheus = grafana.prometheus;
 
-{
-  row:: common.row('CRUD module statistics'),
+// Add util functions for panels.
 
-  local crud_warning(description) = std.join(
-    '\n',
-    [description, |||
-      CRUD 0.11.0 or newer is required to use statistics.
-      Enable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`
-    |||]
+local crud_warning(description) = std.join(
+  '\n',
+  [description, |||
+    CRUD 0.11.0 or newer is required to use statistics.
+    Enable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`
+  |||]
+);
+
+local crud_quantile_warning(description) = std.join(
+  '\n',
+  [description, |||
+    CRUD 0.11.0 or newer is required to use statistics.
+    Enable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.
+    If `No data` displayed yet data expected, try to calibrate tolerated error with
+    `crud.cfg{stats_quantile_tolerated_error=1e-4}`.
+  |||]
+);
+
+local status_text(status) = (if status == 'ok' then 'success' else 'error');
+
+local operation_rps_template(
+  title=null,
+  description=null,
+  datasource=null,
+  policy=null,
+  measurement=null,
+  job=null,
+  rate_time_range=null,
+  operation=null,
+  status=null,
+      ) = common.default_graph(
+  title=(
+    if title != null then
+      title
+    else
+      std.format('%s %s requests', [std.asciiUpper(operation), status_text(status)])
   ),
-
-  local crud_quantile_warning(description) = std.join(
-    '\n',
-    [description, |||
-      CRUD 0.11.0 or newer is required to use statistics.
-      Enable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.
-      If `No data` displayed yet data expected, try to calibrate tolerated error with
-      `crud.cfg{stats_quantile_tolerated_error=1e-4}`.
-    |||]
-  ),
-
-  local status_text(status) = (if status == 'ok' then 'success' else 'error'),
-
-  local operation_rps_template(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    rate_time_range=null,
-    operation=null,
-    status=null,
-  ) = common.default_graph(
-    title=(
-      if title != null then
-        title
-      else
-        std.format('%s %s requests', [std.asciiUpper(operation), status_text(status)])
-    ),
-    description=common.rate_warning(description, datasource),
-    datasource=datasource,
-    min=0,
-    labelY1='requests per second',
-    decimals=2,
-    decimalsY1=2,
-    panel_height=8,
-    panel_width=6,
-  ).addTarget(
-    if datasource == '${DS_PROMETHEUS}' then
-      prometheus.target(
-        expr=std.format(
-          'rate(tnt_crud_stats_count{job=~"%s",operation="%s",status="%s"}[%s])',
-          [job, operation, status, rate_time_range]
-        ),
-        legendFormat='{{alias}} — {{name}}'
-      )
-    else if datasource == '${DS_INFLUXDB}' then
-      influxdb.target(
-        policy=policy,
-        measurement=measurement,
-        group_tags=['label_pairs_alias', 'label_pairs_name'],
-        alias='$tag_label_pairs_alias — $tag_label_pairs_name',
-      ).where('metric_name', '=', 'tnt_crud_stats_count')
-      .where('label_pairs_operation', '=', operation)
-      .where('label_pairs_status', '=', status)
-      .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s'])
-  ),
-
-  local operation_latency_template(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    operation=null,
-    status=null,
-  ) = common.default_graph(
-    title=(
-      if title != null then
-        title
-      else
-        std.format('%s %s requests latency', [std.asciiUpper(operation), status_text(status)])
-    ),
-    description=description,
-    datasource=datasource,
-    format='s',
-    min=0,
-    labelY1='99th percentile',
-    decimals=2,
-    decimalsY1=3,
-    panel_height=8,
-    panel_width=6,
-  ).addTarget(
-    if datasource == '${DS_PROMETHEUS}' then
-      prometheus.target(
-        expr=std.format(
-          'tnt_crud_stats{job=~"%s",operation="%s",status="%s",quantile="0.99"}',
-          [job, operation, status]
-        ),
-        legendFormat='{{alias}} — {{name}}'
-      )
-    else if datasource == '${DS_INFLUXDB}' then
-      influxdb.target(
-        policy=policy,
-        measurement=measurement,
-        group_tags=['label_pairs_alias', 'label_pairs_name'],
-        alias='$tag_label_pairs_alias — $tag_label_pairs_name',
-      ).where('metric_name', '=', 'tnt_crud_stats')
-      .where('label_pairs_operation', '=', operation)
-      .where('label_pairs_status', '=', status)
-      .where('label_pairs_quantile', '=', '0.99')
-      .selectField('value').addConverter('mean')
-  ),
-
-  local operation_rps(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    rate_time_range=null,
-    operation=null,
-    status=null,
-  ) = operation_rps_template(
-    title=title,
-    description=(
-      if description != null then
-        description
-      else
-        crud_warning(std.format(|||
-          Total count of %s %s requests to cluster spaces with CRUD module.
-          Graph shows average requests per second.
-        |||, [status_text(status), operation]))
-    ),
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    rate_time_range=rate_time_range,
-    operation=operation,
-    status=status,
-  ),
-
-  local operation_latency(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    operation=null,
-    status=null,
-  ) = operation_latency_template(
-    title=title,
-    description=(
-      if description != null then
-        description
-      else
-        crud_quantile_warning(std.format(|||
-          99th percentile of %s %s CRUD module requests latency with aging.
-        |||, [status_text(status), operation]))
-    ),
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    operation=operation,
-    status=status,
-  ),
-
-  local operation_rps_object(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    rate_time_range=null,
-    operation=null,
-    status=null,
-  ) = operation_rps_template(
-    title=title,
-    description=(
-      if description != null then
-        description
-      else
-        crud_warning(std.format(|||
-          Total count of %s %s and %s_object requests to cluster spaces with CRUD module.
-          Graph shows average requests per second.
-        |||, [status_text(status), operation, operation]))
-    ),
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    rate_time_range=rate_time_range,
-    operation=operation,
-    status=status,
-  ),
-
-  local operation_latency_object(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    operation=null,
-    status=null,
-  ) = operation_latency_template(
-    title=title,
-    description=(
-      if description != null then
-        description
-      else
-        crud_quantile_warning(std.format(|||
-          99th percentile of %s %s and %s_object CRUD module requests latency with aging.
-        |||, [status_text(status), operation, operation]))
-    ),
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    operation=operation,
-    status=status,
-  ),
-
-  local operation_rps_select(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    rate_time_range=null,
-    status=null,
-  ) = operation_rps_template(
-    title=title,
-    description=(
-      if description != null then
-        description
-      else
-        crud_warning(std.format(|||
-          Total count of %s SELECT and PAIRS requests to cluster spaces with CRUD module.
-          Graph shows average requests per second.
-        |||, status_text(status)))
-    ),
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    rate_time_range=rate_time_range,
-    operation='select',
-    status=status,
-  ),
-
-  local operation_latency_select(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    operation=null,
-    status=null,
-  ) = operation_latency_template(
-    title=title,
-    description=(
-      if description != null then
-        description
-      else
-        crud_quantile_warning(std.format(|||
-          99th percentile of %s SELECT and PAIRS CRUD module requests latency with aging.
-        |||, status_text(status)))
-    ),
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    operation='select',
-    status=status,
-  ),
-
-  local operation_rps_borders(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    rate_time_range=null,
-    status=null,
-  ) = operation_rps_template(
-    title=title,
-    description=(
-      if description != null then
-        description
-      else
-        crud_warning(std.format(|||
-          Total count of %s MIN and MAX requests to cluster spaces with CRUD module.
-          Graph shows average requests per second.
-        |||, status_text(status)))
-    ),
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    rate_time_range=rate_time_range,
-    operation='borders',
-    status=status,
-  ),
-
-  local operation_latency_borders(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    operation=null,
-    status=null,
-  ) = operation_latency_template(
-    title=title,
-    description=(
-      if description != null then
-        description
-      else
-        crud_quantile_warning(std.format(|||
-          99th percentile of %s MIN and MAX CRUD module requests latency with aging.
-        |||, status_text(status)))
-    ),
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    operation='borders',
-    status=status,
-  ),
-
-  local tuples_panel(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    rate_time_range=null,
-    metric_name=null,
-  ) = common.default_graph(
-    title=title,
-    description=common.group_by_fill_0_warning(
-      common.rate_warning(
-        crud_warning(description),
-        datasource,
+  description=common.rate_warning(description, datasource),
+  datasource=datasource,
+  min=0,
+  labelY1='requests per second',
+  decimals=2,
+  decimalsY1=2,
+  panel_height=8,
+  panel_width=6,
+).addTarget(
+  if datasource == '${DS_PROMETHEUS}' then
+    prometheus.target(
+      expr=std.format(
+        'rate(tnt_crud_stats_count{job=~"%s",operation="%s",status="%s"}[%s])',
+        [job, operation, status, rate_time_range]
       ),
+      legendFormat='{{alias}} — {{name}}'
+    )
+  else if datasource == '${DS_INFLUXDB}' then
+    influxdb.target(
+      policy=policy,
+      measurement=measurement,
+      group_tags=['label_pairs_alias', 'label_pairs_name'],
+      alias='$tag_label_pairs_alias — $tag_label_pairs_name',
+    ).where('metric_name', '=', 'tnt_crud_stats_count')
+    .where('label_pairs_operation', '=', operation)
+    .where('label_pairs_status', '=', status)
+    .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s'])
+);
+
+local operation_latency_template(
+  title=null,
+  description=null,
+  datasource=null,
+  policy=null,
+  measurement=null,
+  job=null,
+  operation=null,
+  status=null,
+      ) = common.default_graph(
+  title=(
+    if title != null then
+      title
+    else
+      std.format('%s %s requests latency', [std.asciiUpper(operation), status_text(status)])
+  ),
+  description=description,
+  datasource=datasource,
+  format='s',
+  min=0,
+  labelY1='99th percentile',
+  decimals=2,
+  decimalsY1=3,
+  panel_height=8,
+  panel_width=6,
+).addTarget(
+  if datasource == '${DS_PROMETHEUS}' then
+    prometheus.target(
+      expr=std.format(
+        'tnt_crud_stats{job=~"%s",operation="%s",status="%s",quantile="0.99"}',
+        [job, operation, status]
+      ),
+      legendFormat='{{alias}} — {{name}}'
+    )
+  else if datasource == '${DS_INFLUXDB}' then
+    influxdb.target(
+      policy=policy,
+      measurement=measurement,
+      group_tags=['label_pairs_alias', 'label_pairs_name'],
+      alias='$tag_label_pairs_alias — $tag_label_pairs_name',
+    ).where('metric_name', '=', 'tnt_crud_stats')
+    .where('label_pairs_operation', '=', operation)
+    .where('label_pairs_status', '=', status)
+    .where('label_pairs_quantile', '=', '0.99')
+    .selectField('value').addConverter('mean')
+);
+
+local operation_rps(
+  title=null,
+  description=null,
+  datasource=null,
+  policy=null,
+  measurement=null,
+  job=null,
+  rate_time_range=null,
+  operation=null,
+  status=null,
+      ) = operation_rps_template(
+  title=title,
+  description=(
+    if description != null then
+      description
+    else
+      crud_warning(std.format(|||
+        Total count of %s %s requests to cluster spaces with CRUD module.
+        Graph shows average requests per second.
+      |||, [status_text(status), operation]))
+  ),
+  datasource=datasource,
+  policy=policy,
+  measurement=measurement,
+  job=job,
+  rate_time_range=rate_time_range,
+  operation=operation,
+  status=status,
+);
+
+local operation_latency(
+  title=null,
+  description=null,
+  datasource=null,
+  policy=null,
+  measurement=null,
+  job=null,
+  operation=null,
+  status=null,
+      ) = operation_latency_template(
+  title=title,
+  description=(
+    if description != null then
+      description
+    else
+      crud_quantile_warning(std.format(|||
+        99th percentile of %s %s CRUD module requests latency with aging.
+      |||, [status_text(status), operation]))
+  ),
+  datasource=datasource,
+  policy=policy,
+  measurement=measurement,
+  job=job,
+  operation=operation,
+  status=status,
+);
+
+local operation_rps_object(
+  title=null,
+  description=null,
+  datasource=null,
+  policy=null,
+  measurement=null,
+  job=null,
+  rate_time_range=null,
+  operation=null,
+  status=null,
+      ) = operation_rps_template(
+  title=title,
+  description=(
+    if description != null then
+      description
+    else
+      crud_warning(std.format(|||
+        Total count of %s %s and %s_object requests to cluster spaces with CRUD module.
+        Graph shows average requests per second.
+      |||, [status_text(status), operation, operation]))
+  ),
+  datasource=datasource,
+  policy=policy,
+  measurement=measurement,
+  job=job,
+  rate_time_range=rate_time_range,
+  operation=operation,
+  status=status,
+);
+
+local operation_latency_object(
+  title=null,
+  description=null,
+  datasource=null,
+  policy=null,
+  measurement=null,
+  job=null,
+  operation=null,
+  status=null,
+      ) = operation_latency_template(
+  title=title,
+  description=(
+    if description != null then
+      description
+    else
+      crud_quantile_warning(std.format(|||
+        99th percentile of %s %s and %s_object CRUD module requests latency with aging.
+      |||, [status_text(status), operation, operation]))
+  ),
+  datasource=datasource,
+  policy=policy,
+  measurement=measurement,
+  job=job,
+  operation=operation,
+  status=status,
+);
+
+local operation_rps_select(
+  title=null,
+  description=null,
+  datasource=null,
+  policy=null,
+  measurement=null,
+  job=null,
+  rate_time_range=null,
+  status=null,
+      ) = operation_rps_template(
+  title=title,
+  description=(
+    if description != null then
+      description
+    else
+      crud_warning(std.format(|||
+        Total count of %s SELECT and PAIRS requests to cluster spaces with CRUD module.
+        Graph shows average requests per second.
+      |||, status_text(status)))
+  ),
+  datasource=datasource,
+  policy=policy,
+  measurement=measurement,
+  job=job,
+  rate_time_range=rate_time_range,
+  operation='select',
+  status=status,
+);
+
+local operation_latency_select(
+  title=null,
+  description=null,
+  datasource=null,
+  policy=null,
+  measurement=null,
+  job=null,
+  operation=null,
+  status=null,
+      ) = operation_latency_template(
+  title=title,
+  description=(
+    if description != null then
+      description
+    else
+      crud_quantile_warning(std.format(|||
+        99th percentile of %s SELECT and PAIRS CRUD module requests latency with aging.
+      |||, status_text(status)))
+  ),
+  datasource=datasource,
+  policy=policy,
+  measurement=measurement,
+  job=job,
+  operation='select',
+  status=status,
+);
+
+local operation_rps_borders(
+  title=null,
+  description=null,
+  datasource=null,
+  policy=null,
+  measurement=null,
+  job=null,
+  rate_time_range=null,
+  status=null,
+      ) = operation_rps_template(
+  title=title,
+  description=(
+    if description != null then
+      description
+    else
+      crud_warning(std.format(|||
+        Total count of %s MIN and MAX requests to cluster spaces with CRUD module.
+        Graph shows average requests per second.
+      |||, status_text(status)))
+  ),
+  datasource=datasource,
+  policy=policy,
+  measurement=measurement,
+  job=job,
+  rate_time_range=rate_time_range,
+  operation='borders',
+  status=status,
+);
+
+local operation_latency_borders(
+  title=null,
+  description=null,
+  datasource=null,
+  policy=null,
+  measurement=null,
+  job=null,
+  operation=null,
+  status=null,
+      ) = operation_latency_template(
+  title=title,
+  description=(
+    if description != null then
+      description
+    else
+      crud_quantile_warning(std.format(|||
+        99th percentile of %s MIN and MAX CRUD module requests latency with aging.
+      |||, status_text(status)))
+  ),
+  datasource=datasource,
+  policy=policy,
+  measurement=measurement,
+  job=job,
+  operation='borders',
+  status=status,
+);
+
+local tuples_panel(
+  title=null,
+  description=null,
+  datasource=null,
+  policy=null,
+  measurement=null,
+  job=null,
+  rate_time_range=null,
+  metric_name=null,
+      ) = common.default_graph(
+  title=title,
+  description=common.group_by_fill_0_warning(
+    common.rate_warning(
+      crud_warning(description),
       datasource,
     ),
-    datasource=datasource,
-    min=0,
-    labelY1='tuples per request',
-    panel_height=8,
-    panel_width=8,
-  ).addTarget(
-    if datasource == '${DS_PROMETHEUS}' then
-      prometheus.target(
-        expr=std.format(
-          |||
-            rate(%(metric_name)s{job=~"%(job)s",operation="select"}[%(rate_time_range)s]) /
-            (sum without (status) (rate(tnt_crud_stats_count{job=~"%(job)s",operation="select"}[%(rate_time_range)s])))
-          |||,
-          {
-            metric_name: metric_name,
-            job: job,
-            rate_time_range: rate_time_range,
-          }
-        ),
-        legendFormat='{{alias}} — {{name}}'
-      )
-    else if datasource == '${DS_INFLUXDB}' then
-      influxdb.target(
-        rawQuery=true,
-        query=std.format(|||
-          SELECT mean("%(metric_name)s") / (mean("tnt_crud_stats_count_ok") + mean("tnt_crud_stats_count_error"))
-          as "tnt_crud_tuples_per_request" FROM
-          (SELECT "value" as "%(metric_name)s" FROM %(policy_prefix)s"%(measurement)s"
-          WHERE ("metric_name" = '%(metric_name)s' AND "label_pairs_operation" = 'select') AND $timeFilter),
-          (SELECT "value" as "tnt_crud_stats_count_error" FROM %(policy_prefix)s"%(measurement)s"
-          WHERE ("metric_name" = 'tnt_crud_stats_count' AND "label_pairs_operation" = 'select'
-          AND "label_pairs_status" = 'error') AND $timeFilter),
-          (SELECT "value" as "tnt_crud_stats_count_ok" FROM %(policy_prefix)s"%(measurement)s"
-          WHERE ("metric_name" = 'tnt_crud_stats_count' AND "label_pairs_operation" = 'select'
-          AND "label_pairs_status" = 'ok') AND $timeFilter)
-          GROUP BY time($__interval * 2), "label_pairs_alias", "label_pairs_name" fill(0)
-        |||, {
-          metric_name: metric_name,
-          policy_prefix: if policy == 'default' then '' else std.format('"%(policy)s".', policy),
-          measurement: measurement,
-        }),
-        alias='$tag_label_pairs_alias — $tag_label_pairs_name'
-      )
+    datasource,
   ),
+  datasource=datasource,
+  min=0,
+  labelY1='tuples per request',
+  panel_height=8,
+  panel_width=8,
+).addTarget(
+  if datasource == '${DS_PROMETHEUS}' then
+    prometheus.target(
+      expr=std.format(
+        |||
+          rate(%(metric_name)s{job=~"%(job)s",operation="select"}[%(rate_time_range)s]) /
+          (sum without (status) (rate(tnt_crud_stats_count{job=~"%(job)s",operation="select"}[%(rate_time_range)s])))
+        |||,
+        {
+          metric_name: metric_name,
+          job: job,
+          rate_time_range: rate_time_range,
+        }
+      ),
+      legendFormat='{{alias}} — {{name}}'
+    )
+  else if datasource == '${DS_INFLUXDB}' then
+    influxdb.target(
+      rawQuery=true,
+      query=std.format(|||
+        SELECT mean("%(metric_name)s") / (mean("tnt_crud_stats_count_ok") + mean("tnt_crud_stats_count_error"))
+        as "tnt_crud_tuples_per_request" FROM
+        (SELECT "value" as "%(metric_name)s" FROM %(policy_prefix)s"%(measurement)s"
+        WHERE ("metric_name" = '%(metric_name)s' AND "label_pairs_operation" = 'select') AND $timeFilter),
+        (SELECT "value" as "tnt_crud_stats_count_error" FROM %(policy_prefix)s"%(measurement)s"
+        WHERE ("metric_name" = 'tnt_crud_stats_count' AND "label_pairs_operation" = 'select'
+        AND "label_pairs_status" = 'error') AND $timeFilter),
+        (SELECT "value" as "tnt_crud_stats_count_ok" FROM %(policy_prefix)s"%(measurement)s"
+        WHERE ("metric_name" = 'tnt_crud_stats_count' AND "label_pairs_operation" = 'select'
+        AND "label_pairs_status" = 'ok') AND $timeFilter)
+        GROUP BY time($__interval * 2), "label_pairs_alias", "label_pairs_name" fill(0)
+      |||, {
+        metric_name: metric_name,
+        policy_prefix: if policy == 'default' then '' else std.format('"%(policy)s".', policy),
+        measurement: measurement,
+      }),
+      alias='$tag_label_pairs_alias — $tag_label_pairs_name'
+    )
+);
+
+// Add first set of panels to the module: row, select operations, borders operations, select tuples details.
+local module = {
+  row:: common.row('CRUD module statistics'),
 
   select_success_rps(
     title=null,
@@ -569,538 +572,6 @@ local prometheus = grafana.prometheus;
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s'])
   ),
 
-  insert_success_rps(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    rate_time_range=null,
-  ):: operation_rps_object(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    rate_time_range=rate_time_range,
-    operation='insert',
-    status='ok',
-  ),
-
-  insert_success_latency(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-  ):: operation_latency_object(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    operation='insert',
-    status='ok',
-  ),
-
-  insert_error_rps(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    rate_time_range=null,
-  ):: operation_rps_object(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    rate_time_range=rate_time_range,
-    operation='insert',
-    status='error',
-  ),
-
-  insert_error_latency(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-  ):: operation_latency_object(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    operation='insert',
-    status='error',
-  ),
-
-  replace_success_rps(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    rate_time_range=null,
-  ):: operation_rps_object(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    rate_time_range=rate_time_range,
-    operation='replace',
-    status='ok',
-  ),
-
-  replace_success_latency(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-  ):: operation_latency_object(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    operation='replace',
-    status='ok',
-  ),
-
-  replace_error_rps(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    rate_time_range=null,
-  ):: operation_rps_object(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    rate_time_range=rate_time_range,
-    operation='replace',
-    status='error',
-  ),
-
-  replace_error_latency(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-  ):: operation_latency_object(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    operation='replace',
-    status='error',
-  ),
-
-  upsert_success_rps(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    rate_time_range=null,
-  ):: operation_rps_object(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    rate_time_range=rate_time_range,
-    operation='upsert',
-    status='ok',
-  ),
-
-  upsert_success_latency(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-  ):: operation_latency_object(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    operation='upsert',
-    status='ok',
-  ),
-
-  upsert_error_rps(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    rate_time_range=null,
-  ):: operation_rps_object(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    rate_time_range=rate_time_range,
-    operation='upsert',
-    status='error',
-  ),
-
-  upsert_error_latency(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-  ):: operation_latency_object(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    operation='upsert',
-    status='error',
-  ),
-
-  update_success_rps(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    rate_time_range=null,
-  ):: operation_rps(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    rate_time_range=rate_time_range,
-    operation='update',
-    status='ok',
-  ),
-
-  update_success_latency(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-  ):: operation_latency(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    operation='update',
-    status='ok',
-  ),
-
-  update_error_rps(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    rate_time_range=null,
-  ):: operation_rps(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    rate_time_range=rate_time_range,
-    operation='update',
-    status='error',
-  ),
-
-  update_error_latency(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-  ):: operation_latency(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    operation='update',
-    status='error',
-  ),
-
-  delete_success_rps(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    rate_time_range=null,
-  ):: operation_rps(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    rate_time_range=rate_time_range,
-    operation='delete',
-    status='ok',
-  ),
-
-  delete_success_latency(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-  ):: operation_latency(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    operation='delete',
-    status='ok',
-  ),
-
-  delete_error_rps(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    rate_time_range=null,
-  ):: operation_rps(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    rate_time_range=rate_time_range,
-    operation='delete',
-    status='error',
-  ),
-
-  delete_error_latency(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-  ):: operation_latency(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    operation='delete',
-    status='error',
-  ),
-
-  count_success_rps(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    rate_time_range=null,
-  ):: operation_rps(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    rate_time_range=rate_time_range,
-    operation='count',
-    status='ok',
-  ),
-
-  count_success_latency(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-  ):: operation_latency(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    operation='count',
-    status='ok',
-  ),
-
-  count_error_rps(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    rate_time_range=null,
-  ):: operation_rps(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    rate_time_range=rate_time_range,
-    operation='count',
-    status='error',
-  ),
-
-  count_error_latency(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-  ):: operation_latency(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    operation='count',
-    status='error',
-  ),
-
-  get_success_rps(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    rate_time_range=null,
-  ):: operation_rps(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    rate_time_range=rate_time_range,
-    operation='get',
-    status='ok',
-  ),
-
-  get_success_latency(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-  ):: operation_latency(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    operation='get',
-    status='ok',
-  ),
-
-  get_error_rps(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    rate_time_range=null,
-  ):: operation_rps(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    rate_time_range=rate_time_range,
-    operation='get',
-    status='error',
-  ),
-
-  get_error_latency(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-  ):: operation_latency(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    operation='get',
-    status='error',
-  ),
-
   borders_success_rps(
     title=null,
     description=null,
@@ -1172,156 +643,170 @@ local prometheus = grafana.prometheus;
     job=job,
     status='error',
   ),
+};
 
-  len_success_rps(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    rate_time_range=null,
-  ):: operation_rps(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    rate_time_range=rate_time_range,
-    operation='len',
-    status='ok',
-  ),
+local operations_with_object = ['insert', 'replace', 'upsert'];
 
-  len_success_latency(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-  ):: operation_latency(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    operation='len',
-    status='ok',
-  ),
+local operations_without_object = ['update', 'delete', 'get', 'len', 'truncate', 'count'];
 
-  len_error_rps(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    rate_time_range=null,
-  ):: operation_rps(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    rate_time_range=rate_time_range,
-    operation='len',
-    status='error',
-  ),
+// Add second set of panels to the module: panels for operations which have _object version.
+local module_with_object_panels = std.foldl(function(_module, operation) (
+  _module {
+    [std.format('%s_success_rps', operation)](
+      title=null,
+      description=null,
+      datasource=null,
+      policy=null,
+      measurement=null,
+      job=null,
+      rate_time_range=null,
+    ):: operation_rps_object(
+      title=title,
+      description=description,
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+      rate_time_range=rate_time_range,
+      operation=operation,
+      status='ok',
+    ),
 
-  len_error_latency(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-  ):: operation_latency(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    operation='len',
-    status='error',
-  ),
+    [std.format('%s_success_latency', operation)](
+      title=null,
+      description=null,
+      datasource=null,
+      policy=null,
+      measurement=null,
+      job=null,
+    ):: operation_latency_object(
+      title=title,
+      description=description,
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+      operation=operation,
+      status='ok',
+    ),
 
-  truncate_success_rps(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    rate_time_range=null,
-  ):: operation_rps(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    rate_time_range=rate_time_range,
-    operation='truncate',
-    status='ok',
-  ),
+    [std.format('%s_error_rps', operation)](
+      title=null,
+      description=null,
+      datasource=null,
+      policy=null,
+      measurement=null,
+      job=null,
+      rate_time_range=null,
+    ):: operation_rps_object(
+      title=title,
+      description=description,
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+      rate_time_range=rate_time_range,
+      operation=operation,
+      status='error',
+    ),
 
-  truncate_success_latency(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-  ):: operation_latency(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    operation='truncate',
-    status='ok',
-  ),
+    [std.format('%s_error_latency', operation)](
+      title=null,
+      description=null,
+      datasource=null,
+      policy=null,
+      measurement=null,
+      job=null,
+    ):: operation_latency_object(
+      title=title,
+      description=description,
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+      operation=operation,
+      status='error',
+    ),
+  }
+), operations_with_object, module);
 
-  truncate_error_rps(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-    rate_time_range=null,
-  ):: operation_rps(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    rate_time_range=rate_time_range,
-    operation='truncate',
-    status='error',
-  ),
+// Add last set of panels to the module: remaining operation panels without _object version.
+std.foldl(function(_module, operation) (
+  _module {
+    [std.format('%s_success_rps', operation)](
+      title=null,
+      description=null,
+      datasource=null,
+      policy=null,
+      measurement=null,
+      job=null,
+      rate_time_range=null,
+    ):: operation_rps(
+      title=title,
+      description=description,
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+      rate_time_range=rate_time_range,
+      operation=operation,
+      status='ok',
+    ),
 
-  truncate_error_latency(
-    title=null,
-    description=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-  ):: operation_latency(
-    title=title,
-    description=description,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    operation='truncate',
-    status='error',
-  ),
-}
+    [std.format('%s_success_latency', operation)](
+      title=null,
+      description=null,
+      datasource=null,
+      policy=null,
+      measurement=null,
+      job=null,
+    ):: operation_latency(
+      title=title,
+      description=description,
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+      operation=operation,
+      status='ok',
+    ),
+
+    [std.format('%s_error_rps', operation)](
+      title=null,
+      description=null,
+      datasource=null,
+      policy=null,
+      measurement=null,
+      job=null,
+      rate_time_range=null,
+    ):: operation_rps(
+      title=title,
+      description=description,
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+      rate_time_range=rate_time_range,
+      operation=operation,
+      status='error',
+    ),
+
+    [std.format('%s_error_latency', operation)](
+      title=null,
+      description=null,
+      datasource=null,
+      policy=null,
+      measurement=null,
+      job=null,
+    ):: operation_latency(
+      title=title,
+      description=description,
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+      operation=operation,
+      status='error',
+    ),
+  }
+), operations_without_object, module_with_object_panels)

--- a/dashboard/section.libsonnet
+++ b/dashboard/section.libsonnet
@@ -957,6 +957,36 @@ local tdg_tuples = import 'panels/tdg/tuples.libsonnet';
       job=job,
     ),
 
+    crud.insert_many_success_rps(
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+      rate_time_range=rate_time_range,
+    ),
+
+    crud.insert_many_success_latency(
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+    ),
+
+    crud.insert_many_error_rps(
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+      rate_time_range=rate_time_range,
+    ),
+
+    crud.insert_many_error_latency(
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+    ),
+
     crud.replace_success_rps(
       datasource=datasource,
       policy=policy,
@@ -987,6 +1017,36 @@ local tdg_tuples = import 'panels/tdg/tuples.libsonnet';
       job=job,
     ),
 
+    crud.replace_many_success_rps(
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+      rate_time_range=rate_time_range,
+    ),
+
+    crud.replace_many_success_latency(
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+    ),
+
+    crud.replace_many_error_rps(
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+      rate_time_range=rate_time_range,
+    ),
+
+    crud.replace_many_error_latency(
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+    ),
+
     crud.upsert_success_rps(
       datasource=datasource,
       policy=policy,
@@ -1011,6 +1071,36 @@ local tdg_tuples = import 'panels/tdg/tuples.libsonnet';
     ),
 
     crud.upsert_error_latency(
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+    ),
+
+    crud.upsert_many_success_rps(
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+      rate_time_range=rate_time_range,
+    ),
+
+    crud.upsert_many_success_latency(
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+    ),
+
+    crud.upsert_many_error_rps(
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+      rate_time_range=rate_time_range,
+    ),
+
+    crud.upsert_many_error_latency(
       datasource=datasource,
       policy=policy,
       measurement=measurement,

--- a/example_cluster/project/generate_load.lua
+++ b/example_cluster/project/generate_load.lua
@@ -167,6 +167,9 @@ local BORDERS = 'BORDERS'
 local COUNT = 'COUNT'
 local TRUNCATE = 'TRUNCATE'
 local BIG_SELECT = 'BIG_SELECT'
+local INSERT_MANY = 'INSERT_MANY'
+local REPLACE_MANY = 'REPLACE_MANY'
+local UPSERT_MANY = 'UPSERT_MANY'
 local truncate_inited = false
 local crud_index = 1
 local crud_space_1 = 'customers'
@@ -212,6 +215,37 @@ local function crud_operations_ok(instance, operation, count, space_name)
                 },
             })
             crud_index = crud_index + 1
+
+            if err ~= nil then
+                log.error(err)
+            end
+        end
+
+    elseif operation == INSERT_MANY then
+        for _ = 1, count do
+            local _, err = instance.net_box:call('crud.insert_many', {
+                space_name, {
+                    {
+                        crud_index,
+                        box.NULL,
+                        random_string(8),
+                        math.random(20, 30),
+                    },
+                    {
+                        crud_index + 1,
+                        box.NULL,
+                        random_string(8),
+                        math.random(20, 30),
+                    },
+                    {
+                        crud_index + 2,
+                        box.NULL,
+                        random_string(8),
+                        math.random(20, 30),
+                    },
+                },
+            })
+            crud_index = crud_index + 3
 
             if err ~= nil then
                 log.error(err)
@@ -264,6 +298,37 @@ local function crud_operations_ok(instance, operation, count, space_name)
             end
         end
 
+    elseif operation == UPSERT_MANY then
+        for _ = 1, count do
+            local _, err = instance.net_box:call('crud.upsert_many', {
+                space_name, {
+                    {{
+                        crud_index,
+                        box.NULL,
+                        random_string(8),
+                        math.random(20, 30),
+                    }, {}},
+                    {{
+                        crud_index + 1,
+                        box.NULL,
+                        random_string(8),
+                        math.random(20, 30),
+                    }, {}},
+                    {{
+                        crud_index + 2,
+                        box.NULL,
+                        random_string(8),
+                        math.random(20, 30),
+                    }, {}},
+                },
+            })
+            crud_index = crud_index + 3
+
+            if err ~= nil then
+                log.error(err)
+            end
+        end
+
     elseif operation == REPLACE then
         for _ = 1, count do
             local _, err = instance.net_box:call('crud.replace', {
@@ -275,6 +340,37 @@ local function crud_operations_ok(instance, operation, count, space_name)
                 },
             })
             crud_index = crud_index + 1
+
+            if err ~= nil then
+                log.error(err)
+            end
+        end
+
+    elseif operation == REPLACE_MANY then
+        for _ = 1, count do
+            local _, err = instance.net_box:call('crud.replace_many', {
+                space_name, {
+                    {
+                        crud_index,
+                        box.NULL,
+                        random_string(8),
+                        math.random(20, 30),
+                    },
+                    {
+                        crud_index + 1,
+                        box.NULL,
+                        random_string(8),
+                        math.random(20, 30),
+                    },
+                    {
+                        crud_index + 2,
+                        box.NULL,
+                        random_string(8),
+                        math.random(20, 30),
+                    },
+                },
+            })
+            crud_index = crud_index + 3
 
             if err ~= nil then
                 log.error(err)
@@ -373,6 +469,11 @@ local function crud_operations_err(instance, operation, count)
             instance.net_box:call('crud.insert', {crud_bad_space, {}})
         end
 
+    elseif operation == INSERT_MANY then
+        for _ = 1, count do
+            instance.net_box:call('crud.insert_many', {crud_bad_space, {{}}})
+        end
+
     elseif operation == UPDATE then
         for _ = 1, count do
             instance.net_box:call('crud.update', {
@@ -387,9 +488,21 @@ local function crud_operations_err(instance, operation, count)
             })
         end
 
+    elseif operation == UPSERT_MANY then
+        for _ = 1, count do
+            instance.net_box:call('crud.upsert_many', {
+                crud_bad_space, {{}, {{ '==', 3, random_string(5) }}}
+            })
+        end
+
     elseif operation == REPLACE then
         for _ = 1, count do
             instance.net_box:call('crud.replace', {crud_bad_space, {}})
+        end
+
+    elseif operation == REPLACE_MANY then
+        for _ = 1, count do
+            instance.net_box:call('crud.replace_many', {crud_bad_space, {{}}})
         end
 
     elseif operation == DELETE then
@@ -433,35 +546,44 @@ local function generate_crud_load(name, instance)
 
     if name:match('router') ~= nil then
         space_load_ok_1[INSERT] = math.random(3, 5)
+        space_load_ok_1[INSERT_MANY] = math.random(1, 2)
         space_load_ok_1[SELECT] = math.random(5, 10)
         space_load_ok_1[BIG_SELECT] = math.random(1, 3)
         space_load_ok_1[GET] = math.random(5, 10)
         space_load_ok_1[UPDATE] = math.random(2, 3)
         space_load_ok_1[REPLACE] = math.random(2, 3)
+        space_load_ok_1[REPLACE_MANY] = math.random(1, 2)
         space_load_ok_1[UPSERT] = math.random(1, 2)
+        space_load_ok_1[UPSERT_MANY] = math.random(1, 2)
         space_load_ok_1[DELETE] = math.random(1, 2)
         space_load_ok_1[LEN] = math.random(0, 1)
         space_load_ok_1[COUNT] = math.random(1, 2)
         space_load_ok_1[BORDERS] = math.random(1, 2)
 
         space_load_ok_2[INSERT] = math.random(6, 8)
+        space_load_ok_2[INSERT_MANY] = math.random(1, 2)
         space_load_ok_2[SELECT] = math.random(2, 4)
         space_load_ok_2[BIG_SELECT] = math.random(2, 4)
         space_load_ok_2[GET] = math.random(5, 10)
         space_load_ok_2[UPDATE] = math.random(2, 3)
         space_load_ok_2[REPLACE] = math.random(2, 3)
+        space_load_ok_2[REPLACE_MANY] = math.random(1, 2)
         space_load_ok_2[UPSERT] = math.random(1, 2)
+        space_load_ok_2[UPSERT_MANY] = math.random(1, 2)
         space_load_ok_2[DELETE] = math.random(1, 2)
         space_load_ok_2[LEN] = math.random(0, 1)
         space_load_ok_2[COUNT] = math.random(1, 2)
         space_load_ok_2[BORDERS] = math.random(1, 2)
 
         space_load_err[INSERT] = math.random(1, 3)
+        space_load_err[INSERT_MANY] = math.random(0, 1)
         space_load_err[SELECT] = math.random(2, 5)
         space_load_err[GET] = math.random(2, 5)
         space_load_err[UPDATE] = math.random(0, 1)
         space_load_err[REPLACE] = math.random(0, 1)
+        space_load_err[REPLACE_MANY] = math.random(0, 1)
         space_load_err[UPSERT] = math.random(0, 1)
+        space_load_err[UPSERT_MANY] = math.random(0, 1)
         space_load_err[DELETE] = math.random(0, 1)
         space_load_err[LEN] = math.random(0, 1)
         space_load_err[COUNT] = math.random(0, 1)

--- a/example_cluster/project/project-scm-1.rockspec
+++ b/example_cluster/project/project-scm-1.rockspec
@@ -11,7 +11,7 @@ dependencies = {
     'cartridge == 2.7.4-1',
     'metrics == 0.13.0-1',
     'cartridge-cli-extensions == 1.1.1-1',
-    'crud == 0.11.1',
+    'crud == 0.12.0',
     'expirationd == 1.2.0',
 }
 build = {

--- a/tests/InfluxDB/dashboard_compiled.json
+++ b/tests/InfluxDB/dashboard_compiled.json
@@ -14840,7 +14840,7 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 2,
-               "description": "Total count of success replace and replace_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "description": "Total count of success insert_many and insert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
@@ -14849,6 +14849,626 @@
                   "y": 308
                },
                "id": 119,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "insert_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "INSERT_MANY success requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": "requests per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 2,
+               "description": "99th percentile of success insert_many and insert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 6,
+                  "y": 308
+               },
+               "id": 120,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "insert_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "INSERT_MANY success requests latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "s",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 2,
+               "description": "Total count of error insert_many and insert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 12,
+                  "y": 308
+               },
+               "id": 121,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "insert_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "INSERT_MANY error requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": "requests per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 2,
+               "description": "99th percentile of error insert_many and insert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 18,
+                  "y": 308
+               },
+               "id": 122,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "insert_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "INSERT_MANY error requests latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "s",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 2,
+               "description": "Total count of success replace and replace_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 0,
+                  "y": 316
+               },
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15001,9 +15621,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 308
+                  "y": 316
                },
-               "id": 120,
+               "id": 124,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15156,9 +15776,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 308
+                  "y": 316
                },
-               "id": 121,
+               "id": 125,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15311,9 +15931,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 308
+                  "y": 316
                },
-               "id": 122,
+               "id": 126,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15460,15 +16080,635 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 2,
+               "description": "Total count of success replace_many and replace_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 0,
+                  "y": 324
+               },
+               "id": 127,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "replace_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "REPLACE_MANY success requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": "requests per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 2,
+               "description": "99th percentile of success replace_many and replace_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 6,
+                  "y": 324
+               },
+               "id": 128,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "replace_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "REPLACE_MANY success requests latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "s",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 2,
+               "description": "Total count of error replace_many and replace_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 12,
+                  "y": 324
+               },
+               "id": 129,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "replace_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "REPLACE_MANY error requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": "requests per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 2,
+               "description": "99th percentile of error replace_many and replace_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 18,
+                  "y": 324
+               },
+               "id": 130,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "replace_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "REPLACE_MANY error requests latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "s",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 2,
                "description": "Total count of success upsert and upsert_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 316
+                  "y": 332
                },
-               "id": 123,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15621,9 +16861,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 316
+                  "y": 332
                },
-               "id": 124,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15776,9 +17016,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 316
+                  "y": 332
                },
-               "id": 125,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15931,9 +17171,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 316
+                  "y": 332
                },
-               "id": 126,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16080,15 +17320,635 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 2,
+               "description": "Total count of success upsert_many and upsert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 0,
+                  "y": 340
+               },
+               "id": 135,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "upsert_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "UPSERT_MANY success requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": "requests per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 2,
+               "description": "99th percentile of success upsert_many and upsert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 6,
+                  "y": 340
+               },
+               "id": 136,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "upsert_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "UPSERT_MANY success requests latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "s",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 2,
+               "description": "Total count of error upsert_many and upsert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 12,
+                  "y": 340
+               },
+               "id": 137,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "upsert_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "UPSERT_MANY error requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": "requests per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 2,
+               "description": "99th percentile of error upsert_many and upsert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 18,
+                  "y": 340
+               },
+               "id": 138,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "upsert_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "UPSERT_MANY error requests latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "s",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 2,
                "description": "Total count of success update requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 324
+                  "y": 348
                },
-               "id": 127,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16241,9 +18101,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 324
+                  "y": 348
                },
-               "id": 128,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16396,9 +18256,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 324
+                  "y": 348
                },
-               "id": 129,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16551,9 +18411,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 324
+                  "y": 348
                },
-               "id": 130,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16706,9 +18566,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 332
+                  "y": 356
                },
-               "id": 131,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16861,9 +18721,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 332
+                  "y": 356
                },
-               "id": 132,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17016,9 +18876,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 332
+                  "y": 356
                },
-               "id": 133,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17171,9 +19031,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 332
+                  "y": 356
                },
-               "id": 134,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17326,9 +19186,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 340
+                  "y": 364
                },
-               "id": 135,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17481,9 +19341,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 340
+                  "y": 364
                },
-               "id": 136,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17636,9 +19496,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 340
+                  "y": 364
                },
-               "id": 137,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17791,9 +19651,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 340
+                  "y": 364
                },
-               "id": 138,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17946,9 +19806,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 348
+                  "y": 372
                },
-               "id": 139,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18101,9 +19961,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 348
+                  "y": 372
                },
-               "id": 140,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18256,9 +20116,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 348
+                  "y": 372
                },
-               "id": 141,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18411,9 +20271,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 348
+                  "y": 372
                },
-               "id": 142,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18566,9 +20426,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 356
+                  "y": 380
                },
-               "id": 143,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18721,9 +20581,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 356
+                  "y": 380
                },
-               "id": 144,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18876,9 +20736,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 356
+                  "y": 380
                },
-               "id": 145,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19031,9 +20891,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 356
+                  "y": 380
                },
-               "id": 146,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19186,9 +21046,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 364
+                  "y": 388
                },
-               "id": 147,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19341,9 +21201,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 364
+                  "y": 388
                },
-               "id": 148,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19496,9 +21356,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 364
+                  "y": 388
                },
-               "id": 149,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19651,9 +21511,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 364
+                  "y": 388
                },
-               "id": 150,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19806,9 +21666,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 372
+                  "y": 396
                },
-               "id": 151,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19961,9 +21821,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 372
+                  "y": 396
                },
-               "id": 152,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20116,9 +21976,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 372
+                  "y": 396
                },
-               "id": 153,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20271,9 +22131,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 372
+                  "y": 396
                },
-               "id": 154,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20429,9 +22289,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 380
+            "y": 404
          },
-         "id": 155,
+         "id": 167,
          "panels": [
             {
                "aliasColors": { },
@@ -20446,9 +22306,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 381
+                  "y": 405
                },
-               "id": 156,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20589,9 +22449,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 381
+                  "y": 405
                },
-               "id": 157,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20732,9 +22592,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 389
+                  "y": 413
                },
-               "id": 158,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20869,9 +22729,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 389
+                  "y": 413
                },
-               "id": 159,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
+++ b/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
@@ -14840,7 +14840,7 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 2,
-               "description": "Total count of success replace and replace_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "description": "Total count of success insert_many and insert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
@@ -14849,6 +14849,626 @@
                   "y": 308
                },
                "id": 119,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "insert_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "INSERT_MANY success requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": "requests per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 2,
+               "description": "99th percentile of success insert_many and insert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 6,
+                  "y": 308
+               },
+               "id": 120,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "insert_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "INSERT_MANY success requests latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "s",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 2,
+               "description": "Total count of error insert_many and insert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 12,
+                  "y": 308
+               },
+               "id": 121,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "insert_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "INSERT_MANY error requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": "requests per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 2,
+               "description": "99th percentile of error insert_many and insert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 18,
+                  "y": 308
+               },
+               "id": 122,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "insert_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "INSERT_MANY error requests latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "s",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 2,
+               "description": "Total count of success replace and replace_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 0,
+                  "y": 316
+               },
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15001,9 +15621,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 308
+                  "y": 316
                },
-               "id": 120,
+               "id": 124,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15156,9 +15776,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 308
+                  "y": 316
                },
-               "id": 121,
+               "id": 125,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15311,9 +15931,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 308
+                  "y": 316
                },
-               "id": 122,
+               "id": 126,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15460,15 +16080,635 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 2,
+               "description": "Total count of success replace_many and replace_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 0,
+                  "y": 324
+               },
+               "id": 127,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "replace_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "REPLACE_MANY success requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": "requests per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 2,
+               "description": "99th percentile of success replace_many and replace_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 6,
+                  "y": 324
+               },
+               "id": 128,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "replace_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "REPLACE_MANY success requests latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "s",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 2,
+               "description": "Total count of error replace_many and replace_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 12,
+                  "y": 324
+               },
+               "id": 129,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "replace_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "REPLACE_MANY error requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": "requests per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 2,
+               "description": "99th percentile of error replace_many and replace_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 18,
+                  "y": 324
+               },
+               "id": 130,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "replace_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "REPLACE_MANY error requests latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "s",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 2,
                "description": "Total count of success upsert and upsert_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 316
+                  "y": 332
                },
-               "id": 123,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15621,9 +16861,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 316
+                  "y": 332
                },
-               "id": 124,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15776,9 +17016,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 316
+                  "y": 332
                },
-               "id": 125,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15931,9 +17171,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 316
+                  "y": 332
                },
-               "id": 126,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16080,15 +17320,635 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 2,
+               "description": "Total count of success upsert_many and upsert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 0,
+                  "y": 340
+               },
+               "id": 135,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "upsert_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "UPSERT_MANY success requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": "requests per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 2,
+               "description": "99th percentile of success upsert_many and upsert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 6,
+                  "y": 340
+               },
+               "id": 136,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "upsert_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "UPSERT_MANY success requests latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "s",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 2,
+               "description": "Total count of error upsert_many and upsert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 12,
+                  "y": 340
+               },
+               "id": 137,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "upsert_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "UPSERT_MANY error requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": "requests per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 2,
+               "description": "99th percentile of error upsert_many and upsert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 18,
+                  "y": 340
+               },
+               "id": 138,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "upsert_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "UPSERT_MANY error requests latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "s",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 2,
                "description": "Total count of success update requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 324
+                  "y": 348
                },
-               "id": 127,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16241,9 +18101,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 324
+                  "y": 348
                },
-               "id": 128,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16396,9 +18256,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 324
+                  "y": 348
                },
-               "id": 129,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16551,9 +18411,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 324
+                  "y": 348
                },
-               "id": 130,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16706,9 +18566,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 332
+                  "y": 356
                },
-               "id": 131,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16861,9 +18721,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 332
+                  "y": 356
                },
-               "id": 132,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17016,9 +18876,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 332
+                  "y": 356
                },
-               "id": 133,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17171,9 +19031,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 332
+                  "y": 356
                },
-               "id": 134,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17326,9 +19186,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 340
+                  "y": 364
                },
-               "id": 135,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17481,9 +19341,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 340
+                  "y": 364
                },
-               "id": 136,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17636,9 +19496,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 340
+                  "y": 364
                },
-               "id": 137,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17791,9 +19651,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 340
+                  "y": 364
                },
-               "id": 138,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17946,9 +19806,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 348
+                  "y": 372
                },
-               "id": 139,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18101,9 +19961,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 348
+                  "y": 372
                },
-               "id": 140,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18256,9 +20116,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 348
+                  "y": 372
                },
-               "id": 141,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18411,9 +20271,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 348
+                  "y": 372
                },
-               "id": 142,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18566,9 +20426,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 356
+                  "y": 380
                },
-               "id": 143,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18721,9 +20581,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 356
+                  "y": 380
                },
-               "id": 144,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18876,9 +20736,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 356
+                  "y": 380
                },
-               "id": 145,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19031,9 +20891,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 356
+                  "y": 380
                },
-               "id": 146,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19186,9 +21046,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 364
+                  "y": 388
                },
-               "id": 147,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19341,9 +21201,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 364
+                  "y": 388
                },
-               "id": 148,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19496,9 +21356,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 364
+                  "y": 388
                },
-               "id": 149,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19651,9 +21511,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 364
+                  "y": 388
                },
-               "id": 150,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19806,9 +21666,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 372
+                  "y": 396
                },
-               "id": 151,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19961,9 +21821,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 372
+                  "y": 396
                },
-               "id": 152,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20116,9 +21976,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 372
+                  "y": 396
                },
-               "id": 153,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20271,9 +22131,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 372
+                  "y": 396
                },
-               "id": 154,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20429,9 +22289,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 380
+            "y": 404
          },
-         "id": 155,
+         "id": 167,
          "panels": [
             {
                "aliasColors": { },
@@ -20446,9 +22306,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 381
+                  "y": 405
                },
-               "id": 156,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20589,9 +22449,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 381
+                  "y": 405
                },
-               "id": 157,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20732,9 +22592,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 389
+                  "y": 413
                },
-               "id": 158,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20869,9 +22729,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 389
+                  "y": 413
                },
-               "id": 159,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21009,9 +22869,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 397
+            "y": 421
          },
-         "id": 160,
+         "id": 172,
          "panels": [
             {
                "aliasColors": { },
@@ -21026,9 +22886,9 @@
                   "h": 6,
                   "w": 24,
                   "x": 0,
-                  "y": 398
+                  "y": 422
                },
-               "id": 161,
+               "id": 173,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21157,9 +23017,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 404
+                  "y": 428
                },
-               "id": 162,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21294,9 +23154,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 404
+                  "y": 428
                },
-               "id": 163,
+               "id": 175,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_compiled.json
+++ b/tests/Prometheus/dashboard_compiled.json
@@ -10196,7 +10196,7 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 2,
-               "description": "Total count of success replace and replace_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
+               "description": "Total count of success insert_many and insert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
                "fill": 0,
                "gridPos": {
                   "h": 8,
@@ -10205,6 +10205,366 @@
                   "y": 316
                },
                "id": 126,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"insert_many\",status=\"ok\"}[$rate_time_range])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}} — {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "INSERT_MANY success requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": "requests per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 2,
+               "description": "99th percentile of success insert_many and insert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 6,
+                  "y": 316
+               },
+               "id": 127,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"insert_many\",status=\"ok\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}} — {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "INSERT_MANY success requests latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "s",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 2,
+               "description": "Total count of error insert_many and insert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 12,
+                  "y": 316
+               },
+               "id": 128,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"insert_many\",status=\"error\"}[$rate_time_range])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}} — {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "INSERT_MANY error requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": "requests per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 2,
+               "description": "99th percentile of error insert_many and insert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 18,
+                  "y": 316
+               },
+               "id": 129,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"insert_many\",status=\"error\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}} — {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "INSERT_MANY error requests latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "s",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 2,
+               "description": "Total count of success replace and replace_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 0,
+                  "y": 324
+               },
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10292,9 +10652,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 316
+                  "y": 324
                },
-               "id": 127,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10382,9 +10742,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 316
+                  "y": 324
                },
-               "id": 128,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10472,9 +10832,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 316
+                  "y": 324
                },
-               "id": 129,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10556,15 +10916,375 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 2,
+               "description": "Total count of success replace_many and replace_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 0,
+                  "y": 332
+               },
+               "id": 134,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"replace_many\",status=\"ok\"}[$rate_time_range])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}} — {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "REPLACE_MANY success requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": "requests per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 2,
+               "description": "99th percentile of success replace_many and replace_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 6,
+                  "y": 332
+               },
+               "id": 135,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"replace_many\",status=\"ok\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}} — {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "REPLACE_MANY success requests latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "s",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 2,
+               "description": "Total count of error replace_many and replace_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 12,
+                  "y": 332
+               },
+               "id": 136,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"replace_many\",status=\"error\"}[$rate_time_range])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}} — {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "REPLACE_MANY error requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": "requests per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 2,
+               "description": "99th percentile of error replace_many and replace_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 18,
+                  "y": 332
+               },
+               "id": 137,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"replace_many\",status=\"error\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}} — {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "REPLACE_MANY error requests latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "s",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 2,
                "description": "Total count of success upsert and upsert_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 324
+                  "y": 340
                },
-               "id": 130,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10652,9 +11372,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 324
+                  "y": 340
                },
-               "id": 131,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10742,9 +11462,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 324
+                  "y": 340
                },
-               "id": 132,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10832,9 +11552,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 324
+                  "y": 340
                },
-               "id": 133,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10916,15 +11636,375 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 2,
+               "description": "Total count of success upsert_many and upsert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 0,
+                  "y": 348
+               },
+               "id": 142,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"upsert_many\",status=\"ok\"}[$rate_time_range])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}} — {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "UPSERT_MANY success requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": "requests per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 2,
+               "description": "99th percentile of success upsert_many and upsert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 6,
+                  "y": 348
+               },
+               "id": 143,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"upsert_many\",status=\"ok\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}} — {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "UPSERT_MANY success requests latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "s",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 2,
+               "description": "Total count of error upsert_many and upsert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 12,
+                  "y": 348
+               },
+               "id": 144,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"upsert_many\",status=\"error\"}[$rate_time_range])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}} — {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "UPSERT_MANY error requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": "requests per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 2,
+               "description": "99th percentile of error upsert_many and upsert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 18,
+                  "y": 348
+               },
+               "id": 145,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"upsert_many\",status=\"error\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}} — {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "UPSERT_MANY error requests latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "s",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 2,
                "description": "Total count of success update requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 332
+                  "y": 356
                },
-               "id": 134,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11012,9 +12092,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 332
+                  "y": 356
                },
-               "id": 135,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11102,9 +12182,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 332
+                  "y": 356
                },
-               "id": 136,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11192,9 +12272,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 332
+                  "y": 356
                },
-               "id": 137,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11282,9 +12362,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 340
+                  "y": 364
                },
-               "id": 138,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11372,9 +12452,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 340
+                  "y": 364
                },
-               "id": 139,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11462,9 +12542,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 340
+                  "y": 364
                },
-               "id": 140,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11552,9 +12632,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 340
+                  "y": 364
                },
-               "id": 141,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11642,9 +12722,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 348
+                  "y": 372
                },
-               "id": 142,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11732,9 +12812,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 348
+                  "y": 372
                },
-               "id": 143,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11822,9 +12902,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 348
+                  "y": 372
                },
-               "id": 144,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11912,9 +12992,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 348
+                  "y": 372
                },
-               "id": 145,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12002,9 +13082,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 356
+                  "y": 380
                },
-               "id": 146,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12092,9 +13172,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 356
+                  "y": 380
                },
-               "id": 147,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12182,9 +13262,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 356
+                  "y": 380
                },
-               "id": 148,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12272,9 +13352,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 356
+                  "y": 380
                },
-               "id": 149,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12362,9 +13442,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 364
+                  "y": 388
                },
-               "id": 150,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12452,9 +13532,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 364
+                  "y": 388
                },
-               "id": 151,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12542,9 +13622,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 364
+                  "y": 388
                },
-               "id": 152,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12632,9 +13712,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 364
+                  "y": 388
                },
-               "id": 153,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12722,9 +13802,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 372
+                  "y": 396
                },
-               "id": 154,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12812,9 +13892,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 372
+                  "y": 396
                },
-               "id": 155,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12902,9 +13982,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 372
+                  "y": 396
                },
-               "id": 156,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12992,9 +14072,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 372
+                  "y": 396
                },
-               "id": 157,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13082,9 +14162,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 380
+                  "y": 404
                },
-               "id": 158,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13172,9 +14252,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 380
+                  "y": 404
                },
-               "id": 159,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13262,9 +14342,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 380
+                  "y": 404
                },
-               "id": 160,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13352,9 +14432,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 380
+                  "y": 404
                },
-               "id": 161,
+               "id": 173,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13445,9 +14525,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 388
+            "y": 412
          },
-         "id": 162,
+         "id": 174,
          "panels": [
             {
                "aliasColors": { },
@@ -13462,9 +14542,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 389
+                  "y": 413
                },
-               "id": 163,
+               "id": 175,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13552,9 +14632,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 389
+                  "y": 413
                },
-               "id": 164,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13642,9 +14722,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 397
+                  "y": 421
                },
-               "id": 165,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13732,9 +14812,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 397
+                  "y": 421
                },
-               "id": 166,
+               "id": 178,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_with_custom_panels_compiled.json
+++ b/tests/Prometheus/dashboard_with_custom_panels_compiled.json
@@ -10196,7 +10196,7 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 2,
-               "description": "Total count of success replace and replace_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
+               "description": "Total count of success insert_many and insert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
                "fill": 0,
                "gridPos": {
                   "h": 8,
@@ -10205,6 +10205,366 @@
                   "y": 316
                },
                "id": 126,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"insert_many\",status=\"ok\"}[$rate_time_range])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}} — {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "INSERT_MANY success requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": "requests per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 2,
+               "description": "99th percentile of success insert_many and insert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 6,
+                  "y": 316
+               },
+               "id": 127,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"insert_many\",status=\"ok\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}} — {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "INSERT_MANY success requests latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "s",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 2,
+               "description": "Total count of error insert_many and insert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 12,
+                  "y": 316
+               },
+               "id": 128,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"insert_many\",status=\"error\"}[$rate_time_range])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}} — {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "INSERT_MANY error requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": "requests per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 2,
+               "description": "99th percentile of error insert_many and insert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 18,
+                  "y": 316
+               },
+               "id": 129,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"insert_many\",status=\"error\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}} — {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "INSERT_MANY error requests latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "s",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 2,
+               "description": "Total count of success replace and replace_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 0,
+                  "y": 324
+               },
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10292,9 +10652,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 316
+                  "y": 324
                },
-               "id": 127,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10382,9 +10742,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 316
+                  "y": 324
                },
-               "id": 128,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10472,9 +10832,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 316
+                  "y": 324
                },
-               "id": 129,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10556,15 +10916,375 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 2,
+               "description": "Total count of success replace_many and replace_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 0,
+                  "y": 332
+               },
+               "id": 134,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"replace_many\",status=\"ok\"}[$rate_time_range])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}} — {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "REPLACE_MANY success requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": "requests per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 2,
+               "description": "99th percentile of success replace_many and replace_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 6,
+                  "y": 332
+               },
+               "id": 135,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"replace_many\",status=\"ok\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}} — {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "REPLACE_MANY success requests latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "s",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 2,
+               "description": "Total count of error replace_many and replace_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 12,
+                  "y": 332
+               },
+               "id": 136,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"replace_many\",status=\"error\"}[$rate_time_range])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}} — {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "REPLACE_MANY error requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": "requests per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 2,
+               "description": "99th percentile of error replace_many and replace_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 18,
+                  "y": 332
+               },
+               "id": 137,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"replace_many\",status=\"error\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}} — {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "REPLACE_MANY error requests latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "s",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 2,
                "description": "Total count of success upsert and upsert_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 324
+                  "y": 340
                },
-               "id": 130,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10652,9 +11372,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 324
+                  "y": 340
                },
-               "id": 131,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10742,9 +11462,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 324
+                  "y": 340
                },
-               "id": 132,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10832,9 +11552,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 324
+                  "y": 340
                },
-               "id": 133,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10916,15 +11636,375 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 2,
+               "description": "Total count of success upsert_many and upsert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 0,
+                  "y": 348
+               },
+               "id": 142,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"upsert_many\",status=\"ok\"}[$rate_time_range])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}} — {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "UPSERT_MANY success requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": "requests per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 2,
+               "description": "99th percentile of success upsert_many and upsert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 6,
+                  "y": 348
+               },
+               "id": 143,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"upsert_many\",status=\"ok\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}} — {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "UPSERT_MANY success requests latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "s",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 2,
+               "description": "Total count of error upsert_many and upsert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 12,
+                  "y": 348
+               },
+               "id": 144,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"upsert_many\",status=\"error\"}[$rate_time_range])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}} — {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "UPSERT_MANY error requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": "requests per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 2,
+               "description": "99th percentile of error upsert_many and upsert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 18,
+                  "y": 348
+               },
+               "id": 145,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"upsert_many\",status=\"error\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}} — {{name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "UPSERT_MANY error requests latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "s",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 2,
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 2,
                "description": "Total count of success update requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n\n\nIf `No data` displayed, check up your 'rate_time_range' variable.",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 332
+                  "y": 356
                },
-               "id": 134,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11012,9 +12092,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 332
+                  "y": 356
                },
-               "id": 135,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11102,9 +12182,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 332
+                  "y": 356
                },
-               "id": 136,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11192,9 +12272,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 332
+                  "y": 356
                },
-               "id": 137,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11282,9 +12362,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 340
+                  "y": 364
                },
-               "id": 138,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11372,9 +12452,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 340
+                  "y": 364
                },
-               "id": 139,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11462,9 +12542,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 340
+                  "y": 364
                },
-               "id": 140,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11552,9 +12632,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 340
+                  "y": 364
                },
-               "id": 141,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11642,9 +12722,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 348
+                  "y": 372
                },
-               "id": 142,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11732,9 +12812,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 348
+                  "y": 372
                },
-               "id": 143,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11822,9 +12902,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 348
+                  "y": 372
                },
-               "id": 144,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11912,9 +12992,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 348
+                  "y": 372
                },
-               "id": 145,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12002,9 +13082,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 356
+                  "y": 380
                },
-               "id": 146,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12092,9 +13172,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 356
+                  "y": 380
                },
-               "id": 147,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12182,9 +13262,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 356
+                  "y": 380
                },
-               "id": 148,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12272,9 +13352,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 356
+                  "y": 380
                },
-               "id": 149,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12362,9 +13442,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 364
+                  "y": 388
                },
-               "id": 150,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12452,9 +13532,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 364
+                  "y": 388
                },
-               "id": 151,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12542,9 +13622,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 364
+                  "y": 388
                },
-               "id": 152,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12632,9 +13712,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 364
+                  "y": 388
                },
-               "id": 153,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12722,9 +13802,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 372
+                  "y": 396
                },
-               "id": 154,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12812,9 +13892,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 372
+                  "y": 396
                },
-               "id": 155,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12902,9 +13982,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 372
+                  "y": 396
                },
-               "id": 156,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12992,9 +14072,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 372
+                  "y": 396
                },
-               "id": 157,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13082,9 +14162,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 380
+                  "y": 404
                },
-               "id": 158,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13172,9 +14252,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 380
+                  "y": 404
                },
-               "id": 159,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13262,9 +14342,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 380
+                  "y": 404
                },
-               "id": 160,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13352,9 +14432,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 380
+                  "y": 404
                },
-               "id": 161,
+               "id": 173,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13445,9 +14525,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 388
+            "y": 412
          },
-         "id": 162,
+         "id": 174,
          "panels": [
             {
                "aliasColors": { },
@@ -13462,9 +14542,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 389
+                  "y": 413
                },
-               "id": 163,
+               "id": 175,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13552,9 +14632,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 389
+                  "y": 413
                },
-               "id": 164,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13642,9 +14722,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 397
+                  "y": 421
                },
-               "id": 165,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13732,9 +14812,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 397
+                  "y": 421
                },
-               "id": 166,
+               "id": 178,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13825,9 +14905,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 405
+            "y": 429
          },
-         "id": 167,
+         "id": 179,
          "panels": [
             {
                "aliasColors": { },
@@ -13842,9 +14922,9 @@
                   "h": 6,
                   "w": 24,
                   "x": 0,
-                  "y": 406
+                  "y": 430
                },
-               "id": 168,
+               "id": 180,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13932,9 +15012,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 412
+                  "y": 436
                },
-               "id": 169,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14022,9 +15102,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 412
+                  "y": 436
                },
-               "id": 170,
+               "id": 182,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,


### PR DESCRIPTION
### dashboard: build CRUD panels lib with foldl

This patch is a code health patch that introduces two foldl calls
to build similar CRUD panels in cycle instead of copypaste.

### dashboard: add CRUD many operations panels

CRUD 0.12.0 introduced insert_many, insert_object_many, replace_many,
replace_object_many, upsert_many, upsert_object_many operations and
corresponding metrics labels. This patch adds panels for them.

![image](https://user-images.githubusercontent.com/20455996/180185472-0b210937-b734-4138-a753-e1a860c83194.png)
![image](https://user-images.githubusercontent.com/20455996/180185500-30e79821-dfce-4c67-8871-17d5dc42b358.png)
![image](https://user-images.githubusercontent.com/20455996/180185532-360e70b6-decb-46f8-b196-890e414230fd.png)

1. https://github.com/tarantool/crud/releases/tag/0.12.0

Closes #165