### PR TITLE
dashboard: add runtime arena memory panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 - Options to build static dashboards
+- Runtime arena memory panel
 
 ## Changed
 - Set default Prometheus job to `tarantool`

--- a/dashboard/panels/runtime.libsonnet
+++ b/dashboard/panels/runtime.libsonnet
@@ -4,9 +4,10 @@ local common = import 'dashboard/panels/common.libsonnet';
   row:: common.row('Tarantool runtime overview'),
 
   lua_memory(
-    title='Lua runtime memory',
+    title='Lua memory',
     description=|||
-      Memory used for the Lua runtime.
+      Memory used for objects allocated with Lua
+      by using its internal mechanisms.
       Lua memory is bounded by 2 GB per instance. 
     |||,
     datasource_type=null,
@@ -20,10 +21,42 @@ local common = import 'dashboard/panels/common.libsonnet';
     datasource=datasource,
     format='bytes',
     labelY1='in bytes',
-    panel_width=12,
+    panel_width=8,
   ).addTarget(common.default_metric_target(
     datasource_type,
     'tnt_info_memory_lua',
+    job,
+    policy,
+    measurement
+  )),
+
+  runtime_memory(
+    title='Runtime arena memory',
+    description=|||
+      Memory used by runtime arena.
+      Runtime arena stores network buffers, tuples
+      created with box.tuple.new and other objects
+      allocated by application not covered by basic
+      Lua mechanisms (spaces data and indexes
+      are not included here, see memtx/vinyl arena).
+    |||,
+    datasource_type=null,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+  ):: common.default_graph(
+    title=title,
+    description=description,
+    datasource=datasource,
+    format='bytes',
+    labelY1='in bytes',
+    legend_avg=false,
+    legend_max=false,
+    panel_width=8,
+  ).addTarget(common.default_metric_target(
+    datasource_type,
+    'tnt_runtime_used',
     job,
     policy,
     measurement
@@ -48,7 +81,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     datasource=datasource,
     format='bytes',
     labelY1='in bytes',
-    panel_width=12,
+    panel_width=8,
   ).addTarget(common.default_metric_target(
     datasource_type,
     'tnt_info_memory_tx',

--- a/dashboard/section.libsonnet
+++ b/dashboard/section.libsonnet
@@ -627,6 +627,14 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       job=job,
     ),
 
+    runtime.runtime_memory(
+      datasource_type=datasource_type,
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+    ),
+
     runtime.memory_tx(
       datasource_type=datasource_type,
       datasource=datasource,

--- a/tests/InfluxDB/dashboard_compiled.json
+++ b/tests/InfluxDB/dashboard_compiled.json
@@ -7978,11 +7978,11 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 3,
-               "description": "Memory used for the Lua runtime.\nLua memory is bounded by 2 GB per instance. \n",
+               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance. \n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 177
                },
@@ -8067,7 +8067,138 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Lua runtime memory",
+               "title": "Lua memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 3,
+               "description": "Memory used by runtime arena.\nRuntime arena stores network buffers, tuples\ncreated with box.tuple.new and other objects\nallocated by application not covered by basic\nLua mechanisms (spaces data and indexes\nare not included here, see memtx/vinyl arena).\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 177
+               },
+               "id": 68,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_runtime_used"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Runtime arena memory",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -8113,11 +8244,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 177
                },
-               "id": 68,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8248,7 +8379,7 @@
                   "x": 0,
                   "y": 185
                },
-               "id": 69,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8379,7 +8510,7 @@
                   "x": 12,
                   "y": 185
                },
-               "id": 70,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8510,7 +8641,7 @@
                   "x": 0,
                   "y": 193
                },
-               "id": 71,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -8641,7 +8772,7 @@
                   "x": 8,
                   "y": 193
                },
-               "id": 72,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8772,7 +8903,7 @@
                   "x": 16,
                   "y": 193
                },
-               "id": 73,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8906,7 +9037,7 @@
             "x": 0,
             "y": 201
          },
-         "id": 74,
+         "id": 75,
          "panels": [
             {
                "aliasColors": { },
@@ -8923,7 +9054,7 @@
                   "x": 0,
                   "y": 202
                },
-               "id": 75,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9060,7 +9191,7 @@
                   "x": 6,
                   "y": 202
                },
-               "id": 76,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9197,7 +9328,7 @@
                   "x": 12,
                   "y": 202
                },
-               "id": 77,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9334,7 +9465,7 @@
                   "x": 18,
                   "y": 202
                },
-               "id": 78,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9465,7 +9596,7 @@
                   "x": 0,
                   "y": 210
                },
-               "id": 79,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9602,7 +9733,7 @@
                   "x": 12,
                   "y": 210
                },
-               "id": 80,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9739,7 +9870,7 @@
                   "x": 0,
                   "y": 218
                },
-               "id": 81,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9876,7 +10007,7 @@
                   "x": 8,
                   "y": 218
                },
-               "id": 82,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10013,7 +10144,7 @@
                   "x": 16,
                   "y": 218
                },
-               "id": 83,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10150,7 +10281,7 @@
                   "x": 0,
                   "y": 226
                },
-               "id": 84,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10287,7 +10418,7 @@
                   "x": 8,
                   "y": 226
                },
-               "id": 85,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10424,7 +10555,7 @@
                   "x": 16,
                   "y": 226
                },
-               "id": 86,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10561,7 +10692,7 @@
                   "x": 0,
                   "y": 234
                },
-               "id": 87,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10692,7 +10823,7 @@
                   "x": 6,
                   "y": 234
                },
-               "id": 88,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10823,7 +10954,7 @@
                   "x": 12,
                   "y": 234
                },
-               "id": 89,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10954,7 +11085,7 @@
                   "x": 18,
                   "y": 234
                },
-               "id": 90,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11085,7 +11216,7 @@
                   "x": 0,
                   "y": 242
                },
-               "id": 91,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11216,7 +11347,7 @@
                   "x": 8,
                   "y": 242
                },
-               "id": 92,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11353,7 +11484,7 @@
                   "x": 16,
                   "y": 242
                },
-               "id": 93,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11493,7 +11624,7 @@
             "x": 0,
             "y": 250
          },
-         "id": 94,
+         "id": 95,
          "panels": [
             {
                "aliasColors": { },
@@ -11510,7 +11641,7 @@
                   "x": 0,
                   "y": 251
                },
-               "id": 95,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11653,7 +11784,7 @@
                   "x": 8,
                   "y": 251
                },
-               "id": 96,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11796,7 +11927,7 @@
                   "x": 16,
                   "y": 251
                },
-               "id": 97,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11939,7 +12070,7 @@
                   "x": 0,
                   "y": 259
                },
-               "id": 98,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12082,7 +12213,7 @@
                   "x": 8,
                   "y": 259
                },
-               "id": 99,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12225,7 +12356,7 @@
                   "x": 16,
                   "y": 259
                },
-               "id": 100,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12368,7 +12499,7 @@
                   "x": 0,
                   "y": 267
                },
-               "id": 101,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12511,7 +12642,7 @@
                   "x": 8,
                   "y": 267
                },
-               "id": 102,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12654,7 +12785,7 @@
                   "x": 16,
                   "y": 267
                },
-               "id": 103,
+               "id": 104,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12797,7 +12928,7 @@
                   "x": 0,
                   "y": 275
                },
-               "id": 104,
+               "id": 105,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12940,7 +13071,7 @@
                   "x": 8,
                   "y": 275
                },
-               "id": 105,
+               "id": 106,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13083,7 +13214,7 @@
                   "x": 16,
                   "y": 275
                },
-               "id": 106,
+               "id": 107,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13229,7 +13360,7 @@
             "x": 0,
             "y": 283
          },
-         "id": 107,
+         "id": 108,
          "panels": [
             {
                "aliasColors": { },
@@ -13246,7 +13377,7 @@
                   "x": 0,
                   "y": 284
                },
-               "id": 108,
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13401,7 +13532,7 @@
                   "x": 6,
                   "y": 284
                },
-               "id": 109,
+               "id": 110,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13556,7 +13687,7 @@
                   "x": 12,
                   "y": 284
                },
-               "id": 110,
+               "id": 111,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13711,7 +13842,7 @@
                   "x": 18,
                   "y": 284
                },
-               "id": 111,
+               "id": 112,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13866,7 +13997,7 @@
                   "x": 0,
                   "y": 292
                },
-               "id": 112,
+               "id": 113,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13973,7 +14104,7 @@
                   "x": 8,
                   "y": 292
                },
-               "id": 113,
+               "id": 114,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14080,7 +14211,7 @@
                   "x": 16,
                   "y": 292
                },
-               "id": 114,
+               "id": 115,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14229,7 +14360,7 @@
                   "x": 0,
                   "y": 300
                },
-               "id": 115,
+               "id": 116,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14384,7 +14515,7 @@
                   "x": 6,
                   "y": 300
                },
-               "id": 116,
+               "id": 117,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14539,7 +14670,7 @@
                   "x": 12,
                   "y": 300
                },
-               "id": 117,
+               "id": 118,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14694,7 +14825,7 @@
                   "x": 18,
                   "y": 300
                },
-               "id": 118,
+               "id": 119,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14849,7 +14980,7 @@
                   "x": 0,
                   "y": 308
                },
-               "id": 119,
+               "id": 120,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15004,7 +15135,7 @@
                   "x": 6,
                   "y": 308
                },
-               "id": 120,
+               "id": 121,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15159,7 +15290,7 @@
                   "x": 12,
                   "y": 308
                },
-               "id": 121,
+               "id": 122,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15314,7 +15445,7 @@
                   "x": 18,
                   "y": 308
                },
-               "id": 122,
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15469,7 +15600,7 @@
                   "x": 0,
                   "y": 316
                },
-               "id": 123,
+               "id": 124,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15624,7 +15755,7 @@
                   "x": 6,
                   "y": 316
                },
-               "id": 124,
+               "id": 125,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15779,7 +15910,7 @@
                   "x": 12,
                   "y": 316
                },
-               "id": 125,
+               "id": 126,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15934,7 +16065,7 @@
                   "x": 18,
                   "y": 316
                },
-               "id": 126,
+               "id": 127,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16089,7 +16220,7 @@
                   "x": 0,
                   "y": 324
                },
-               "id": 127,
+               "id": 128,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16244,7 +16375,7 @@
                   "x": 6,
                   "y": 324
                },
-               "id": 128,
+               "id": 129,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16399,7 +16530,7 @@
                   "x": 12,
                   "y": 324
                },
-               "id": 129,
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16554,7 +16685,7 @@
                   "x": 18,
                   "y": 324
                },
-               "id": 130,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16709,7 +16840,7 @@
                   "x": 0,
                   "y": 332
                },
-               "id": 131,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16864,7 +16995,7 @@
                   "x": 6,
                   "y": 332
                },
-               "id": 132,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17019,7 +17150,7 @@
                   "x": 12,
                   "y": 332
                },
-               "id": 133,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17174,7 +17305,7 @@
                   "x": 18,
                   "y": 332
                },
-               "id": 134,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17329,7 +17460,7 @@
                   "x": 0,
                   "y": 340
                },
-               "id": 135,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17484,7 +17615,7 @@
                   "x": 6,
                   "y": 340
                },
-               "id": 136,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17639,7 +17770,7 @@
                   "x": 12,
                   "y": 340
                },
-               "id": 137,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17794,7 +17925,7 @@
                   "x": 18,
                   "y": 340
                },
-               "id": 138,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17949,7 +18080,7 @@
                   "x": 0,
                   "y": 348
                },
-               "id": 139,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18104,7 +18235,7 @@
                   "x": 6,
                   "y": 348
                },
-               "id": 140,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18259,7 +18390,7 @@
                   "x": 12,
                   "y": 348
                },
-               "id": 141,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18414,7 +18545,7 @@
                   "x": 18,
                   "y": 348
                },
-               "id": 142,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18569,7 +18700,7 @@
                   "x": 0,
                   "y": 356
                },
-               "id": 143,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18724,7 +18855,7 @@
                   "x": 6,
                   "y": 356
                },
-               "id": 144,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18879,7 +19010,7 @@
                   "x": 12,
                   "y": 356
                },
-               "id": 145,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19034,7 +19165,7 @@
                   "x": 18,
                   "y": 356
                },
-               "id": 146,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19189,7 +19320,7 @@
                   "x": 0,
                   "y": 364
                },
-               "id": 147,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19344,7 +19475,7 @@
                   "x": 6,
                   "y": 364
                },
-               "id": 148,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19499,7 +19630,7 @@
                   "x": 12,
                   "y": 364
                },
-               "id": 149,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19654,7 +19785,7 @@
                   "x": 18,
                   "y": 364
                },
-               "id": 150,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19809,7 +19940,7 @@
                   "x": 0,
                   "y": 372
                },
-               "id": 151,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19964,7 +20095,7 @@
                   "x": 6,
                   "y": 372
                },
-               "id": 152,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20119,7 +20250,7 @@
                   "x": 12,
                   "y": 372
                },
-               "id": 153,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20274,7 +20405,7 @@
                   "x": 18,
                   "y": 372
                },
-               "id": 154,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20429,7 +20560,7 @@
                   "x": 0,
                   "y": 380
                },
-               "id": 155,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20584,7 +20715,7 @@
                   "x": 6,
                   "y": 380
                },
-               "id": 156,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20739,7 +20870,7 @@
                   "x": 12,
                   "y": 380
                },
-               "id": 157,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20894,7 +21025,7 @@
                   "x": 18,
                   "y": 380
                },
-               "id": 158,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21049,7 +21180,7 @@
                   "x": 0,
                   "y": 388
                },
-               "id": 159,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21204,7 +21335,7 @@
                   "x": 6,
                   "y": 388
                },
-               "id": 160,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21359,7 +21490,7 @@
                   "x": 12,
                   "y": 388
                },
-               "id": 161,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21514,7 +21645,7 @@
                   "x": 18,
                   "y": 388
                },
-               "id": 162,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21669,7 +21800,7 @@
                   "x": 0,
                   "y": 396
                },
-               "id": 163,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21824,7 +21955,7 @@
                   "x": 6,
                   "y": 396
                },
-               "id": 164,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21979,7 +22110,7 @@
                   "x": 12,
                   "y": 396
                },
-               "id": 165,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22134,7 +22265,7 @@
                   "x": 18,
                   "y": 396
                },
-               "id": 166,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22292,7 +22423,7 @@
             "x": 0,
             "y": 404
          },
-         "id": 167,
+         "id": 168,
          "panels": [
             {
                "aliasColors": { },
@@ -22309,7 +22440,7 @@
                   "x": 0,
                   "y": 405
                },
-               "id": 168,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22452,7 +22583,7 @@
                   "x": 12,
                   "y": 405
                },
-               "id": 169,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22595,7 +22726,7 @@
                   "x": 0,
                   "y": 413
                },
-               "id": 170,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22732,7 +22863,7 @@
                   "x": 12,
                   "y": 413
                },
-               "id": 171,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/InfluxDB/dashboard_static_compiled.json
+++ b/tests/InfluxDB/dashboard_static_compiled.json
@@ -7955,11 +7955,11 @@
                "dashes": false,
                "datasource": "influxdb",
                "decimals": 3,
-               "description": "Memory used for the Lua runtime.\nLua memory is bounded by 2 GB per instance. \n",
+               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance. \n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 177
                },
@@ -8044,7 +8044,138 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Lua runtime memory",
+               "title": "Lua memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "influxdb",
+               "decimals": 3,
+               "description": "Memory used by runtime arena.\nRuntime arena stores network buffers, tuples\ncreated with box.tuple.new and other objects\nallocated by application not covered by basic\nLua mechanisms (spaces data and indexes\nare not included here, see memtx/vinyl arena).\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 177
+               },
+               "id": 68,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_runtime_used"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Runtime arena memory",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -8090,11 +8221,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 177
                },
-               "id": 68,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8225,7 +8356,7 @@
                   "x": 0,
                   "y": 185
                },
-               "id": 69,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8356,7 +8487,7 @@
                   "x": 12,
                   "y": 185
                },
-               "id": 70,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8487,7 +8618,7 @@
                   "x": 0,
                   "y": 193
                },
-               "id": 71,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -8618,7 +8749,7 @@
                   "x": 8,
                   "y": 193
                },
-               "id": 72,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8749,7 +8880,7 @@
                   "x": 16,
                   "y": 193
                },
-               "id": 73,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8883,7 +9014,7 @@
             "x": 0,
             "y": 201
          },
-         "id": 74,
+         "id": 75,
          "panels": [
             {
                "aliasColors": { },
@@ -8900,7 +9031,7 @@
                   "x": 0,
                   "y": 202
                },
-               "id": 75,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9037,7 +9168,7 @@
                   "x": 6,
                   "y": 202
                },
-               "id": 76,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9174,7 +9305,7 @@
                   "x": 12,
                   "y": 202
                },
-               "id": 77,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9311,7 +9442,7 @@
                   "x": 18,
                   "y": 202
                },
-               "id": 78,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9442,7 +9573,7 @@
                   "x": 0,
                   "y": 210
                },
-               "id": 79,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9579,7 +9710,7 @@
                   "x": 12,
                   "y": 210
                },
-               "id": 80,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9716,7 +9847,7 @@
                   "x": 0,
                   "y": 218
                },
-               "id": 81,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9853,7 +9984,7 @@
                   "x": 8,
                   "y": 218
                },
-               "id": 82,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9990,7 +10121,7 @@
                   "x": 16,
                   "y": 218
                },
-               "id": 83,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10127,7 +10258,7 @@
                   "x": 0,
                   "y": 226
                },
-               "id": 84,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10264,7 +10395,7 @@
                   "x": 8,
                   "y": 226
                },
-               "id": 85,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10401,7 +10532,7 @@
                   "x": 16,
                   "y": 226
                },
-               "id": 86,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10538,7 +10669,7 @@
                   "x": 0,
                   "y": 234
                },
-               "id": 87,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10669,7 +10800,7 @@
                   "x": 6,
                   "y": 234
                },
-               "id": 88,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10800,7 +10931,7 @@
                   "x": 12,
                   "y": 234
                },
-               "id": 89,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10931,7 +11062,7 @@
                   "x": 18,
                   "y": 234
                },
-               "id": 90,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11062,7 +11193,7 @@
                   "x": 0,
                   "y": 242
                },
-               "id": 91,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11193,7 +11324,7 @@
                   "x": 8,
                   "y": 242
                },
-               "id": 92,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11330,7 +11461,7 @@
                   "x": 16,
                   "y": 242
                },
-               "id": 93,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11470,7 +11601,7 @@
             "x": 0,
             "y": 250
          },
-         "id": 94,
+         "id": 95,
          "panels": [
             {
                "aliasColors": { },
@@ -11487,7 +11618,7 @@
                   "x": 0,
                   "y": 251
                },
-               "id": 95,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11630,7 +11761,7 @@
                   "x": 8,
                   "y": 251
                },
-               "id": 96,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11773,7 +11904,7 @@
                   "x": 16,
                   "y": 251
                },
-               "id": 97,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11916,7 +12047,7 @@
                   "x": 0,
                   "y": 259
                },
-               "id": 98,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12059,7 +12190,7 @@
                   "x": 8,
                   "y": 259
                },
-               "id": 99,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12202,7 +12333,7 @@
                   "x": 16,
                   "y": 259
                },
-               "id": 100,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12345,7 +12476,7 @@
                   "x": 0,
                   "y": 267
                },
-               "id": 101,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12488,7 +12619,7 @@
                   "x": 8,
                   "y": 267
                },
-               "id": 102,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12631,7 +12762,7 @@
                   "x": 16,
                   "y": 267
                },
-               "id": 103,
+               "id": 104,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12774,7 +12905,7 @@
                   "x": 0,
                   "y": 275
                },
-               "id": 104,
+               "id": 105,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12917,7 +13048,7 @@
                   "x": 8,
                   "y": 275
                },
-               "id": 105,
+               "id": 106,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13060,7 +13191,7 @@
                   "x": 16,
                   "y": 275
                },
-               "id": 106,
+               "id": 107,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13206,7 +13337,7 @@
             "x": 0,
             "y": 283
          },
-         "id": 107,
+         "id": 108,
          "panels": [
             {
                "aliasColors": { },
@@ -13223,7 +13354,7 @@
                   "x": 0,
                   "y": 284
                },
-               "id": 108,
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13378,7 +13509,7 @@
                   "x": 6,
                   "y": 284
                },
-               "id": 109,
+               "id": 110,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13533,7 +13664,7 @@
                   "x": 12,
                   "y": 284
                },
-               "id": 110,
+               "id": 111,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13688,7 +13819,7 @@
                   "x": 18,
                   "y": 284
                },
-               "id": 111,
+               "id": 112,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13843,7 +13974,7 @@
                   "x": 0,
                   "y": 292
                },
-               "id": 112,
+               "id": 113,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13950,7 +14081,7 @@
                   "x": 8,
                   "y": 292
                },
-               "id": 113,
+               "id": 114,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14057,7 +14188,7 @@
                   "x": 16,
                   "y": 292
                },
-               "id": 114,
+               "id": 115,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14206,7 +14337,7 @@
                   "x": 0,
                   "y": 300
                },
-               "id": 115,
+               "id": 116,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14361,7 +14492,7 @@
                   "x": 6,
                   "y": 300
                },
-               "id": 116,
+               "id": 117,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14516,7 +14647,7 @@
                   "x": 12,
                   "y": 300
                },
-               "id": 117,
+               "id": 118,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14671,7 +14802,7 @@
                   "x": 18,
                   "y": 300
                },
-               "id": 118,
+               "id": 119,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14826,7 +14957,7 @@
                   "x": 0,
                   "y": 308
                },
-               "id": 119,
+               "id": 120,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14981,7 +15112,7 @@
                   "x": 6,
                   "y": 308
                },
-               "id": 120,
+               "id": 121,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15136,7 +15267,7 @@
                   "x": 12,
                   "y": 308
                },
-               "id": 121,
+               "id": 122,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15291,7 +15422,7 @@
                   "x": 18,
                   "y": 308
                },
-               "id": 122,
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15446,7 +15577,7 @@
                   "x": 0,
                   "y": 316
                },
-               "id": 123,
+               "id": 124,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15601,7 +15732,7 @@
                   "x": 6,
                   "y": 316
                },
-               "id": 124,
+               "id": 125,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15756,7 +15887,7 @@
                   "x": 12,
                   "y": 316
                },
-               "id": 125,
+               "id": 126,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15911,7 +16042,7 @@
                   "x": 18,
                   "y": 316
                },
-               "id": 126,
+               "id": 127,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16066,7 +16197,7 @@
                   "x": 0,
                   "y": 324
                },
-               "id": 127,
+               "id": 128,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16221,7 +16352,7 @@
                   "x": 6,
                   "y": 324
                },
-               "id": 128,
+               "id": 129,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16376,7 +16507,7 @@
                   "x": 12,
                   "y": 324
                },
-               "id": 129,
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16531,7 +16662,7 @@
                   "x": 18,
                   "y": 324
                },
-               "id": 130,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16686,7 +16817,7 @@
                   "x": 0,
                   "y": 332
                },
-               "id": 131,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16841,7 +16972,7 @@
                   "x": 6,
                   "y": 332
                },
-               "id": 132,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16996,7 +17127,7 @@
                   "x": 12,
                   "y": 332
                },
-               "id": 133,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17151,7 +17282,7 @@
                   "x": 18,
                   "y": 332
                },
-               "id": 134,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17306,7 +17437,7 @@
                   "x": 0,
                   "y": 340
                },
-               "id": 135,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17461,7 +17592,7 @@
                   "x": 6,
                   "y": 340
                },
-               "id": 136,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17616,7 +17747,7 @@
                   "x": 12,
                   "y": 340
                },
-               "id": 137,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17771,7 +17902,7 @@
                   "x": 18,
                   "y": 340
                },
-               "id": 138,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17926,7 +18057,7 @@
                   "x": 0,
                   "y": 348
                },
-               "id": 139,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18081,7 +18212,7 @@
                   "x": 6,
                   "y": 348
                },
-               "id": 140,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18236,7 +18367,7 @@
                   "x": 12,
                   "y": 348
                },
-               "id": 141,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18391,7 +18522,7 @@
                   "x": 18,
                   "y": 348
                },
-               "id": 142,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18546,7 +18677,7 @@
                   "x": 0,
                   "y": 356
                },
-               "id": 143,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18701,7 +18832,7 @@
                   "x": 6,
                   "y": 356
                },
-               "id": 144,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18856,7 +18987,7 @@
                   "x": 12,
                   "y": 356
                },
-               "id": 145,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19011,7 +19142,7 @@
                   "x": 18,
                   "y": 356
                },
-               "id": 146,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19166,7 +19297,7 @@
                   "x": 0,
                   "y": 364
                },
-               "id": 147,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19321,7 +19452,7 @@
                   "x": 6,
                   "y": 364
                },
-               "id": 148,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19476,7 +19607,7 @@
                   "x": 12,
                   "y": 364
                },
-               "id": 149,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19631,7 +19762,7 @@
                   "x": 18,
                   "y": 364
                },
-               "id": 150,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19786,7 +19917,7 @@
                   "x": 0,
                   "y": 372
                },
-               "id": 151,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19941,7 +20072,7 @@
                   "x": 6,
                   "y": 372
                },
-               "id": 152,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20096,7 +20227,7 @@
                   "x": 12,
                   "y": 372
                },
-               "id": 153,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20251,7 +20382,7 @@
                   "x": 18,
                   "y": 372
                },
-               "id": 154,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20406,7 +20537,7 @@
                   "x": 0,
                   "y": 380
                },
-               "id": 155,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20561,7 +20692,7 @@
                   "x": 6,
                   "y": 380
                },
-               "id": 156,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20716,7 +20847,7 @@
                   "x": 12,
                   "y": 380
                },
-               "id": 157,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20871,7 +21002,7 @@
                   "x": 18,
                   "y": 380
                },
-               "id": 158,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21026,7 +21157,7 @@
                   "x": 0,
                   "y": 388
                },
-               "id": 159,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21181,7 +21312,7 @@
                   "x": 6,
                   "y": 388
                },
-               "id": 160,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21336,7 +21467,7 @@
                   "x": 12,
                   "y": 388
                },
-               "id": 161,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21491,7 +21622,7 @@
                   "x": 18,
                   "y": 388
                },
-               "id": 162,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21646,7 +21777,7 @@
                   "x": 0,
                   "y": 396
                },
-               "id": 163,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21801,7 +21932,7 @@
                   "x": 6,
                   "y": 396
                },
-               "id": 164,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21956,7 +22087,7 @@
                   "x": 12,
                   "y": 396
                },
-               "id": 165,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22111,7 +22242,7 @@
                   "x": 18,
                   "y": 396
                },
-               "id": 166,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22269,7 +22400,7 @@
             "x": 0,
             "y": 404
          },
-         "id": 167,
+         "id": 168,
          "panels": [
             {
                "aliasColors": { },
@@ -22286,7 +22417,7 @@
                   "x": 0,
                   "y": 405
                },
-               "id": 168,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22429,7 +22560,7 @@
                   "x": 12,
                   "y": 405
                },
-               "id": 169,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22572,7 +22703,7 @@
                   "x": 0,
                   "y": 413
                },
-               "id": 170,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22709,7 +22840,7 @@
                   "x": 12,
                   "y": 413
                },
-               "id": 171,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/InfluxDB/dashboard_tdg_compiled.json
+++ b/tests/InfluxDB/dashboard_tdg_compiled.json
@@ -7290,11 +7290,11 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 3,
-               "description": "Memory used for the Lua runtime.\nLua memory is bounded by 2 GB per instance. \n",
+               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance. \n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 168
                },
@@ -7379,7 +7379,138 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Lua runtime memory",
+               "title": "Lua memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 3,
+               "description": "Memory used by runtime arena.\nRuntime arena stores network buffers, tuples\ncreated with box.tuple.new and other objects\nallocated by application not covered by basic\nLua mechanisms (spaces data and indexes\nare not included here, see memtx/vinyl arena).\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 168
+               },
+               "id": 63,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_runtime_used"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Runtime arena memory",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -7425,11 +7556,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 168
                },
-               "id": 63,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7560,7 +7691,7 @@
                   "x": 0,
                   "y": 176
                },
-               "id": 64,
+               "id": 65,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7691,7 +7822,7 @@
                   "x": 12,
                   "y": 176
                },
-               "id": 65,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7822,7 +7953,7 @@
                   "x": 0,
                   "y": 184
                },
-               "id": 66,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -7953,7 +8084,7 @@
                   "x": 8,
                   "y": 184
                },
-               "id": 67,
+               "id": 68,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8084,7 +8215,7 @@
                   "x": 16,
                   "y": 184
                },
-               "id": 68,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8218,7 +8349,7 @@
             "x": 0,
             "y": 192
          },
-         "id": 69,
+         "id": 70,
          "panels": [
             {
                "aliasColors": { },
@@ -8235,7 +8366,7 @@
                   "x": 0,
                   "y": 193
                },
-               "id": 70,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8372,7 +8503,7 @@
                   "x": 6,
                   "y": 193
                },
-               "id": 71,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8509,7 +8640,7 @@
                   "x": 12,
                   "y": 193
                },
-               "id": 72,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8646,7 +8777,7 @@
                   "x": 18,
                   "y": 193
                },
-               "id": 73,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8777,7 +8908,7 @@
                   "x": 0,
                   "y": 201
                },
-               "id": 74,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8914,7 +9045,7 @@
                   "x": 12,
                   "y": 201
                },
-               "id": 75,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9051,7 +9182,7 @@
                   "x": 0,
                   "y": 209
                },
-               "id": 76,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9188,7 +9319,7 @@
                   "x": 8,
                   "y": 209
                },
-               "id": 77,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9325,7 +9456,7 @@
                   "x": 16,
                   "y": 209
                },
-               "id": 78,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9462,7 +9593,7 @@
                   "x": 0,
                   "y": 217
                },
-               "id": 79,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9599,7 +9730,7 @@
                   "x": 8,
                   "y": 217
                },
-               "id": 80,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9736,7 +9867,7 @@
                   "x": 16,
                   "y": 217
                },
-               "id": 81,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9873,7 +10004,7 @@
                   "x": 0,
                   "y": 225
                },
-               "id": 82,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10004,7 +10135,7 @@
                   "x": 6,
                   "y": 225
                },
-               "id": 83,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10135,7 +10266,7 @@
                   "x": 12,
                   "y": 225
                },
-               "id": 84,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10266,7 +10397,7 @@
                   "x": 18,
                   "y": 225
                },
-               "id": 85,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10397,7 +10528,7 @@
                   "x": 0,
                   "y": 233
                },
-               "id": 86,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10528,7 +10659,7 @@
                   "x": 8,
                   "y": 233
                },
-               "id": 87,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10665,7 +10796,7 @@
                   "x": 16,
                   "y": 233
                },
-               "id": 88,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10805,7 +10936,7 @@
             "x": 0,
             "y": 241
          },
-         "id": 89,
+         "id": 90,
          "panels": [
             {
                "aliasColors": { },
@@ -10822,7 +10953,7 @@
                   "x": 0,
                   "y": 242
                },
-               "id": 90,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10965,7 +11096,7 @@
                   "x": 8,
                   "y": 242
                },
-               "id": 91,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11108,7 +11239,7 @@
                   "x": 16,
                   "y": 242
                },
-               "id": 92,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11251,7 +11382,7 @@
                   "x": 0,
                   "y": 250
                },
-               "id": 93,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11394,7 +11525,7 @@
                   "x": 8,
                   "y": 250
                },
-               "id": 94,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11537,7 +11668,7 @@
                   "x": 16,
                   "y": 250
                },
-               "id": 95,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11680,7 +11811,7 @@
                   "x": 0,
                   "y": 258
                },
-               "id": 96,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11823,7 +11954,7 @@
                   "x": 8,
                   "y": 258
                },
-               "id": 97,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11966,7 +12097,7 @@
                   "x": 16,
                   "y": 258
                },
-               "id": 98,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12109,7 +12240,7 @@
                   "x": 0,
                   "y": 266
                },
-               "id": 99,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12252,7 +12383,7 @@
                   "x": 8,
                   "y": 266
                },
-               "id": 100,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12395,7 +12526,7 @@
                   "x": 16,
                   "y": 266
                },
-               "id": 101,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12541,7 +12672,7 @@
             "x": 0,
             "y": 274
          },
-         "id": 102,
+         "id": 103,
          "panels": [
             {
                "aliasColors": { },
@@ -12558,7 +12689,7 @@
                   "x": 0,
                   "y": 275
                },
-               "id": 103,
+               "id": 104,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12707,7 +12838,7 @@
                   "x": 8,
                   "y": 275
                },
-               "id": 104,
+               "id": 105,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12856,7 +12987,7 @@
                   "x": 16,
                   "y": 275
                },
-               "id": 105,
+               "id": 106,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13005,7 +13136,7 @@
                   "x": 0,
                   "y": 283
                },
-               "id": 106,
+               "id": 107,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13160,7 +13291,7 @@
                   "x": 6,
                   "y": 283
                },
-               "id": 107,
+               "id": 108,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13315,7 +13446,7 @@
                   "x": 12,
                   "y": 283
                },
-               "id": 108,
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13470,7 +13601,7 @@
                   "x": 18,
                   "y": 283
                },
-               "id": 109,
+               "id": 110,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13625,7 +13756,7 @@
                   "x": 0,
                   "y": 291
                },
-               "id": 110,
+               "id": 111,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13780,7 +13911,7 @@
                   "x": 6,
                   "y": 291
                },
-               "id": 111,
+               "id": 112,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13935,7 +14066,7 @@
                   "x": 12,
                   "y": 291
                },
-               "id": 112,
+               "id": 113,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14090,7 +14221,7 @@
                   "x": 18,
                   "y": 291
                },
-               "id": 113,
+               "id": 114,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14248,7 +14379,7 @@
             "x": 0,
             "y": 299
          },
-         "id": 114,
+         "id": 115,
          "panels": [
             {
                "aliasColors": { },
@@ -14265,7 +14396,7 @@
                   "x": 0,
                   "y": 300
                },
-               "id": 115,
+               "id": 116,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -14420,7 +14551,7 @@
                   "x": 6,
                   "y": 300
                },
-               "id": 116,
+               "id": 117,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14581,7 +14712,7 @@
                   "x": 12,
                   "y": 300
                },
-               "id": 117,
+               "id": 118,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14742,7 +14873,7 @@
                   "x": 18,
                   "y": 300
                },
-               "id": 118,
+               "id": 119,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14903,7 +15034,7 @@
                   "x": 0,
                   "y": 308
                },
-               "id": 119,
+               "id": 120,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15058,7 +15189,7 @@
                   "x": 6,
                   "y": 308
                },
-               "id": 120,
+               "id": 121,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15213,7 +15344,7 @@
                   "x": 12,
                   "y": 308
                },
-               "id": 121,
+               "id": 122,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15368,7 +15499,7 @@
                   "x": 18,
                   "y": 308
                },
-               "id": 122,
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15523,7 +15654,7 @@
                   "x": 0,
                   "y": 316
                },
-               "id": 123,
+               "id": 124,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15684,7 +15815,7 @@
                   "x": 8,
                   "y": 316
                },
-               "id": 124,
+               "id": 125,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15845,7 +15976,7 @@
                   "x": 16,
                   "y": 316
                },
-               "id": 125,
+               "id": 126,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16006,7 +16137,7 @@
                   "x": 0,
                   "y": 324
                },
-               "id": 126,
+               "id": 127,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16167,7 +16298,7 @@
                   "x": 8,
                   "y": 324
                },
-               "id": 127,
+               "id": 128,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -16322,7 +16453,7 @@
                   "x": 16,
                   "y": 324
                },
-               "id": 128,
+               "id": 129,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16483,7 +16614,7 @@
                   "x": 0,
                   "y": 332
                },
-               "id": 129,
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16644,7 +16775,7 @@
                   "x": 8,
                   "y": 332
                },
-               "id": 130,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16805,7 +16936,7 @@
                   "x": 16,
                   "y": 332
                },
-               "id": 131,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16966,7 +17097,7 @@
                   "x": 0,
                   "y": 340
                },
-               "id": 132,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17127,7 +17258,7 @@
                   "x": 8,
                   "y": 340
                },
-               "id": 133,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -17282,7 +17413,7 @@
                   "x": 16,
                   "y": 340
                },
-               "id": 134,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17443,7 +17574,7 @@
                   "x": 0,
                   "y": 348
                },
-               "id": 135,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17610,7 +17741,7 @@
                   "x": 0,
                   "y": 358
                },
-               "id": 136,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17771,7 +17902,7 @@
                   "x": 6,
                   "y": 358
                },
-               "id": 137,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17932,7 +18063,7 @@
                   "x": 12,
                   "y": 358
                },
-               "id": 138,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18093,7 +18224,7 @@
                   "x": 18,
                   "y": 358
                },
-               "id": 139,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18257,7 +18388,7 @@
             "x": 0,
             "y": 366
          },
-         "id": 140,
+         "id": 141,
          "panels": [
             {
                "aliasColors": { },
@@ -18274,7 +18405,7 @@
                   "x": 0,
                   "y": 367
                },
-               "id": 141,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18429,7 +18560,7 @@
                   "x": 12,
                   "y": 367
                },
-               "id": 142,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18584,7 +18715,7 @@
                   "x": 0,
                   "y": 375
                },
-               "id": 143,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18745,7 +18876,7 @@
                   "x": 12,
                   "y": 375
                },
-               "id": 144,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18906,7 +19037,7 @@
                   "x": 0,
                   "y": 383
                },
-               "id": 145,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19067,7 +19198,7 @@
                   "x": 8,
                   "y": 383
                },
-               "id": 146,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19228,7 +19359,7 @@
                   "x": 16,
                   "y": 383
                },
-               "id": 147,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19389,7 +19520,7 @@
                   "x": 0,
                   "y": 391
                },
-               "id": 148,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19550,7 +19681,7 @@
                   "x": 8,
                   "y": 391
                },
-               "id": 149,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19711,7 +19842,7 @@
                   "x": 16,
                   "y": 391
                },
-               "id": 150,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19872,7 +20003,7 @@
                   "x": 0,
                   "y": 399
                },
-               "id": 151,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20039,7 +20170,7 @@
                   "x": 6,
                   "y": 399
                },
-               "id": 152,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20206,7 +20337,7 @@
                   "x": 12,
                   "y": 399
                },
-               "id": 153,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20373,7 +20504,7 @@
                   "x": 18,
                   "y": 399
                },
-               "id": 154,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20540,7 +20671,7 @@
                   "x": 0,
                   "y": 407
                },
-               "id": 155,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20707,7 +20838,7 @@
                   "x": 12,
                   "y": 407
                },
-               "id": 156,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20871,7 +21002,7 @@
             "x": 0,
             "y": 415
          },
-         "id": 157,
+         "id": 158,
          "panels": [
             {
                "aliasColors": { },
@@ -20888,7 +21019,7 @@
                   "x": 0,
                   "y": 416
                },
-               "id": 158,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -21037,7 +21168,7 @@
                   "x": 12,
                   "y": 416
                },
-               "id": 159,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21186,7 +21317,7 @@
                   "x": 0,
                   "y": 424
                },
-               "id": 160,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21341,7 +21472,7 @@
                   "x": 12,
                   "y": 424
                },
-               "id": 161,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21493,7 +21624,7 @@
             "x": 0,
             "y": 432
          },
-         "id": 162,
+         "id": 163,
          "panels": [
             {
                "aliasColors": { },
@@ -21510,7 +21641,7 @@
                   "x": 0,
                   "y": 433
                },
-               "id": 163,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -21659,7 +21790,7 @@
                   "x": 12,
                   "y": 433
                },
-               "id": 164,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -21811,7 +21942,7 @@
             "x": 0,
             "y": 441
          },
-         "id": 165,
+         "id": 166,
          "panels": [
             {
                "aliasColors": { },
@@ -21828,7 +21959,7 @@
                   "x": 0,
                   "y": 442
                },
-               "id": 166,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21971,7 +22102,7 @@
                   "x": 12,
                   "y": 442
                },
-               "id": 167,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22114,7 +22245,7 @@
                   "x": 0,
                   "y": 450
                },
-               "id": 168,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22251,7 +22382,7 @@
                   "x": 12,
                   "y": 450
                },
-               "id": 169,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22391,7 +22522,7 @@
             "x": 0,
             "y": 458
          },
-         "id": 170,
+         "id": 171,
          "panels": [
             {
                "aliasColors": { },
@@ -22408,7 +22539,7 @@
                   "x": 0,
                   "y": 459
                },
-               "id": 171,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22515,7 +22646,7 @@
                   "x": 12,
                   "y": 459
                },
-               "id": 172,
+               "id": 173,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22622,7 +22753,7 @@
                   "x": 0,
                   "y": 467
                },
-               "id": 173,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22753,7 +22884,7 @@
                   "x": 12,
                   "y": 467
                },
-               "id": 174,
+               "id": 175,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22887,7 +23018,7 @@
             "x": 0,
             "y": 475
          },
-         "id": 175,
+         "id": 176,
          "panels": [
             {
                "aliasColors": { },
@@ -22904,7 +23035,7 @@
                   "x": 0,
                   "y": 476
                },
-               "id": 176,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -23041,7 +23172,7 @@
                   "x": 8,
                   "y": 476
                },
-               "id": 177,
+               "id": 178,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -23178,7 +23309,7 @@
                   "x": 16,
                   "y": 476
                },
-               "id": 178,
+               "id": 179,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -23315,7 +23446,7 @@
                   "x": 0,
                   "y": 484
                },
-               "id": 179,
+               "id": 180,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -23452,7 +23583,7 @@
                   "x": 8,
                   "y": 484
                },
-               "id": 180,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -23589,7 +23720,7 @@
                   "x": 16,
                   "y": 484
                },
-               "id": 181,
+               "id": 182,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -23729,7 +23860,7 @@
             "x": 0,
             "y": 492
          },
-         "id": 182,
+         "id": 183,
          "panels": [
             {
                "aliasColors": { },
@@ -23746,7 +23877,7 @@
                   "x": 0,
                   "y": 493
                },
-               "id": 183,
+               "id": 184,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23901,7 +24032,7 @@
                   "x": 8,
                   "y": 493
                },
-               "id": 184,
+               "id": 185,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24008,7 +24139,7 @@
                   "x": 16,
                   "y": 493
                },
-               "id": 185,
+               "id": 186,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24163,7 +24294,7 @@
                   "x": 0,
                   "y": 501
                },
-               "id": 186,
+               "id": 187,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24318,7 +24449,7 @@
                   "x": 8,
                   "y": 501
                },
-               "id": 187,
+               "id": 188,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24425,7 +24556,7 @@
                   "x": 16,
                   "y": 501
                },
-               "id": 188,
+               "id": 189,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24583,7 +24714,7 @@
             "x": 0,
             "y": 509
          },
-         "id": 189,
+         "id": 190,
          "panels": [
             {
                "aliasColors": { },
@@ -24600,7 +24731,7 @@
                   "x": 0,
                   "y": 510
                },
-               "id": 190,
+               "id": 191,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24749,7 +24880,7 @@
                   "x": 6,
                   "y": 510
                },
-               "id": 191,
+               "id": 192,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24898,7 +25029,7 @@
                   "x": 12,
                   "y": 510
                },
-               "id": 192,
+               "id": 193,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25047,7 +25178,7 @@
                   "x": 18,
                   "y": 510
                },
-               "id": 193,
+               "id": 194,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25196,7 +25327,7 @@
                   "x": 0,
                   "y": 518
                },
-               "id": 194,
+               "id": 195,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25345,7 +25476,7 @@
                   "x": 12,
                   "y": 518
                },
-               "id": 195,
+               "id": 196,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25494,7 +25625,7 @@
                   "x": 0,
                   "y": 526
                },
-               "id": 196,
+               "id": 197,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25643,7 +25774,7 @@
                   "x": 6,
                   "y": 526
                },
-               "id": 197,
+               "id": 198,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25792,7 +25923,7 @@
                   "x": 12,
                   "y": 526
                },
-               "id": 198,
+               "id": 199,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25941,7 +26072,7 @@
                   "x": 18,
                   "y": 526
                },
-               "id": 199,
+               "id": 200,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26090,7 +26221,7 @@
                   "x": 0,
                   "y": 534
                },
-               "id": 200,
+               "id": 201,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26239,7 +26370,7 @@
                   "x": 6,
                   "y": 534
                },
-               "id": 201,
+               "id": 202,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26388,7 +26519,7 @@
                   "x": 12,
                   "y": 534
                },
-               "id": 202,
+               "id": 203,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26537,7 +26668,7 @@
                   "x": 18,
                   "y": 534
                },
-               "id": 203,
+               "id": 204,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26686,7 +26817,7 @@
                   "x": 0,
                   "y": 542
                },
-               "id": 204,
+               "id": 205,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26835,7 +26966,7 @@
                   "x": 6,
                   "y": 542
                },
-               "id": 205,
+               "id": 206,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26984,7 +27115,7 @@
                   "x": 12,
                   "y": 542
                },
-               "id": 206,
+               "id": 207,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27133,7 +27264,7 @@
                   "x": 18,
                   "y": 542
                },
-               "id": 207,
+               "id": 208,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27285,7 +27416,7 @@
             "x": 0,
             "y": 550
          },
-         "id": 208,
+         "id": 209,
          "panels": [
             {
                "aliasColors": { },
@@ -27302,7 +27433,7 @@
                   "x": 0,
                   "y": 551
                },
-               "id": 209,
+               "id": 210,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27469,7 +27600,7 @@
                   "x": 8,
                   "y": 551
                },
-               "id": 210,
+               "id": 211,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27636,7 +27767,7 @@
                   "x": 16,
                   "y": 551
                },
-               "id": 211,
+               "id": 212,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27803,7 +27934,7 @@
                   "x": 0,
                   "y": 559
                },
-               "id": 212,
+               "id": 213,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27970,7 +28101,7 @@
                   "x": 8,
                   "y": 559
                },
-               "id": 213,
+               "id": 214,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28137,7 +28268,7 @@
                   "x": 16,
                   "y": 559
                },
-               "id": 214,
+               "id": 215,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28304,7 +28435,7 @@
                   "x": 0,
                   "y": 567
                },
-               "id": 215,
+               "id": 216,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28471,7 +28602,7 @@
                   "x": 8,
                   "y": 567
                },
-               "id": 216,
+               "id": 217,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28638,7 +28769,7 @@
                   "x": 16,
                   "y": 567
                },
-               "id": 217,
+               "id": 218,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28805,7 +28936,7 @@
                   "x": 0,
                   "y": 575
                },
-               "id": 218,
+               "id": 219,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28972,7 +29103,7 @@
                   "x": 8,
                   "y": 575
                },
-               "id": 219,
+               "id": 220,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29139,7 +29270,7 @@
                   "x": 16,
                   "y": 575
                },
-               "id": 220,
+               "id": 221,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29309,7 +29440,7 @@
             "x": 0,
             "y": 583
          },
-         "id": 221,
+         "id": 222,
          "panels": [
             {
                "aliasColors": { },
@@ -29326,7 +29457,7 @@
                   "x": 0,
                   "y": 584
                },
-               "id": 222,
+               "id": 223,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29475,7 +29606,7 @@
                   "x": 8,
                   "y": 584
                },
-               "id": 223,
+               "id": 224,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29624,7 +29755,7 @@
                   "x": 16,
                   "y": 584
                },
-               "id": 224,
+               "id": 225,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29773,7 +29904,7 @@
                   "x": 0,
                   "y": 592
                },
-               "id": 225,
+               "id": 226,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -29916,7 +30047,7 @@
                   "x": 12,
                   "y": 592
                },
-               "id": 226,
+               "id": 227,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30023,7 +30154,7 @@
                   "x": 0,
                   "y": 600
                },
-               "id": 227,
+               "id": 228,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30172,7 +30303,7 @@
                   "x": 6,
                   "y": 600
                },
-               "id": 228,
+               "id": 229,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30321,7 +30452,7 @@
                   "x": 12,
                   "y": 600
                },
-               "id": 229,
+               "id": 230,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30470,7 +30601,7 @@
                   "x": 18,
                   "y": 600
                },
-               "id": 230,
+               "id": 231,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30619,7 +30750,7 @@
                   "x": 0,
                   "y": 608
                },
-               "id": 231,
+               "id": 232,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -30762,7 +30893,7 @@
                   "x": 12,
                   "y": 608
                },
-               "id": 232,
+               "id": 233,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30869,7 +31000,7 @@
                   "x": 0,
                   "y": 616
                },
-               "id": 233,
+               "id": 234,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31018,7 +31149,7 @@
                   "x": 8,
                   "y": 616
                },
-               "id": 234,
+               "id": 235,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31167,7 +31298,7 @@
                   "x": 16,
                   "y": 616
                },
-               "id": 235,
+               "id": 236,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31316,7 +31447,7 @@
                   "x": 0,
                   "y": 624
                },
-               "id": 236,
+               "id": 237,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -31459,7 +31590,7 @@
                   "x": 12,
                   "y": 624
                },
-               "id": 237,
+               "id": 238,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/InfluxDB/dashboard_tdg_static_compiled.json
+++ b/tests/InfluxDB/dashboard_tdg_static_compiled.json
@@ -7267,11 +7267,11 @@
                "dashes": false,
                "datasource": "influxdb",
                "decimals": 3,
-               "description": "Memory used for the Lua runtime.\nLua memory is bounded by 2 GB per instance. \n",
+               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance. \n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 168
                },
@@ -7356,7 +7356,138 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Lua runtime memory",
+               "title": "Lua memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "influxdb",
+               "decimals": 3,
+               "description": "Memory used by runtime arena.\nRuntime arena stores network buffers, tuples\ncreated with box.tuple.new and other objects\nallocated by application not covered by basic\nLua mechanisms (spaces data and indexes\nare not included here, see memtx/vinyl arena).\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 168
+               },
+               "id": 63,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_runtime_used"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Runtime arena memory",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -7402,11 +7533,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 168
                },
-               "id": 63,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7537,7 +7668,7 @@
                   "x": 0,
                   "y": 176
                },
-               "id": 64,
+               "id": 65,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7668,7 +7799,7 @@
                   "x": 12,
                   "y": 176
                },
-               "id": 65,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7799,7 +7930,7 @@
                   "x": 0,
                   "y": 184
                },
-               "id": 66,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -7930,7 +8061,7 @@
                   "x": 8,
                   "y": 184
                },
-               "id": 67,
+               "id": 68,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8061,7 +8192,7 @@
                   "x": 16,
                   "y": 184
                },
-               "id": 68,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8195,7 +8326,7 @@
             "x": 0,
             "y": 192
          },
-         "id": 69,
+         "id": 70,
          "panels": [
             {
                "aliasColors": { },
@@ -8212,7 +8343,7 @@
                   "x": 0,
                   "y": 193
                },
-               "id": 70,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8349,7 +8480,7 @@
                   "x": 6,
                   "y": 193
                },
-               "id": 71,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8486,7 +8617,7 @@
                   "x": 12,
                   "y": 193
                },
-               "id": 72,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8623,7 +8754,7 @@
                   "x": 18,
                   "y": 193
                },
-               "id": 73,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8754,7 +8885,7 @@
                   "x": 0,
                   "y": 201
                },
-               "id": 74,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8891,7 +9022,7 @@
                   "x": 12,
                   "y": 201
                },
-               "id": 75,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9028,7 +9159,7 @@
                   "x": 0,
                   "y": 209
                },
-               "id": 76,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9165,7 +9296,7 @@
                   "x": 8,
                   "y": 209
                },
-               "id": 77,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9302,7 +9433,7 @@
                   "x": 16,
                   "y": 209
                },
-               "id": 78,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9439,7 +9570,7 @@
                   "x": 0,
                   "y": 217
                },
-               "id": 79,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9576,7 +9707,7 @@
                   "x": 8,
                   "y": 217
                },
-               "id": 80,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9713,7 +9844,7 @@
                   "x": 16,
                   "y": 217
                },
-               "id": 81,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9850,7 +9981,7 @@
                   "x": 0,
                   "y": 225
                },
-               "id": 82,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9981,7 +10112,7 @@
                   "x": 6,
                   "y": 225
                },
-               "id": 83,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10112,7 +10243,7 @@
                   "x": 12,
                   "y": 225
                },
-               "id": 84,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10243,7 +10374,7 @@
                   "x": 18,
                   "y": 225
                },
-               "id": 85,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10374,7 +10505,7 @@
                   "x": 0,
                   "y": 233
                },
-               "id": 86,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10505,7 +10636,7 @@
                   "x": 8,
                   "y": 233
                },
-               "id": 87,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10642,7 +10773,7 @@
                   "x": 16,
                   "y": 233
                },
-               "id": 88,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10782,7 +10913,7 @@
             "x": 0,
             "y": 241
          },
-         "id": 89,
+         "id": 90,
          "panels": [
             {
                "aliasColors": { },
@@ -10799,7 +10930,7 @@
                   "x": 0,
                   "y": 242
                },
-               "id": 90,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10942,7 +11073,7 @@
                   "x": 8,
                   "y": 242
                },
-               "id": 91,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11085,7 +11216,7 @@
                   "x": 16,
                   "y": 242
                },
-               "id": 92,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11228,7 +11359,7 @@
                   "x": 0,
                   "y": 250
                },
-               "id": 93,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11371,7 +11502,7 @@
                   "x": 8,
                   "y": 250
                },
-               "id": 94,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11514,7 +11645,7 @@
                   "x": 16,
                   "y": 250
                },
-               "id": 95,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11657,7 +11788,7 @@
                   "x": 0,
                   "y": 258
                },
-               "id": 96,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11800,7 +11931,7 @@
                   "x": 8,
                   "y": 258
                },
-               "id": 97,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11943,7 +12074,7 @@
                   "x": 16,
                   "y": 258
                },
-               "id": 98,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12086,7 +12217,7 @@
                   "x": 0,
                   "y": 266
                },
-               "id": 99,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12229,7 +12360,7 @@
                   "x": 8,
                   "y": 266
                },
-               "id": 100,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12372,7 +12503,7 @@
                   "x": 16,
                   "y": 266
                },
-               "id": 101,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12518,7 +12649,7 @@
             "x": 0,
             "y": 274
          },
-         "id": 102,
+         "id": 103,
          "panels": [
             {
                "aliasColors": { },
@@ -12535,7 +12666,7 @@
                   "x": 0,
                   "y": 275
                },
-               "id": 103,
+               "id": 104,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12684,7 +12815,7 @@
                   "x": 8,
                   "y": 275
                },
-               "id": 104,
+               "id": 105,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12833,7 +12964,7 @@
                   "x": 16,
                   "y": 275
                },
-               "id": 105,
+               "id": 106,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12982,7 +13113,7 @@
                   "x": 0,
                   "y": 283
                },
-               "id": 106,
+               "id": 107,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13137,7 +13268,7 @@
                   "x": 6,
                   "y": 283
                },
-               "id": 107,
+               "id": 108,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13292,7 +13423,7 @@
                   "x": 12,
                   "y": 283
                },
-               "id": 108,
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13447,7 +13578,7 @@
                   "x": 18,
                   "y": 283
                },
-               "id": 109,
+               "id": 110,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13602,7 +13733,7 @@
                   "x": 0,
                   "y": 291
                },
-               "id": 110,
+               "id": 111,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13757,7 +13888,7 @@
                   "x": 6,
                   "y": 291
                },
-               "id": 111,
+               "id": 112,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13912,7 +14043,7 @@
                   "x": 12,
                   "y": 291
                },
-               "id": 112,
+               "id": 113,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14067,7 +14198,7 @@
                   "x": 18,
                   "y": 291
                },
-               "id": 113,
+               "id": 114,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14225,7 +14356,7 @@
             "x": 0,
             "y": 299
          },
-         "id": 114,
+         "id": 115,
          "panels": [
             {
                "aliasColors": { },
@@ -14242,7 +14373,7 @@
                   "x": 0,
                   "y": 300
                },
-               "id": 115,
+               "id": 116,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -14397,7 +14528,7 @@
                   "x": 6,
                   "y": 300
                },
-               "id": 116,
+               "id": 117,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14558,7 +14689,7 @@
                   "x": 12,
                   "y": 300
                },
-               "id": 117,
+               "id": 118,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14719,7 +14850,7 @@
                   "x": 18,
                   "y": 300
                },
-               "id": 118,
+               "id": 119,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14880,7 +15011,7 @@
                   "x": 0,
                   "y": 308
                },
-               "id": 119,
+               "id": 120,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15035,7 +15166,7 @@
                   "x": 6,
                   "y": 308
                },
-               "id": 120,
+               "id": 121,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15190,7 +15321,7 @@
                   "x": 12,
                   "y": 308
                },
-               "id": 121,
+               "id": 122,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15345,7 +15476,7 @@
                   "x": 18,
                   "y": 308
                },
-               "id": 122,
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15500,7 +15631,7 @@
                   "x": 0,
                   "y": 316
                },
-               "id": 123,
+               "id": 124,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15661,7 +15792,7 @@
                   "x": 8,
                   "y": 316
                },
-               "id": 124,
+               "id": 125,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15822,7 +15953,7 @@
                   "x": 16,
                   "y": 316
                },
-               "id": 125,
+               "id": 126,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15983,7 +16114,7 @@
                   "x": 0,
                   "y": 324
                },
-               "id": 126,
+               "id": 127,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16144,7 +16275,7 @@
                   "x": 8,
                   "y": 324
                },
-               "id": 127,
+               "id": 128,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -16299,7 +16430,7 @@
                   "x": 16,
                   "y": 324
                },
-               "id": 128,
+               "id": 129,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16460,7 +16591,7 @@
                   "x": 0,
                   "y": 332
                },
-               "id": 129,
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16621,7 +16752,7 @@
                   "x": 8,
                   "y": 332
                },
-               "id": 130,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16782,7 +16913,7 @@
                   "x": 16,
                   "y": 332
                },
-               "id": 131,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16943,7 +17074,7 @@
                   "x": 0,
                   "y": 340
                },
-               "id": 132,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17104,7 +17235,7 @@
                   "x": 8,
                   "y": 340
                },
-               "id": 133,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -17259,7 +17390,7 @@
                   "x": 16,
                   "y": 340
                },
-               "id": 134,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17420,7 +17551,7 @@
                   "x": 0,
                   "y": 348
                },
-               "id": 135,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17587,7 +17718,7 @@
                   "x": 0,
                   "y": 358
                },
-               "id": 136,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17748,7 +17879,7 @@
                   "x": 6,
                   "y": 358
                },
-               "id": 137,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17909,7 +18040,7 @@
                   "x": 12,
                   "y": 358
                },
-               "id": 138,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18070,7 +18201,7 @@
                   "x": 18,
                   "y": 358
                },
-               "id": 139,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18234,7 +18365,7 @@
             "x": 0,
             "y": 366
          },
-         "id": 140,
+         "id": 141,
          "panels": [
             {
                "aliasColors": { },
@@ -18251,7 +18382,7 @@
                   "x": 0,
                   "y": 367
                },
-               "id": 141,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18406,7 +18537,7 @@
                   "x": 12,
                   "y": 367
                },
-               "id": 142,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18561,7 +18692,7 @@
                   "x": 0,
                   "y": 375
                },
-               "id": 143,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18722,7 +18853,7 @@
                   "x": 12,
                   "y": 375
                },
-               "id": 144,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18883,7 +19014,7 @@
                   "x": 0,
                   "y": 383
                },
-               "id": 145,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19044,7 +19175,7 @@
                   "x": 8,
                   "y": 383
                },
-               "id": 146,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19205,7 +19336,7 @@
                   "x": 16,
                   "y": 383
                },
-               "id": 147,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19366,7 +19497,7 @@
                   "x": 0,
                   "y": 391
                },
-               "id": 148,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19527,7 +19658,7 @@
                   "x": 8,
                   "y": 391
                },
-               "id": 149,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19688,7 +19819,7 @@
                   "x": 16,
                   "y": 391
                },
-               "id": 150,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19849,7 +19980,7 @@
                   "x": 0,
                   "y": 399
                },
-               "id": 151,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20016,7 +20147,7 @@
                   "x": 6,
                   "y": 399
                },
-               "id": 152,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20183,7 +20314,7 @@
                   "x": 12,
                   "y": 399
                },
-               "id": 153,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20350,7 +20481,7 @@
                   "x": 18,
                   "y": 399
                },
-               "id": 154,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20517,7 +20648,7 @@
                   "x": 0,
                   "y": 407
                },
-               "id": 155,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20684,7 +20815,7 @@
                   "x": 12,
                   "y": 407
                },
-               "id": 156,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20848,7 +20979,7 @@
             "x": 0,
             "y": 415
          },
-         "id": 157,
+         "id": 158,
          "panels": [
             {
                "aliasColors": { },
@@ -20865,7 +20996,7 @@
                   "x": 0,
                   "y": 416
                },
-               "id": 158,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -21014,7 +21145,7 @@
                   "x": 12,
                   "y": 416
                },
-               "id": 159,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21163,7 +21294,7 @@
                   "x": 0,
                   "y": 424
                },
-               "id": 160,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21318,7 +21449,7 @@
                   "x": 12,
                   "y": 424
                },
-               "id": 161,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21470,7 +21601,7 @@
             "x": 0,
             "y": 432
          },
-         "id": 162,
+         "id": 163,
          "panels": [
             {
                "aliasColors": { },
@@ -21487,7 +21618,7 @@
                   "x": 0,
                   "y": 433
                },
-               "id": 163,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -21636,7 +21767,7 @@
                   "x": 12,
                   "y": 433
                },
-               "id": 164,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -21788,7 +21919,7 @@
             "x": 0,
             "y": 441
          },
-         "id": 165,
+         "id": 166,
          "panels": [
             {
                "aliasColors": { },
@@ -21805,7 +21936,7 @@
                   "x": 0,
                   "y": 442
                },
-               "id": 166,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21948,7 +22079,7 @@
                   "x": 12,
                   "y": 442
                },
-               "id": 167,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22091,7 +22222,7 @@
                   "x": 0,
                   "y": 450
                },
-               "id": 168,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22228,7 +22359,7 @@
                   "x": 12,
                   "y": 450
                },
-               "id": 169,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22368,7 +22499,7 @@
             "x": 0,
             "y": 458
          },
-         "id": 170,
+         "id": 171,
          "panels": [
             {
                "aliasColors": { },
@@ -22385,7 +22516,7 @@
                   "x": 0,
                   "y": 459
                },
-               "id": 171,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22492,7 +22623,7 @@
                   "x": 12,
                   "y": 459
                },
-               "id": 172,
+               "id": 173,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22599,7 +22730,7 @@
                   "x": 0,
                   "y": 467
                },
-               "id": 173,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22730,7 +22861,7 @@
                   "x": 12,
                   "y": 467
                },
-               "id": 174,
+               "id": 175,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22864,7 +22995,7 @@
             "x": 0,
             "y": 475
          },
-         "id": 175,
+         "id": 176,
          "panels": [
             {
                "aliasColors": { },
@@ -22881,7 +23012,7 @@
                   "x": 0,
                   "y": 476
                },
-               "id": 176,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -23018,7 +23149,7 @@
                   "x": 8,
                   "y": 476
                },
-               "id": 177,
+               "id": 178,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -23155,7 +23286,7 @@
                   "x": 16,
                   "y": 476
                },
-               "id": 178,
+               "id": 179,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -23292,7 +23423,7 @@
                   "x": 0,
                   "y": 484
                },
-               "id": 179,
+               "id": 180,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -23429,7 +23560,7 @@
                   "x": 8,
                   "y": 484
                },
-               "id": 180,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -23566,7 +23697,7 @@
                   "x": 16,
                   "y": 484
                },
-               "id": 181,
+               "id": 182,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -23706,7 +23837,7 @@
             "x": 0,
             "y": 492
          },
-         "id": 182,
+         "id": 183,
          "panels": [
             {
                "aliasColors": { },
@@ -23723,7 +23854,7 @@
                   "x": 0,
                   "y": 493
                },
-               "id": 183,
+               "id": 184,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23878,7 +24009,7 @@
                   "x": 8,
                   "y": 493
                },
-               "id": 184,
+               "id": 185,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23985,7 +24116,7 @@
                   "x": 16,
                   "y": 493
                },
-               "id": 185,
+               "id": 186,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24140,7 +24271,7 @@
                   "x": 0,
                   "y": 501
                },
-               "id": 186,
+               "id": 187,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24295,7 +24426,7 @@
                   "x": 8,
                   "y": 501
                },
-               "id": 187,
+               "id": 188,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24402,7 +24533,7 @@
                   "x": 16,
                   "y": 501
                },
-               "id": 188,
+               "id": 189,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24560,7 +24691,7 @@
             "x": 0,
             "y": 509
          },
-         "id": 189,
+         "id": 190,
          "panels": [
             {
                "aliasColors": { },
@@ -24577,7 +24708,7 @@
                   "x": 0,
                   "y": 510
                },
-               "id": 190,
+               "id": 191,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24726,7 +24857,7 @@
                   "x": 6,
                   "y": 510
                },
-               "id": 191,
+               "id": 192,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24875,7 +25006,7 @@
                   "x": 12,
                   "y": 510
                },
-               "id": 192,
+               "id": 193,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25024,7 +25155,7 @@
                   "x": 18,
                   "y": 510
                },
-               "id": 193,
+               "id": 194,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25173,7 +25304,7 @@
                   "x": 0,
                   "y": 518
                },
-               "id": 194,
+               "id": 195,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25322,7 +25453,7 @@
                   "x": 12,
                   "y": 518
                },
-               "id": 195,
+               "id": 196,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25471,7 +25602,7 @@
                   "x": 0,
                   "y": 526
                },
-               "id": 196,
+               "id": 197,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25620,7 +25751,7 @@
                   "x": 6,
                   "y": 526
                },
-               "id": 197,
+               "id": 198,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25769,7 +25900,7 @@
                   "x": 12,
                   "y": 526
                },
-               "id": 198,
+               "id": 199,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25918,7 +26049,7 @@
                   "x": 18,
                   "y": 526
                },
-               "id": 199,
+               "id": 200,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26067,7 +26198,7 @@
                   "x": 0,
                   "y": 534
                },
-               "id": 200,
+               "id": 201,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26216,7 +26347,7 @@
                   "x": 6,
                   "y": 534
                },
-               "id": 201,
+               "id": 202,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26365,7 +26496,7 @@
                   "x": 12,
                   "y": 534
                },
-               "id": 202,
+               "id": 203,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26514,7 +26645,7 @@
                   "x": 18,
                   "y": 534
                },
-               "id": 203,
+               "id": 204,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26663,7 +26794,7 @@
                   "x": 0,
                   "y": 542
                },
-               "id": 204,
+               "id": 205,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26812,7 +26943,7 @@
                   "x": 6,
                   "y": 542
                },
-               "id": 205,
+               "id": 206,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26961,7 +27092,7 @@
                   "x": 12,
                   "y": 542
                },
-               "id": 206,
+               "id": 207,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27110,7 +27241,7 @@
                   "x": 18,
                   "y": 542
                },
-               "id": 207,
+               "id": 208,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27262,7 +27393,7 @@
             "x": 0,
             "y": 550
          },
-         "id": 208,
+         "id": 209,
          "panels": [
             {
                "aliasColors": { },
@@ -27279,7 +27410,7 @@
                   "x": 0,
                   "y": 551
                },
-               "id": 209,
+               "id": 210,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27446,7 +27577,7 @@
                   "x": 8,
                   "y": 551
                },
-               "id": 210,
+               "id": 211,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27613,7 +27744,7 @@
                   "x": 16,
                   "y": 551
                },
-               "id": 211,
+               "id": 212,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27780,7 +27911,7 @@
                   "x": 0,
                   "y": 559
                },
-               "id": 212,
+               "id": 213,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27947,7 +28078,7 @@
                   "x": 8,
                   "y": 559
                },
-               "id": 213,
+               "id": 214,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28114,7 +28245,7 @@
                   "x": 16,
                   "y": 559
                },
-               "id": 214,
+               "id": 215,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28281,7 +28412,7 @@
                   "x": 0,
                   "y": 567
                },
-               "id": 215,
+               "id": 216,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28448,7 +28579,7 @@
                   "x": 8,
                   "y": 567
                },
-               "id": 216,
+               "id": 217,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28615,7 +28746,7 @@
                   "x": 16,
                   "y": 567
                },
-               "id": 217,
+               "id": 218,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28782,7 +28913,7 @@
                   "x": 0,
                   "y": 575
                },
-               "id": 218,
+               "id": 219,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28949,7 +29080,7 @@
                   "x": 8,
                   "y": 575
                },
-               "id": 219,
+               "id": 220,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29116,7 +29247,7 @@
                   "x": 16,
                   "y": 575
                },
-               "id": 220,
+               "id": 221,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29286,7 +29417,7 @@
             "x": 0,
             "y": 583
          },
-         "id": 221,
+         "id": 222,
          "panels": [
             {
                "aliasColors": { },
@@ -29303,7 +29434,7 @@
                   "x": 0,
                   "y": 584
                },
-               "id": 222,
+               "id": 223,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29452,7 +29583,7 @@
                   "x": 8,
                   "y": 584
                },
-               "id": 223,
+               "id": 224,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29601,7 +29732,7 @@
                   "x": 16,
                   "y": 584
                },
-               "id": 224,
+               "id": 225,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29750,7 +29881,7 @@
                   "x": 0,
                   "y": 592
                },
-               "id": 225,
+               "id": 226,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -29893,7 +30024,7 @@
                   "x": 12,
                   "y": 592
                },
-               "id": 226,
+               "id": 227,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30000,7 +30131,7 @@
                   "x": 0,
                   "y": 600
                },
-               "id": 227,
+               "id": 228,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30149,7 +30280,7 @@
                   "x": 6,
                   "y": 600
                },
-               "id": 228,
+               "id": 229,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30298,7 +30429,7 @@
                   "x": 12,
                   "y": 600
                },
-               "id": 229,
+               "id": 230,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30447,7 +30578,7 @@
                   "x": 18,
                   "y": 600
                },
-               "id": 230,
+               "id": 231,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30596,7 +30727,7 @@
                   "x": 0,
                   "y": 608
                },
-               "id": 231,
+               "id": 232,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -30739,7 +30870,7 @@
                   "x": 12,
                   "y": 608
                },
-               "id": 232,
+               "id": 233,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30846,7 +30977,7 @@
                   "x": 0,
                   "y": 616
                },
-               "id": 233,
+               "id": 234,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30995,7 +31126,7 @@
                   "x": 8,
                   "y": 616
                },
-               "id": 234,
+               "id": 235,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31144,7 +31275,7 @@
                   "x": 16,
                   "y": 616
                },
-               "id": 235,
+               "id": 236,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31293,7 +31424,7 @@
                   "x": 0,
                   "y": 624
                },
-               "id": 236,
+               "id": 237,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -31436,7 +31567,7 @@
                   "x": 12,
                   "y": 624
                },
-               "id": 237,
+               "id": 238,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
+++ b/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
@@ -7978,11 +7978,11 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 3,
-               "description": "Memory used for the Lua runtime.\nLua memory is bounded by 2 GB per instance. \n",
+               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance. \n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 177
                },
@@ -8067,7 +8067,138 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Lua runtime memory",
+               "title": "Lua memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 3,
+               "description": "Memory used by runtime arena.\nRuntime arena stores network buffers, tuples\ncreated with box.tuple.new and other objects\nallocated by application not covered by basic\nLua mechanisms (spaces data and indexes\nare not included here, see memtx/vinyl arena).\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 177
+               },
+               "id": 68,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_runtime_used"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Runtime arena memory",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -8113,11 +8244,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 177
                },
-               "id": 68,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8248,7 +8379,7 @@
                   "x": 0,
                   "y": 185
                },
-               "id": 69,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8379,7 +8510,7 @@
                   "x": 12,
                   "y": 185
                },
-               "id": 70,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8510,7 +8641,7 @@
                   "x": 0,
                   "y": 193
                },
-               "id": 71,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -8641,7 +8772,7 @@
                   "x": 8,
                   "y": 193
                },
-               "id": 72,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8772,7 +8903,7 @@
                   "x": 16,
                   "y": 193
                },
-               "id": 73,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8906,7 +9037,7 @@
             "x": 0,
             "y": 201
          },
-         "id": 74,
+         "id": 75,
          "panels": [
             {
                "aliasColors": { },
@@ -8923,7 +9054,7 @@
                   "x": 0,
                   "y": 202
                },
-               "id": 75,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9060,7 +9191,7 @@
                   "x": 6,
                   "y": 202
                },
-               "id": 76,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9197,7 +9328,7 @@
                   "x": 12,
                   "y": 202
                },
-               "id": 77,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9334,7 +9465,7 @@
                   "x": 18,
                   "y": 202
                },
-               "id": 78,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9465,7 +9596,7 @@
                   "x": 0,
                   "y": 210
                },
-               "id": 79,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9602,7 +9733,7 @@
                   "x": 12,
                   "y": 210
                },
-               "id": 80,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9739,7 +9870,7 @@
                   "x": 0,
                   "y": 218
                },
-               "id": 81,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9876,7 +10007,7 @@
                   "x": 8,
                   "y": 218
                },
-               "id": 82,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10013,7 +10144,7 @@
                   "x": 16,
                   "y": 218
                },
-               "id": 83,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10150,7 +10281,7 @@
                   "x": 0,
                   "y": 226
                },
-               "id": 84,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10287,7 +10418,7 @@
                   "x": 8,
                   "y": 226
                },
-               "id": 85,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10424,7 +10555,7 @@
                   "x": 16,
                   "y": 226
                },
-               "id": 86,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10561,7 +10692,7 @@
                   "x": 0,
                   "y": 234
                },
-               "id": 87,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10692,7 +10823,7 @@
                   "x": 6,
                   "y": 234
                },
-               "id": 88,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10823,7 +10954,7 @@
                   "x": 12,
                   "y": 234
                },
-               "id": 89,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10954,7 +11085,7 @@
                   "x": 18,
                   "y": 234
                },
-               "id": 90,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11085,7 +11216,7 @@
                   "x": 0,
                   "y": 242
                },
-               "id": 91,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11216,7 +11347,7 @@
                   "x": 8,
                   "y": 242
                },
-               "id": 92,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11353,7 +11484,7 @@
                   "x": 16,
                   "y": 242
                },
-               "id": 93,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11493,7 +11624,7 @@
             "x": 0,
             "y": 250
          },
-         "id": 94,
+         "id": 95,
          "panels": [
             {
                "aliasColors": { },
@@ -11510,7 +11641,7 @@
                   "x": 0,
                   "y": 251
                },
-               "id": 95,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11653,7 +11784,7 @@
                   "x": 8,
                   "y": 251
                },
-               "id": 96,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11796,7 +11927,7 @@
                   "x": 16,
                   "y": 251
                },
-               "id": 97,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11939,7 +12070,7 @@
                   "x": 0,
                   "y": 259
                },
-               "id": 98,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12082,7 +12213,7 @@
                   "x": 8,
                   "y": 259
                },
-               "id": 99,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12225,7 +12356,7 @@
                   "x": 16,
                   "y": 259
                },
-               "id": 100,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12368,7 +12499,7 @@
                   "x": 0,
                   "y": 267
                },
-               "id": 101,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12511,7 +12642,7 @@
                   "x": 8,
                   "y": 267
                },
-               "id": 102,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12654,7 +12785,7 @@
                   "x": 16,
                   "y": 267
                },
-               "id": 103,
+               "id": 104,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12797,7 +12928,7 @@
                   "x": 0,
                   "y": 275
                },
-               "id": 104,
+               "id": 105,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12940,7 +13071,7 @@
                   "x": 8,
                   "y": 275
                },
-               "id": 105,
+               "id": 106,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13083,7 +13214,7 @@
                   "x": 16,
                   "y": 275
                },
-               "id": 106,
+               "id": 107,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13229,7 +13360,7 @@
             "x": 0,
             "y": 283
          },
-         "id": 107,
+         "id": 108,
          "panels": [
             {
                "aliasColors": { },
@@ -13246,7 +13377,7 @@
                   "x": 0,
                   "y": 284
                },
-               "id": 108,
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13401,7 +13532,7 @@
                   "x": 6,
                   "y": 284
                },
-               "id": 109,
+               "id": 110,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13556,7 +13687,7 @@
                   "x": 12,
                   "y": 284
                },
-               "id": 110,
+               "id": 111,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13711,7 +13842,7 @@
                   "x": 18,
                   "y": 284
                },
-               "id": 111,
+               "id": 112,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13866,7 +13997,7 @@
                   "x": 0,
                   "y": 292
                },
-               "id": 112,
+               "id": 113,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13973,7 +14104,7 @@
                   "x": 8,
                   "y": 292
                },
-               "id": 113,
+               "id": 114,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14080,7 +14211,7 @@
                   "x": 16,
                   "y": 292
                },
-               "id": 114,
+               "id": 115,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14229,7 +14360,7 @@
                   "x": 0,
                   "y": 300
                },
-               "id": 115,
+               "id": 116,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14384,7 +14515,7 @@
                   "x": 6,
                   "y": 300
                },
-               "id": 116,
+               "id": 117,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14539,7 +14670,7 @@
                   "x": 12,
                   "y": 300
                },
-               "id": 117,
+               "id": 118,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14694,7 +14825,7 @@
                   "x": 18,
                   "y": 300
                },
-               "id": 118,
+               "id": 119,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14849,7 +14980,7 @@
                   "x": 0,
                   "y": 308
                },
-               "id": 119,
+               "id": 120,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15004,7 +15135,7 @@
                   "x": 6,
                   "y": 308
                },
-               "id": 120,
+               "id": 121,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15159,7 +15290,7 @@
                   "x": 12,
                   "y": 308
                },
-               "id": 121,
+               "id": 122,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15314,7 +15445,7 @@
                   "x": 18,
                   "y": 308
                },
-               "id": 122,
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15469,7 +15600,7 @@
                   "x": 0,
                   "y": 316
                },
-               "id": 123,
+               "id": 124,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15624,7 +15755,7 @@
                   "x": 6,
                   "y": 316
                },
-               "id": 124,
+               "id": 125,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15779,7 +15910,7 @@
                   "x": 12,
                   "y": 316
                },
-               "id": 125,
+               "id": 126,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15934,7 +16065,7 @@
                   "x": 18,
                   "y": 316
                },
-               "id": 126,
+               "id": 127,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16089,7 +16220,7 @@
                   "x": 0,
                   "y": 324
                },
-               "id": 127,
+               "id": 128,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16244,7 +16375,7 @@
                   "x": 6,
                   "y": 324
                },
-               "id": 128,
+               "id": 129,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16399,7 +16530,7 @@
                   "x": 12,
                   "y": 324
                },
-               "id": 129,
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16554,7 +16685,7 @@
                   "x": 18,
                   "y": 324
                },
-               "id": 130,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16709,7 +16840,7 @@
                   "x": 0,
                   "y": 332
                },
-               "id": 131,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16864,7 +16995,7 @@
                   "x": 6,
                   "y": 332
                },
-               "id": 132,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17019,7 +17150,7 @@
                   "x": 12,
                   "y": 332
                },
-               "id": 133,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17174,7 +17305,7 @@
                   "x": 18,
                   "y": 332
                },
-               "id": 134,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17329,7 +17460,7 @@
                   "x": 0,
                   "y": 340
                },
-               "id": 135,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17484,7 +17615,7 @@
                   "x": 6,
                   "y": 340
                },
-               "id": 136,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17639,7 +17770,7 @@
                   "x": 12,
                   "y": 340
                },
-               "id": 137,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17794,7 +17925,7 @@
                   "x": 18,
                   "y": 340
                },
-               "id": 138,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17949,7 +18080,7 @@
                   "x": 0,
                   "y": 348
                },
-               "id": 139,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18104,7 +18235,7 @@
                   "x": 6,
                   "y": 348
                },
-               "id": 140,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18259,7 +18390,7 @@
                   "x": 12,
                   "y": 348
                },
-               "id": 141,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18414,7 +18545,7 @@
                   "x": 18,
                   "y": 348
                },
-               "id": 142,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18569,7 +18700,7 @@
                   "x": 0,
                   "y": 356
                },
-               "id": 143,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18724,7 +18855,7 @@
                   "x": 6,
                   "y": 356
                },
-               "id": 144,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18879,7 +19010,7 @@
                   "x": 12,
                   "y": 356
                },
-               "id": 145,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19034,7 +19165,7 @@
                   "x": 18,
                   "y": 356
                },
-               "id": 146,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19189,7 +19320,7 @@
                   "x": 0,
                   "y": 364
                },
-               "id": 147,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19344,7 +19475,7 @@
                   "x": 6,
                   "y": 364
                },
-               "id": 148,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19499,7 +19630,7 @@
                   "x": 12,
                   "y": 364
                },
-               "id": 149,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19654,7 +19785,7 @@
                   "x": 18,
                   "y": 364
                },
-               "id": 150,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19809,7 +19940,7 @@
                   "x": 0,
                   "y": 372
                },
-               "id": 151,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19964,7 +20095,7 @@
                   "x": 6,
                   "y": 372
                },
-               "id": 152,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20119,7 +20250,7 @@
                   "x": 12,
                   "y": 372
                },
-               "id": 153,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20274,7 +20405,7 @@
                   "x": 18,
                   "y": 372
                },
-               "id": 154,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20429,7 +20560,7 @@
                   "x": 0,
                   "y": 380
                },
-               "id": 155,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20584,7 +20715,7 @@
                   "x": 6,
                   "y": 380
                },
-               "id": 156,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20739,7 +20870,7 @@
                   "x": 12,
                   "y": 380
                },
-               "id": 157,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20894,7 +21025,7 @@
                   "x": 18,
                   "y": 380
                },
-               "id": 158,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21049,7 +21180,7 @@
                   "x": 0,
                   "y": 388
                },
-               "id": 159,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21204,7 +21335,7 @@
                   "x": 6,
                   "y": 388
                },
-               "id": 160,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21359,7 +21490,7 @@
                   "x": 12,
                   "y": 388
                },
-               "id": 161,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21514,7 +21645,7 @@
                   "x": 18,
                   "y": 388
                },
-               "id": 162,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21669,7 +21800,7 @@
                   "x": 0,
                   "y": 396
                },
-               "id": 163,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21824,7 +21955,7 @@
                   "x": 6,
                   "y": 396
                },
-               "id": 164,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21979,7 +22110,7 @@
                   "x": 12,
                   "y": 396
                },
-               "id": 165,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22134,7 +22265,7 @@
                   "x": 18,
                   "y": 396
                },
-               "id": 166,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22292,7 +22423,7 @@
             "x": 0,
             "y": 404
          },
-         "id": 167,
+         "id": 168,
          "panels": [
             {
                "aliasColors": { },
@@ -22309,7 +22440,7 @@
                   "x": 0,
                   "y": 405
                },
-               "id": 168,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22452,7 +22583,7 @@
                   "x": 12,
                   "y": 405
                },
-               "id": 169,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22595,7 +22726,7 @@
                   "x": 0,
                   "y": 413
                },
-               "id": 170,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22732,7 +22863,7 @@
                   "x": 12,
                   "y": 413
                },
-               "id": 171,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22872,7 +23003,7 @@
             "x": 0,
             "y": 421
          },
-         "id": 172,
+         "id": 173,
          "panels": [
             {
                "aliasColors": { },
@@ -22889,7 +23020,7 @@
                   "x": 0,
                   "y": 422
                },
-               "id": 173,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23020,7 +23151,7 @@
                   "x": 0,
                   "y": 428
                },
-               "id": 174,
+               "id": 175,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23157,7 +23288,7 @@
                   "x": 12,
                   "y": 428
                },
-               "id": 175,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_compiled.json
+++ b/tests/Prometheus/dashboard_compiled.json
@@ -5720,11 +5720,11 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 3,
-               "description": "Memory used for the Lua runtime.\nLua memory is bounded by 2 GB per instance. \n",
+               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance. \n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 185
                },
@@ -5768,7 +5768,97 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Lua runtime memory",
+               "title": "Lua memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 3,
+               "description": "Memory used by runtime arena.\nRuntime arena stores network buffers, tuples\ncreated with box.tuple.new and other objects\nallocated by application not covered by basic\nLua mechanisms (spaces data and indexes\nare not included here, see memtx/vinyl arena).\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 185
+               },
+               "id": 75,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_runtime_used{job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Runtime arena memory",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -5814,11 +5904,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 185
                },
-               "id": 75,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5908,7 +5998,7 @@
                   "x": 0,
                   "y": 193
                },
-               "id": 76,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5998,7 +6088,7 @@
                   "x": 12,
                   "y": 193
                },
-               "id": 77,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6088,7 +6178,7 @@
                   "x": 0,
                   "y": 201
                },
-               "id": 78,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6178,7 +6268,7 @@
                   "x": 8,
                   "y": 201
                },
-               "id": 79,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6268,7 +6358,7 @@
                   "x": 16,
                   "y": 201
                },
-               "id": 80,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6361,7 +6451,7 @@
             "x": 0,
             "y": 209
          },
-         "id": 81,
+         "id": 82,
          "panels": [
             {
                "aliasColors": { },
@@ -6378,7 +6468,7 @@
                   "x": 0,
                   "y": 210
                },
-               "id": 82,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6468,7 +6558,7 @@
                   "x": 6,
                   "y": 210
                },
-               "id": 83,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6558,7 +6648,7 @@
                   "x": 12,
                   "y": 210
                },
-               "id": 84,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6648,7 +6738,7 @@
                   "x": 18,
                   "y": 210
                },
-               "id": 85,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6738,7 +6828,7 @@
                   "x": 0,
                   "y": 218
                },
-               "id": 86,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6828,7 +6918,7 @@
                   "x": 12,
                   "y": 218
                },
-               "id": 87,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6918,7 +7008,7 @@
                   "x": 0,
                   "y": 226
                },
-               "id": 88,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7008,7 +7098,7 @@
                   "x": 8,
                   "y": 226
                },
-               "id": 89,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7098,7 +7188,7 @@
                   "x": 16,
                   "y": 226
                },
-               "id": 90,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7188,7 +7278,7 @@
                   "x": 0,
                   "y": 234
                },
-               "id": 91,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7278,7 +7368,7 @@
                   "x": 8,
                   "y": 234
                },
-               "id": 92,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7368,7 +7458,7 @@
                   "x": 16,
                   "y": 234
                },
-               "id": 93,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7458,7 +7548,7 @@
                   "x": 0,
                   "y": 242
                },
-               "id": 94,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7548,7 +7638,7 @@
                   "x": 6,
                   "y": 242
                },
-               "id": 95,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7638,7 +7728,7 @@
                   "x": 12,
                   "y": 242
                },
-               "id": 96,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7728,7 +7818,7 @@
                   "x": 18,
                   "y": 242
                },
-               "id": 97,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7818,7 +7908,7 @@
                   "x": 0,
                   "y": 250
                },
-               "id": 98,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7908,7 +7998,7 @@
                   "x": 8,
                   "y": 250
                },
-               "id": 99,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7998,7 +8088,7 @@
                   "x": 16,
                   "y": 250
                },
-               "id": 100,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8091,7 +8181,7 @@
             "x": 0,
             "y": 258
          },
-         "id": 101,
+         "id": 102,
          "panels": [
             {
                "aliasColors": { },
@@ -8108,7 +8198,7 @@
                   "x": 0,
                   "y": 259
                },
-               "id": 102,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8198,7 +8288,7 @@
                   "x": 8,
                   "y": 259
                },
-               "id": 103,
+               "id": 104,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8288,7 +8378,7 @@
                   "x": 16,
                   "y": 259
                },
-               "id": 104,
+               "id": 105,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8378,7 +8468,7 @@
                   "x": 0,
                   "y": 267
                },
-               "id": 105,
+               "id": 106,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8468,7 +8558,7 @@
                   "x": 8,
                   "y": 267
                },
-               "id": 106,
+               "id": 107,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8558,7 +8648,7 @@
                   "x": 16,
                   "y": 267
                },
-               "id": 107,
+               "id": 108,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8648,7 +8738,7 @@
                   "x": 0,
                   "y": 275
                },
-               "id": 108,
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8738,7 +8828,7 @@
                   "x": 8,
                   "y": 275
                },
-               "id": 109,
+               "id": 110,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8828,7 +8918,7 @@
                   "x": 16,
                   "y": 275
                },
-               "id": 110,
+               "id": 111,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8918,7 +9008,7 @@
                   "x": 0,
                   "y": 283
                },
-               "id": 111,
+               "id": 112,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9008,7 +9098,7 @@
                   "x": 8,
                   "y": 283
                },
-               "id": 112,
+               "id": 113,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9098,7 +9188,7 @@
                   "x": 16,
                   "y": 283
                },
-               "id": 113,
+               "id": 114,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9191,7 +9281,7 @@
             "x": 0,
             "y": 291
          },
-         "id": 114,
+         "id": 115,
          "panels": [
             {
                "aliasColors": { },
@@ -9208,7 +9298,7 @@
                   "x": 0,
                   "y": 292
                },
-               "id": 115,
+               "id": 116,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9298,7 +9388,7 @@
                   "x": 6,
                   "y": 292
                },
-               "id": 116,
+               "id": 117,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9388,7 +9478,7 @@
                   "x": 12,
                   "y": 292
                },
-               "id": 117,
+               "id": 118,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9478,7 +9568,7 @@
                   "x": 18,
                   "y": 292
                },
-               "id": 118,
+               "id": 119,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9568,7 +9658,7 @@
                   "x": 0,
                   "y": 300
                },
-               "id": 119,
+               "id": 120,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9658,7 +9748,7 @@
                   "x": 8,
                   "y": 300
                },
-               "id": 120,
+               "id": 121,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9748,7 +9838,7 @@
                   "x": 16,
                   "y": 300
                },
-               "id": 121,
+               "id": 122,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9838,7 +9928,7 @@
                   "x": 0,
                   "y": 308
                },
-               "id": 122,
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9928,7 +10018,7 @@
                   "x": 6,
                   "y": 308
                },
-               "id": 123,
+               "id": 124,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10018,7 +10108,7 @@
                   "x": 12,
                   "y": 308
                },
-               "id": 124,
+               "id": 125,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10108,7 +10198,7 @@
                   "x": 18,
                   "y": 308
                },
-               "id": 125,
+               "id": 126,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10198,7 +10288,7 @@
                   "x": 0,
                   "y": 316
                },
-               "id": 126,
+               "id": 127,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10288,7 +10378,7 @@
                   "x": 6,
                   "y": 316
                },
-               "id": 127,
+               "id": 128,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10378,7 +10468,7 @@
                   "x": 12,
                   "y": 316
                },
-               "id": 128,
+               "id": 129,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10468,7 +10558,7 @@
                   "x": 18,
                   "y": 316
                },
-               "id": 129,
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10558,7 +10648,7 @@
                   "x": 0,
                   "y": 324
                },
-               "id": 130,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10648,7 +10738,7 @@
                   "x": 6,
                   "y": 324
                },
-               "id": 131,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10738,7 +10828,7 @@
                   "x": 12,
                   "y": 324
                },
-               "id": 132,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10828,7 +10918,7 @@
                   "x": 18,
                   "y": 324
                },
-               "id": 133,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10918,7 +11008,7 @@
                   "x": 0,
                   "y": 332
                },
-               "id": 134,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11008,7 +11098,7 @@
                   "x": 6,
                   "y": 332
                },
-               "id": 135,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11098,7 +11188,7 @@
                   "x": 12,
                   "y": 332
                },
-               "id": 136,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11188,7 +11278,7 @@
                   "x": 18,
                   "y": 332
                },
-               "id": 137,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11278,7 +11368,7 @@
                   "x": 0,
                   "y": 340
                },
-               "id": 138,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11368,7 +11458,7 @@
                   "x": 6,
                   "y": 340
                },
-               "id": 139,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11458,7 +11548,7 @@
                   "x": 12,
                   "y": 340
                },
-               "id": 140,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11548,7 +11638,7 @@
                   "x": 18,
                   "y": 340
                },
-               "id": 141,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11638,7 +11728,7 @@
                   "x": 0,
                   "y": 348
                },
-               "id": 142,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11728,7 +11818,7 @@
                   "x": 6,
                   "y": 348
                },
-               "id": 143,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11818,7 +11908,7 @@
                   "x": 12,
                   "y": 348
                },
-               "id": 144,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11908,7 +11998,7 @@
                   "x": 18,
                   "y": 348
                },
-               "id": 145,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11998,7 +12088,7 @@
                   "x": 0,
                   "y": 356
                },
-               "id": 146,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12088,7 +12178,7 @@
                   "x": 6,
                   "y": 356
                },
-               "id": 147,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12178,7 +12268,7 @@
                   "x": 12,
                   "y": 356
                },
-               "id": 148,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12268,7 +12358,7 @@
                   "x": 18,
                   "y": 356
                },
-               "id": 149,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12358,7 +12448,7 @@
                   "x": 0,
                   "y": 364
                },
-               "id": 150,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12448,7 +12538,7 @@
                   "x": 6,
                   "y": 364
                },
-               "id": 151,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12538,7 +12628,7 @@
                   "x": 12,
                   "y": 364
                },
-               "id": 152,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12628,7 +12718,7 @@
                   "x": 18,
                   "y": 364
                },
-               "id": 153,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12718,7 +12808,7 @@
                   "x": 0,
                   "y": 372
                },
-               "id": 154,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12808,7 +12898,7 @@
                   "x": 6,
                   "y": 372
                },
-               "id": 155,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12898,7 +12988,7 @@
                   "x": 12,
                   "y": 372
                },
-               "id": 156,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12988,7 +13078,7 @@
                   "x": 18,
                   "y": 372
                },
-               "id": 157,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13078,7 +13168,7 @@
                   "x": 0,
                   "y": 380
                },
-               "id": 158,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13168,7 +13258,7 @@
                   "x": 6,
                   "y": 380
                },
-               "id": 159,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13258,7 +13348,7 @@
                   "x": 12,
                   "y": 380
                },
-               "id": 160,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13348,7 +13438,7 @@
                   "x": 18,
                   "y": 380
                },
-               "id": 161,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13438,7 +13528,7 @@
                   "x": 0,
                   "y": 388
                },
-               "id": 162,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13528,7 +13618,7 @@
                   "x": 6,
                   "y": 388
                },
-               "id": 163,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13618,7 +13708,7 @@
                   "x": 12,
                   "y": 388
                },
-               "id": 164,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13708,7 +13798,7 @@
                   "x": 18,
                   "y": 388
                },
-               "id": 165,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13798,7 +13888,7 @@
                   "x": 0,
                   "y": 396
                },
-               "id": 166,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13888,7 +13978,7 @@
                   "x": 6,
                   "y": 396
                },
-               "id": 167,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13978,7 +14068,7 @@
                   "x": 12,
                   "y": 396
                },
-               "id": 168,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14068,7 +14158,7 @@
                   "x": 18,
                   "y": 396
                },
-               "id": 169,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14158,7 +14248,7 @@
                   "x": 0,
                   "y": 404
                },
-               "id": 170,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14248,7 +14338,7 @@
                   "x": 6,
                   "y": 404
                },
-               "id": 171,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14338,7 +14428,7 @@
                   "x": 12,
                   "y": 404
                },
-               "id": 172,
+               "id": 173,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14428,7 +14518,7 @@
                   "x": 18,
                   "y": 404
                },
-               "id": 173,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14521,7 +14611,7 @@
             "x": 0,
             "y": 412
          },
-         "id": 174,
+         "id": 175,
          "panels": [
             {
                "aliasColors": { },
@@ -14538,7 +14628,7 @@
                   "x": 0,
                   "y": 413
                },
-               "id": 175,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14628,7 +14718,7 @@
                   "x": 12,
                   "y": 413
                },
-               "id": 176,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14718,7 +14808,7 @@
                   "x": 0,
                   "y": 421
                },
-               "id": 177,
+               "id": 178,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14808,7 +14898,7 @@
                   "x": 12,
                   "y": 421
                },
-               "id": 178,
+               "id": 179,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_static_compiled.json
+++ b/tests/Prometheus/dashboard_static_compiled.json
@@ -5704,11 +5704,11 @@
                "dashes": false,
                "datasource": "Prometheus",
                "decimals": 3,
-               "description": "Memory used for the Lua runtime.\nLua memory is bounded by 2 GB per instance. \n",
+               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance. \n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 185
                },
@@ -5752,7 +5752,97 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Lua runtime memory",
+               "title": "Lua memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Memory used by runtime arena.\nRuntime arena stores network buffers, tuples\ncreated with box.tuple.new and other objects\nallocated by application not covered by basic\nLua mechanisms (spaces data and indexes\nare not included here, see memtx/vinyl arena).\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 185
+               },
+               "id": 75,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_runtime_used{job=~\"tarantool\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Runtime arena memory",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -5798,11 +5888,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 185
                },
-               "id": 75,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5892,7 +5982,7 @@
                   "x": 0,
                   "y": 193
                },
-               "id": 76,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5982,7 +6072,7 @@
                   "x": 12,
                   "y": 193
                },
-               "id": 77,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6072,7 +6162,7 @@
                   "x": 0,
                   "y": 201
                },
-               "id": 78,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6162,7 +6252,7 @@
                   "x": 8,
                   "y": 201
                },
-               "id": 79,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6252,7 +6342,7 @@
                   "x": 16,
                   "y": 201
                },
-               "id": 80,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6345,7 +6435,7 @@
             "x": 0,
             "y": 209
          },
-         "id": 81,
+         "id": 82,
          "panels": [
             {
                "aliasColors": { },
@@ -6362,7 +6452,7 @@
                   "x": 0,
                   "y": 210
                },
-               "id": 82,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6452,7 +6542,7 @@
                   "x": 6,
                   "y": 210
                },
-               "id": 83,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6542,7 +6632,7 @@
                   "x": 12,
                   "y": 210
                },
-               "id": 84,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6632,7 +6722,7 @@
                   "x": 18,
                   "y": 210
                },
-               "id": 85,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6722,7 +6812,7 @@
                   "x": 0,
                   "y": 218
                },
-               "id": 86,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6812,7 +6902,7 @@
                   "x": 12,
                   "y": 218
                },
-               "id": 87,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6902,7 +6992,7 @@
                   "x": 0,
                   "y": 226
                },
-               "id": 88,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6992,7 +7082,7 @@
                   "x": 8,
                   "y": 226
                },
-               "id": 89,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7082,7 +7172,7 @@
                   "x": 16,
                   "y": 226
                },
-               "id": 90,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7172,7 +7262,7 @@
                   "x": 0,
                   "y": 234
                },
-               "id": 91,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7262,7 +7352,7 @@
                   "x": 8,
                   "y": 234
                },
-               "id": 92,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7352,7 +7442,7 @@
                   "x": 16,
                   "y": 234
                },
-               "id": 93,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7442,7 +7532,7 @@
                   "x": 0,
                   "y": 242
                },
-               "id": 94,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7532,7 +7622,7 @@
                   "x": 6,
                   "y": 242
                },
-               "id": 95,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7622,7 +7712,7 @@
                   "x": 12,
                   "y": 242
                },
-               "id": 96,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7712,7 +7802,7 @@
                   "x": 18,
                   "y": 242
                },
-               "id": 97,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7802,7 +7892,7 @@
                   "x": 0,
                   "y": 250
                },
-               "id": 98,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7892,7 +7982,7 @@
                   "x": 8,
                   "y": 250
                },
-               "id": 99,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7982,7 +8072,7 @@
                   "x": 16,
                   "y": 250
                },
-               "id": 100,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8075,7 +8165,7 @@
             "x": 0,
             "y": 258
          },
-         "id": 101,
+         "id": 102,
          "panels": [
             {
                "aliasColors": { },
@@ -8092,7 +8182,7 @@
                   "x": 0,
                   "y": 259
                },
-               "id": 102,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8182,7 +8272,7 @@
                   "x": 8,
                   "y": 259
                },
-               "id": 103,
+               "id": 104,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8272,7 +8362,7 @@
                   "x": 16,
                   "y": 259
                },
-               "id": 104,
+               "id": 105,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8362,7 +8452,7 @@
                   "x": 0,
                   "y": 267
                },
-               "id": 105,
+               "id": 106,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8452,7 +8542,7 @@
                   "x": 8,
                   "y": 267
                },
-               "id": 106,
+               "id": 107,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8542,7 +8632,7 @@
                   "x": 16,
                   "y": 267
                },
-               "id": 107,
+               "id": 108,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8632,7 +8722,7 @@
                   "x": 0,
                   "y": 275
                },
-               "id": 108,
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8722,7 +8812,7 @@
                   "x": 8,
                   "y": 275
                },
-               "id": 109,
+               "id": 110,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8812,7 +8902,7 @@
                   "x": 16,
                   "y": 275
                },
-               "id": 110,
+               "id": 111,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8902,7 +8992,7 @@
                   "x": 0,
                   "y": 283
                },
-               "id": 111,
+               "id": 112,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8992,7 +9082,7 @@
                   "x": 8,
                   "y": 283
                },
-               "id": 112,
+               "id": 113,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9082,7 +9172,7 @@
                   "x": 16,
                   "y": 283
                },
-               "id": 113,
+               "id": 114,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9175,7 +9265,7 @@
             "x": 0,
             "y": 291
          },
-         "id": 114,
+         "id": 115,
          "panels": [
             {
                "aliasColors": { },
@@ -9192,7 +9282,7 @@
                   "x": 0,
                   "y": 292
                },
-               "id": 115,
+               "id": 116,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9282,7 +9372,7 @@
                   "x": 6,
                   "y": 292
                },
-               "id": 116,
+               "id": 117,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9372,7 +9462,7 @@
                   "x": 12,
                   "y": 292
                },
-               "id": 117,
+               "id": 118,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9462,7 +9552,7 @@
                   "x": 18,
                   "y": 292
                },
-               "id": 118,
+               "id": 119,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9552,7 +9642,7 @@
                   "x": 0,
                   "y": 300
                },
-               "id": 119,
+               "id": 120,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9642,7 +9732,7 @@
                   "x": 8,
                   "y": 300
                },
-               "id": 120,
+               "id": 121,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9732,7 +9822,7 @@
                   "x": 16,
                   "y": 300
                },
-               "id": 121,
+               "id": 122,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9822,7 +9912,7 @@
                   "x": 0,
                   "y": 308
                },
-               "id": 122,
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9912,7 +10002,7 @@
                   "x": 6,
                   "y": 308
                },
-               "id": 123,
+               "id": 124,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10002,7 +10092,7 @@
                   "x": 12,
                   "y": 308
                },
-               "id": 124,
+               "id": 125,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10092,7 +10182,7 @@
                   "x": 18,
                   "y": 308
                },
-               "id": 125,
+               "id": 126,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10182,7 +10272,7 @@
                   "x": 0,
                   "y": 316
                },
-               "id": 126,
+               "id": 127,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10272,7 +10362,7 @@
                   "x": 6,
                   "y": 316
                },
-               "id": 127,
+               "id": 128,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10362,7 +10452,7 @@
                   "x": 12,
                   "y": 316
                },
-               "id": 128,
+               "id": 129,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10452,7 +10542,7 @@
                   "x": 18,
                   "y": 316
                },
-               "id": 129,
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10542,7 +10632,7 @@
                   "x": 0,
                   "y": 324
                },
-               "id": 130,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10632,7 +10722,7 @@
                   "x": 6,
                   "y": 324
                },
-               "id": 131,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10722,7 +10812,7 @@
                   "x": 12,
                   "y": 324
                },
-               "id": 132,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10812,7 +10902,7 @@
                   "x": 18,
                   "y": 324
                },
-               "id": 133,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10902,7 +10992,7 @@
                   "x": 0,
                   "y": 332
                },
-               "id": 134,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10992,7 +11082,7 @@
                   "x": 6,
                   "y": 332
                },
-               "id": 135,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11082,7 +11172,7 @@
                   "x": 12,
                   "y": 332
                },
-               "id": 136,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11172,7 +11262,7 @@
                   "x": 18,
                   "y": 332
                },
-               "id": 137,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11262,7 +11352,7 @@
                   "x": 0,
                   "y": 340
                },
-               "id": 138,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11352,7 +11442,7 @@
                   "x": 6,
                   "y": 340
                },
-               "id": 139,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11442,7 +11532,7 @@
                   "x": 12,
                   "y": 340
                },
-               "id": 140,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11532,7 +11622,7 @@
                   "x": 18,
                   "y": 340
                },
-               "id": 141,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11622,7 +11712,7 @@
                   "x": 0,
                   "y": 348
                },
-               "id": 142,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11712,7 +11802,7 @@
                   "x": 6,
                   "y": 348
                },
-               "id": 143,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11802,7 +11892,7 @@
                   "x": 12,
                   "y": 348
                },
-               "id": 144,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11892,7 +11982,7 @@
                   "x": 18,
                   "y": 348
                },
-               "id": 145,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11982,7 +12072,7 @@
                   "x": 0,
                   "y": 356
                },
-               "id": 146,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12072,7 +12162,7 @@
                   "x": 6,
                   "y": 356
                },
-               "id": 147,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12162,7 +12252,7 @@
                   "x": 12,
                   "y": 356
                },
-               "id": 148,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12252,7 +12342,7 @@
                   "x": 18,
                   "y": 356
                },
-               "id": 149,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12342,7 +12432,7 @@
                   "x": 0,
                   "y": 364
                },
-               "id": 150,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12432,7 +12522,7 @@
                   "x": 6,
                   "y": 364
                },
-               "id": 151,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12522,7 +12612,7 @@
                   "x": 12,
                   "y": 364
                },
-               "id": 152,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12612,7 +12702,7 @@
                   "x": 18,
                   "y": 364
                },
-               "id": 153,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12702,7 +12792,7 @@
                   "x": 0,
                   "y": 372
                },
-               "id": 154,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12792,7 +12882,7 @@
                   "x": 6,
                   "y": 372
                },
-               "id": 155,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12882,7 +12972,7 @@
                   "x": 12,
                   "y": 372
                },
-               "id": 156,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12972,7 +13062,7 @@
                   "x": 18,
                   "y": 372
                },
-               "id": 157,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13062,7 +13152,7 @@
                   "x": 0,
                   "y": 380
                },
-               "id": 158,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13152,7 +13242,7 @@
                   "x": 6,
                   "y": 380
                },
-               "id": 159,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13242,7 +13332,7 @@
                   "x": 12,
                   "y": 380
                },
-               "id": 160,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13332,7 +13422,7 @@
                   "x": 18,
                   "y": 380
                },
-               "id": 161,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13422,7 +13512,7 @@
                   "x": 0,
                   "y": 388
                },
-               "id": 162,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13512,7 +13602,7 @@
                   "x": 6,
                   "y": 388
                },
-               "id": 163,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13602,7 +13692,7 @@
                   "x": 12,
                   "y": 388
                },
-               "id": 164,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13692,7 +13782,7 @@
                   "x": 18,
                   "y": 388
                },
-               "id": 165,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13782,7 +13872,7 @@
                   "x": 0,
                   "y": 396
                },
-               "id": 166,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13872,7 +13962,7 @@
                   "x": 6,
                   "y": 396
                },
-               "id": 167,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13962,7 +14052,7 @@
                   "x": 12,
                   "y": 396
                },
-               "id": 168,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14052,7 +14142,7 @@
                   "x": 18,
                   "y": 396
                },
-               "id": 169,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14142,7 +14232,7 @@
                   "x": 0,
                   "y": 404
                },
-               "id": 170,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14232,7 +14322,7 @@
                   "x": 6,
                   "y": 404
                },
-               "id": 171,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14322,7 +14412,7 @@
                   "x": 12,
                   "y": 404
                },
-               "id": 172,
+               "id": 173,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14412,7 +14502,7 @@
                   "x": 18,
                   "y": 404
                },
-               "id": 173,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14505,7 +14595,7 @@
             "x": 0,
             "y": 412
          },
-         "id": 174,
+         "id": 175,
          "panels": [
             {
                "aliasColors": { },
@@ -14522,7 +14612,7 @@
                   "x": 0,
                   "y": 413
                },
-               "id": 175,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14612,7 +14702,7 @@
                   "x": 12,
                   "y": 413
                },
-               "id": 176,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14702,7 +14792,7 @@
                   "x": 0,
                   "y": 421
                },
-               "id": 177,
+               "id": 178,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14792,7 +14882,7 @@
                   "x": 12,
                   "y": 421
                },
-               "id": 178,
+               "id": 179,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_tdg_compiled.json
+++ b/tests/Prometheus/dashboard_tdg_compiled.json
@@ -5340,11 +5340,11 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 3,
-               "description": "Memory used for the Lua runtime.\nLua memory is bounded by 2 GB per instance. \n",
+               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance. \n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 176
                },
@@ -5388,7 +5388,97 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Lua runtime memory",
+               "title": "Lua memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 3,
+               "description": "Memory used by runtime arena.\nRuntime arena stores network buffers, tuples\ncreated with box.tuple.new and other objects\nallocated by application not covered by basic\nLua mechanisms (spaces data and indexes\nare not included here, see memtx/vinyl arena).\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 176
+               },
+               "id": 70,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_runtime_used{job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Runtime arena memory",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -5434,11 +5524,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 176
                },
-               "id": 70,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5528,7 +5618,7 @@
                   "x": 0,
                   "y": 184
                },
-               "id": 71,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5618,7 +5708,7 @@
                   "x": 12,
                   "y": 184
                },
-               "id": 72,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5708,7 +5798,7 @@
                   "x": 0,
                   "y": 192
                },
-               "id": 73,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5798,7 +5888,7 @@
                   "x": 8,
                   "y": 192
                },
-               "id": 74,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5888,7 +5978,7 @@
                   "x": 16,
                   "y": 192
                },
-               "id": 75,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5981,7 +6071,7 @@
             "x": 0,
             "y": 200
          },
-         "id": 76,
+         "id": 77,
          "panels": [
             {
                "aliasColors": { },
@@ -5998,7 +6088,7 @@
                   "x": 0,
                   "y": 201
                },
-               "id": 77,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6088,7 +6178,7 @@
                   "x": 6,
                   "y": 201
                },
-               "id": 78,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6178,7 +6268,7 @@
                   "x": 12,
                   "y": 201
                },
-               "id": 79,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6268,7 +6358,7 @@
                   "x": 18,
                   "y": 201
                },
-               "id": 80,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6358,7 +6448,7 @@
                   "x": 0,
                   "y": 209
                },
-               "id": 81,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6448,7 +6538,7 @@
                   "x": 12,
                   "y": 209
                },
-               "id": 82,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6538,7 +6628,7 @@
                   "x": 0,
                   "y": 217
                },
-               "id": 83,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6628,7 +6718,7 @@
                   "x": 8,
                   "y": 217
                },
-               "id": 84,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6718,7 +6808,7 @@
                   "x": 16,
                   "y": 217
                },
-               "id": 85,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6808,7 +6898,7 @@
                   "x": 0,
                   "y": 225
                },
-               "id": 86,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6898,7 +6988,7 @@
                   "x": 8,
                   "y": 225
                },
-               "id": 87,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6988,7 +7078,7 @@
                   "x": 16,
                   "y": 225
                },
-               "id": 88,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7078,7 +7168,7 @@
                   "x": 0,
                   "y": 233
                },
-               "id": 89,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7168,7 +7258,7 @@
                   "x": 6,
                   "y": 233
                },
-               "id": 90,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7258,7 +7348,7 @@
                   "x": 12,
                   "y": 233
                },
-               "id": 91,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7348,7 +7438,7 @@
                   "x": 18,
                   "y": 233
                },
-               "id": 92,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7438,7 +7528,7 @@
                   "x": 0,
                   "y": 241
                },
-               "id": 93,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7528,7 +7618,7 @@
                   "x": 8,
                   "y": 241
                },
-               "id": 94,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7618,7 +7708,7 @@
                   "x": 16,
                   "y": 241
                },
-               "id": 95,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7711,7 +7801,7 @@
             "x": 0,
             "y": 249
          },
-         "id": 96,
+         "id": 97,
          "panels": [
             {
                "aliasColors": { },
@@ -7728,7 +7818,7 @@
                   "x": 0,
                   "y": 250
                },
-               "id": 97,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7818,7 +7908,7 @@
                   "x": 8,
                   "y": 250
                },
-               "id": 98,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7908,7 +7998,7 @@
                   "x": 16,
                   "y": 250
                },
-               "id": 99,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7998,7 +8088,7 @@
                   "x": 0,
                   "y": 258
                },
-               "id": 100,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8088,7 +8178,7 @@
                   "x": 8,
                   "y": 258
                },
-               "id": 101,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8178,7 +8268,7 @@
                   "x": 16,
                   "y": 258
                },
-               "id": 102,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8268,7 +8358,7 @@
                   "x": 0,
                   "y": 266
                },
-               "id": 103,
+               "id": 104,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8358,7 +8448,7 @@
                   "x": 8,
                   "y": 266
                },
-               "id": 104,
+               "id": 105,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8448,7 +8538,7 @@
                   "x": 16,
                   "y": 266
                },
-               "id": 105,
+               "id": 106,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8538,7 +8628,7 @@
                   "x": 0,
                   "y": 274
                },
-               "id": 106,
+               "id": 107,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8628,7 +8718,7 @@
                   "x": 8,
                   "y": 274
                },
-               "id": 107,
+               "id": 108,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8718,7 +8808,7 @@
                   "x": 16,
                   "y": 274
                },
-               "id": 108,
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8811,7 +8901,7 @@
             "x": 0,
             "y": 282
          },
-         "id": 109,
+         "id": 110,
          "panels": [
             {
                "aliasColors": { },
@@ -8828,7 +8918,7 @@
                   "x": 0,
                   "y": 283
                },
-               "id": 110,
+               "id": 111,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8918,7 +9008,7 @@
                   "x": 8,
                   "y": 283
                },
-               "id": 111,
+               "id": 112,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9008,7 +9098,7 @@
                   "x": 16,
                   "y": 283
                },
-               "id": 112,
+               "id": 113,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9098,7 +9188,7 @@
                   "x": 0,
                   "y": 291
                },
-               "id": 113,
+               "id": 114,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9188,7 +9278,7 @@
                   "x": 6,
                   "y": 291
                },
-               "id": 114,
+               "id": 115,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9278,7 +9368,7 @@
                   "x": 12,
                   "y": 291
                },
-               "id": 115,
+               "id": 116,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9368,7 +9458,7 @@
                   "x": 18,
                   "y": 291
                },
-               "id": 116,
+               "id": 117,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9458,7 +9548,7 @@
                   "x": 0,
                   "y": 299
                },
-               "id": 117,
+               "id": 118,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9548,7 +9638,7 @@
                   "x": 6,
                   "y": 299
                },
-               "id": 118,
+               "id": 119,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9638,7 +9728,7 @@
                   "x": 12,
                   "y": 299
                },
-               "id": 119,
+               "id": 120,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9728,7 +9818,7 @@
                   "x": 18,
                   "y": 299
                },
-               "id": 120,
+               "id": 121,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9821,7 +9911,7 @@
             "x": 0,
             "y": 307
          },
-         "id": 121,
+         "id": 122,
          "panels": [
             {
                "aliasColors": { },
@@ -9838,7 +9928,7 @@
                   "x": 0,
                   "y": 308
                },
-               "id": 122,
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -9928,7 +10018,7 @@
                   "x": 6,
                   "y": 308
                },
-               "id": 123,
+               "id": 124,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10018,7 +10108,7 @@
                   "x": 12,
                   "y": 308
                },
-               "id": 124,
+               "id": 125,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10108,7 +10198,7 @@
                   "x": 18,
                   "y": 308
                },
-               "id": 125,
+               "id": 126,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10198,7 +10288,7 @@
                   "x": 0,
                   "y": 316
                },
-               "id": 126,
+               "id": 127,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10288,7 +10378,7 @@
                   "x": 6,
                   "y": 316
                },
-               "id": 127,
+               "id": 128,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10378,7 +10468,7 @@
                   "x": 12,
                   "y": 316
                },
-               "id": 128,
+               "id": 129,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10468,7 +10558,7 @@
                   "x": 18,
                   "y": 316
                },
-               "id": 129,
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10558,7 +10648,7 @@
                   "x": 0,
                   "y": 324
                },
-               "id": 130,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10648,7 +10738,7 @@
                   "x": 8,
                   "y": 324
                },
-               "id": 131,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10738,7 +10828,7 @@
                   "x": 16,
                   "y": 324
                },
-               "id": 132,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10828,7 +10918,7 @@
                   "x": 0,
                   "y": 332
                },
-               "id": 133,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10918,7 +11008,7 @@
                   "x": 8,
                   "y": 332
                },
-               "id": 134,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -11008,7 +11098,7 @@
                   "x": 16,
                   "y": 332
                },
-               "id": 135,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11098,7 +11188,7 @@
                   "x": 0,
                   "y": 340
                },
-               "id": 136,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11188,7 +11278,7 @@
                   "x": 8,
                   "y": 340
                },
-               "id": 137,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11278,7 +11368,7 @@
                   "x": 16,
                   "y": 340
                },
-               "id": 138,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11368,7 +11458,7 @@
                   "x": 0,
                   "y": 348
                },
-               "id": 139,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11458,7 +11548,7 @@
                   "x": 8,
                   "y": 348
                },
-               "id": 140,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -11548,7 +11638,7 @@
                   "x": 16,
                   "y": 348
                },
-               "id": 141,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11638,7 +11728,7 @@
                   "x": 0,
                   "y": 356
                },
-               "id": 142,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11728,7 +11818,7 @@
                   "x": 0,
                   "y": 366
                },
-               "id": 143,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11818,7 +11908,7 @@
                   "x": 6,
                   "y": 366
                },
-               "id": 144,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11908,7 +11998,7 @@
                   "x": 12,
                   "y": 366
                },
-               "id": 145,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11998,7 +12088,7 @@
                   "x": 18,
                   "y": 366
                },
-               "id": 146,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12091,7 +12181,7 @@
             "x": 0,
             "y": 374
          },
-         "id": 147,
+         "id": 148,
          "panels": [
             {
                "aliasColors": { },
@@ -12108,7 +12198,7 @@
                   "x": 0,
                   "y": 375
                },
-               "id": 148,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12198,7 +12288,7 @@
                   "x": 12,
                   "y": 375
                },
-               "id": 149,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12288,7 +12378,7 @@
                   "x": 0,
                   "y": 383
                },
-               "id": 150,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12378,7 +12468,7 @@
                   "x": 12,
                   "y": 383
                },
-               "id": 151,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12468,7 +12558,7 @@
                   "x": 0,
                   "y": 391
                },
-               "id": 152,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12558,7 +12648,7 @@
                   "x": 8,
                   "y": 391
                },
-               "id": 153,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12648,7 +12738,7 @@
                   "x": 16,
                   "y": 391
                },
-               "id": 154,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12738,7 +12828,7 @@
                   "x": 0,
                   "y": 399
                },
-               "id": 155,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12828,7 +12918,7 @@
                   "x": 8,
                   "y": 399
                },
-               "id": 156,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12918,7 +13008,7 @@
                   "x": 16,
                   "y": 399
                },
-               "id": 157,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13008,7 +13098,7 @@
                   "x": 0,
                   "y": 407
                },
-               "id": 158,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13098,7 +13188,7 @@
                   "x": 6,
                   "y": 407
                },
-               "id": 159,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13188,7 +13278,7 @@
                   "x": 12,
                   "y": 407
                },
-               "id": 160,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13278,7 +13368,7 @@
                   "x": 18,
                   "y": 407
                },
-               "id": 161,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13368,7 +13458,7 @@
                   "x": 0,
                   "y": 415
                },
-               "id": 162,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13458,7 +13548,7 @@
                   "x": 12,
                   "y": 415
                },
-               "id": 163,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13551,7 +13641,7 @@
             "x": 0,
             "y": 423
          },
-         "id": 164,
+         "id": 165,
          "panels": [
             {
                "aliasColors": { },
@@ -13568,7 +13658,7 @@
                   "x": 0,
                   "y": 424
                },
-               "id": 165,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -13658,7 +13748,7 @@
                   "x": 12,
                   "y": 424
                },
-               "id": 166,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13748,7 +13838,7 @@
                   "x": 0,
                   "y": 432
                },
-               "id": 167,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13838,7 +13928,7 @@
                   "x": 12,
                   "y": 432
                },
-               "id": 168,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13931,7 +14021,7 @@
             "x": 0,
             "y": 440
          },
-         "id": 169,
+         "id": 170,
          "panels": [
             {
                "aliasColors": { },
@@ -13948,7 +14038,7 @@
                   "x": 0,
                   "y": 441
                },
-               "id": 170,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -14038,7 +14128,7 @@
                   "x": 12,
                   "y": 441
                },
-               "id": 171,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -14131,7 +14221,7 @@
             "x": 0,
             "y": 449
          },
-         "id": 172,
+         "id": 173,
          "panels": [
             {
                "aliasColors": { },
@@ -14148,7 +14238,7 @@
                   "x": 0,
                   "y": 450
                },
-               "id": 173,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14238,7 +14328,7 @@
                   "x": 12,
                   "y": 450
                },
-               "id": 174,
+               "id": 175,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14328,7 +14418,7 @@
                   "x": 0,
                   "y": 458
                },
-               "id": 175,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14418,7 +14508,7 @@
                   "x": 12,
                   "y": 458
                },
-               "id": 176,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14511,7 +14601,7 @@
             "x": 0,
             "y": 466
          },
-         "id": 177,
+         "id": 178,
          "panels": [
             {
                "aliasColors": { },
@@ -14528,7 +14618,7 @@
                   "x": 0,
                   "y": 467
                },
-               "id": 178,
+               "id": 179,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14618,7 +14708,7 @@
                   "x": 12,
                   "y": 467
                },
-               "id": 179,
+               "id": 180,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14708,7 +14798,7 @@
                   "x": 0,
                   "y": 475
                },
-               "id": 180,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14798,7 +14888,7 @@
                   "x": 12,
                   "y": 475
                },
-               "id": 181,
+               "id": 182,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14891,7 +14981,7 @@
             "x": 0,
             "y": 483
          },
-         "id": 182,
+         "id": 183,
          "panels": [
             {
                "aliasColors": { },
@@ -14908,7 +14998,7 @@
                   "x": 0,
                   "y": 484
                },
-               "id": 183,
+               "id": 184,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -14998,7 +15088,7 @@
                   "x": 8,
                   "y": 484
                },
-               "id": 184,
+               "id": 185,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15088,7 +15178,7 @@
                   "x": 16,
                   "y": 484
                },
-               "id": 185,
+               "id": 186,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15178,7 +15268,7 @@
                   "x": 0,
                   "y": 492
                },
-               "id": 186,
+               "id": 187,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15268,7 +15358,7 @@
                   "x": 8,
                   "y": 492
                },
-               "id": 187,
+               "id": 188,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15358,7 +15448,7 @@
                   "x": 16,
                   "y": 492
                },
-               "id": 188,
+               "id": 189,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15451,7 +15541,7 @@
             "x": 0,
             "y": 500
          },
-         "id": 189,
+         "id": 190,
          "panels": [
             {
                "aliasColors": { },
@@ -15468,7 +15558,7 @@
                   "x": 0,
                   "y": 501
                },
-               "id": 190,
+               "id": 191,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15558,7 +15648,7 @@
                   "x": 8,
                   "y": 501
                },
-               "id": 191,
+               "id": 192,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15648,7 +15738,7 @@
                   "x": 16,
                   "y": 501
                },
-               "id": 192,
+               "id": 193,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15738,7 +15828,7 @@
                   "x": 0,
                   "y": 509
                },
-               "id": 193,
+               "id": 194,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15828,7 +15918,7 @@
                   "x": 8,
                   "y": 509
                },
-               "id": 194,
+               "id": 195,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15918,7 +16008,7 @@
                   "x": 16,
                   "y": 509
                },
-               "id": 195,
+               "id": 196,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16011,7 +16101,7 @@
             "x": 0,
             "y": 517
          },
-         "id": 196,
+         "id": 197,
          "panels": [
             {
                "aliasColors": { },
@@ -16028,7 +16118,7 @@
                   "x": 0,
                   "y": 518
                },
-               "id": 197,
+               "id": 198,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16118,7 +16208,7 @@
                   "x": 6,
                   "y": 518
                },
-               "id": 198,
+               "id": 199,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16208,7 +16298,7 @@
                   "x": 12,
                   "y": 518
                },
-               "id": 199,
+               "id": 200,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16298,7 +16388,7 @@
                   "x": 18,
                   "y": 518
                },
-               "id": 200,
+               "id": 201,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16388,7 +16478,7 @@
                   "x": 0,
                   "y": 526
                },
-               "id": 201,
+               "id": 202,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16478,7 +16568,7 @@
                   "x": 12,
                   "y": 526
                },
-               "id": 202,
+               "id": 203,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16568,7 +16658,7 @@
                   "x": 0,
                   "y": 534
                },
-               "id": 203,
+               "id": 204,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16658,7 +16748,7 @@
                   "x": 6,
                   "y": 534
                },
-               "id": 204,
+               "id": 205,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16748,7 +16838,7 @@
                   "x": 12,
                   "y": 534
                },
-               "id": 205,
+               "id": 206,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16838,7 +16928,7 @@
                   "x": 18,
                   "y": 534
                },
-               "id": 206,
+               "id": 207,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16928,7 +17018,7 @@
                   "x": 0,
                   "y": 542
                },
-               "id": 207,
+               "id": 208,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17018,7 +17108,7 @@
                   "x": 6,
                   "y": 542
                },
-               "id": 208,
+               "id": 209,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17108,7 +17198,7 @@
                   "x": 12,
                   "y": 542
                },
-               "id": 209,
+               "id": 210,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17198,7 +17288,7 @@
                   "x": 18,
                   "y": 542
                },
-               "id": 210,
+               "id": 211,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17288,7 +17378,7 @@
                   "x": 0,
                   "y": 550
                },
-               "id": 211,
+               "id": 212,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17378,7 +17468,7 @@
                   "x": 6,
                   "y": 550
                },
-               "id": 212,
+               "id": 213,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17468,7 +17558,7 @@
                   "x": 12,
                   "y": 550
                },
-               "id": 213,
+               "id": 214,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17558,7 +17648,7 @@
                   "x": 18,
                   "y": 550
                },
-               "id": 214,
+               "id": 215,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17651,7 +17741,7 @@
             "x": 0,
             "y": 558
          },
-         "id": 215,
+         "id": 216,
          "panels": [
             {
                "aliasColors": { },
@@ -17668,7 +17758,7 @@
                   "x": 0,
                   "y": 559
                },
-               "id": 216,
+               "id": 217,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17758,7 +17848,7 @@
                   "x": 8,
                   "y": 559
                },
-               "id": 217,
+               "id": 218,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17848,7 +17938,7 @@
                   "x": 16,
                   "y": 559
                },
-               "id": 218,
+               "id": 219,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17938,7 +18028,7 @@
                   "x": 0,
                   "y": 567
                },
-               "id": 219,
+               "id": 220,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18028,7 +18118,7 @@
                   "x": 8,
                   "y": 567
                },
-               "id": 220,
+               "id": 221,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18118,7 +18208,7 @@
                   "x": 16,
                   "y": 567
                },
-               "id": 221,
+               "id": 222,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18208,7 +18298,7 @@
                   "x": 0,
                   "y": 575
                },
-               "id": 222,
+               "id": 223,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18298,7 +18388,7 @@
                   "x": 8,
                   "y": 575
                },
-               "id": 223,
+               "id": 224,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18388,7 +18478,7 @@
                   "x": 16,
                   "y": 575
                },
-               "id": 224,
+               "id": 225,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18478,7 +18568,7 @@
                   "x": 0,
                   "y": 583
                },
-               "id": 225,
+               "id": 226,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18568,7 +18658,7 @@
                   "x": 8,
                   "y": 583
                },
-               "id": 226,
+               "id": 227,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18658,7 +18748,7 @@
                   "x": 16,
                   "y": 583
                },
-               "id": 227,
+               "id": 228,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18751,7 +18841,7 @@
             "x": 0,
             "y": 591
          },
-         "id": 228,
+         "id": 229,
          "panels": [
             {
                "aliasColors": { },
@@ -18768,7 +18858,7 @@
                   "x": 0,
                   "y": 592
                },
-               "id": 229,
+               "id": 230,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18858,7 +18948,7 @@
                   "x": 8,
                   "y": 592
                },
-               "id": 230,
+               "id": 231,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18948,7 +19038,7 @@
                   "x": 16,
                   "y": 592
                },
-               "id": 231,
+               "id": 232,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19038,7 +19128,7 @@
                   "x": 0,
                   "y": 600
                },
-               "id": 232,
+               "id": 233,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -19128,7 +19218,7 @@
                   "x": 12,
                   "y": 600
                },
-               "id": 233,
+               "id": 234,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19218,7 +19308,7 @@
                   "x": 0,
                   "y": 608
                },
-               "id": 234,
+               "id": 235,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19308,7 +19398,7 @@
                   "x": 6,
                   "y": 608
                },
-               "id": 235,
+               "id": 236,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19398,7 +19488,7 @@
                   "x": 12,
                   "y": 608
                },
-               "id": 236,
+               "id": 237,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19488,7 +19578,7 @@
                   "x": 18,
                   "y": 608
                },
-               "id": 237,
+               "id": 238,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19578,7 +19668,7 @@
                   "x": 0,
                   "y": 616
                },
-               "id": 238,
+               "id": 239,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -19668,7 +19758,7 @@
                   "x": 12,
                   "y": 616
                },
-               "id": 239,
+               "id": 240,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19758,7 +19848,7 @@
                   "x": 0,
                   "y": 624
                },
-               "id": 240,
+               "id": 241,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19848,7 +19938,7 @@
                   "x": 8,
                   "y": 624
                },
-               "id": 241,
+               "id": 242,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19938,7 +20028,7 @@
                   "x": 16,
                   "y": 624
                },
-               "id": 242,
+               "id": 243,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20028,7 +20118,7 @@
                   "x": 0,
                   "y": 632
                },
-               "id": 243,
+               "id": 244,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -20118,7 +20208,7 @@
                   "x": 12,
                   "y": 632
                },
-               "id": 244,
+               "id": 245,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_tdg_static_compiled.json
+++ b/tests/Prometheus/dashboard_tdg_static_compiled.json
@@ -5324,11 +5324,11 @@
                "dashes": false,
                "datasource": "Prometheus",
                "decimals": 3,
-               "description": "Memory used for the Lua runtime.\nLua memory is bounded by 2 GB per instance. \n",
+               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance. \n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 176
                },
@@ -5372,7 +5372,97 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Lua runtime memory",
+               "title": "Lua memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Memory used by runtime arena.\nRuntime arena stores network buffers, tuples\ncreated with box.tuple.new and other objects\nallocated by application not covered by basic\nLua mechanisms (spaces data and indexes\nare not included here, see memtx/vinyl arena).\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 176
+               },
+               "id": 70,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_runtime_used{job=~\"tarantool\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Runtime arena memory",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -5418,11 +5508,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 176
                },
-               "id": 70,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5512,7 +5602,7 @@
                   "x": 0,
                   "y": 184
                },
-               "id": 71,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5602,7 +5692,7 @@
                   "x": 12,
                   "y": 184
                },
-               "id": 72,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5692,7 +5782,7 @@
                   "x": 0,
                   "y": 192
                },
-               "id": 73,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5782,7 +5872,7 @@
                   "x": 8,
                   "y": 192
                },
-               "id": 74,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5872,7 +5962,7 @@
                   "x": 16,
                   "y": 192
                },
-               "id": 75,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5965,7 +6055,7 @@
             "x": 0,
             "y": 200
          },
-         "id": 76,
+         "id": 77,
          "panels": [
             {
                "aliasColors": { },
@@ -5982,7 +6072,7 @@
                   "x": 0,
                   "y": 201
                },
-               "id": 77,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6072,7 +6162,7 @@
                   "x": 6,
                   "y": 201
                },
-               "id": 78,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6162,7 +6252,7 @@
                   "x": 12,
                   "y": 201
                },
-               "id": 79,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6252,7 +6342,7 @@
                   "x": 18,
                   "y": 201
                },
-               "id": 80,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6342,7 +6432,7 @@
                   "x": 0,
                   "y": 209
                },
-               "id": 81,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6432,7 +6522,7 @@
                   "x": 12,
                   "y": 209
                },
-               "id": 82,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6522,7 +6612,7 @@
                   "x": 0,
                   "y": 217
                },
-               "id": 83,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6612,7 +6702,7 @@
                   "x": 8,
                   "y": 217
                },
-               "id": 84,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6702,7 +6792,7 @@
                   "x": 16,
                   "y": 217
                },
-               "id": 85,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6792,7 +6882,7 @@
                   "x": 0,
                   "y": 225
                },
-               "id": 86,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6882,7 +6972,7 @@
                   "x": 8,
                   "y": 225
                },
-               "id": 87,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6972,7 +7062,7 @@
                   "x": 16,
                   "y": 225
                },
-               "id": 88,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7062,7 +7152,7 @@
                   "x": 0,
                   "y": 233
                },
-               "id": 89,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7152,7 +7242,7 @@
                   "x": 6,
                   "y": 233
                },
-               "id": 90,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7242,7 +7332,7 @@
                   "x": 12,
                   "y": 233
                },
-               "id": 91,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7332,7 +7422,7 @@
                   "x": 18,
                   "y": 233
                },
-               "id": 92,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7422,7 +7512,7 @@
                   "x": 0,
                   "y": 241
                },
-               "id": 93,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7512,7 +7602,7 @@
                   "x": 8,
                   "y": 241
                },
-               "id": 94,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7602,7 +7692,7 @@
                   "x": 16,
                   "y": 241
                },
-               "id": 95,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7695,7 +7785,7 @@
             "x": 0,
             "y": 249
          },
-         "id": 96,
+         "id": 97,
          "panels": [
             {
                "aliasColors": { },
@@ -7712,7 +7802,7 @@
                   "x": 0,
                   "y": 250
                },
-               "id": 97,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7802,7 +7892,7 @@
                   "x": 8,
                   "y": 250
                },
-               "id": 98,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7892,7 +7982,7 @@
                   "x": 16,
                   "y": 250
                },
-               "id": 99,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7982,7 +8072,7 @@
                   "x": 0,
                   "y": 258
                },
-               "id": 100,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8072,7 +8162,7 @@
                   "x": 8,
                   "y": 258
                },
-               "id": 101,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8162,7 +8252,7 @@
                   "x": 16,
                   "y": 258
                },
-               "id": 102,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8252,7 +8342,7 @@
                   "x": 0,
                   "y": 266
                },
-               "id": 103,
+               "id": 104,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8342,7 +8432,7 @@
                   "x": 8,
                   "y": 266
                },
-               "id": 104,
+               "id": 105,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8432,7 +8522,7 @@
                   "x": 16,
                   "y": 266
                },
-               "id": 105,
+               "id": 106,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8522,7 +8612,7 @@
                   "x": 0,
                   "y": 274
                },
-               "id": 106,
+               "id": 107,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8612,7 +8702,7 @@
                   "x": 8,
                   "y": 274
                },
-               "id": 107,
+               "id": 108,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8702,7 +8792,7 @@
                   "x": 16,
                   "y": 274
                },
-               "id": 108,
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8795,7 +8885,7 @@
             "x": 0,
             "y": 282
          },
-         "id": 109,
+         "id": 110,
          "panels": [
             {
                "aliasColors": { },
@@ -8812,7 +8902,7 @@
                   "x": 0,
                   "y": 283
                },
-               "id": 110,
+               "id": 111,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8902,7 +8992,7 @@
                   "x": 8,
                   "y": 283
                },
-               "id": 111,
+               "id": 112,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8992,7 +9082,7 @@
                   "x": 16,
                   "y": 283
                },
-               "id": 112,
+               "id": 113,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9082,7 +9172,7 @@
                   "x": 0,
                   "y": 291
                },
-               "id": 113,
+               "id": 114,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9172,7 +9262,7 @@
                   "x": 6,
                   "y": 291
                },
-               "id": 114,
+               "id": 115,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9262,7 +9352,7 @@
                   "x": 12,
                   "y": 291
                },
-               "id": 115,
+               "id": 116,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9352,7 +9442,7 @@
                   "x": 18,
                   "y": 291
                },
-               "id": 116,
+               "id": 117,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9442,7 +9532,7 @@
                   "x": 0,
                   "y": 299
                },
-               "id": 117,
+               "id": 118,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9532,7 +9622,7 @@
                   "x": 6,
                   "y": 299
                },
-               "id": 118,
+               "id": 119,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9622,7 +9712,7 @@
                   "x": 12,
                   "y": 299
                },
-               "id": 119,
+               "id": 120,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9712,7 +9802,7 @@
                   "x": 18,
                   "y": 299
                },
-               "id": 120,
+               "id": 121,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9805,7 +9895,7 @@
             "x": 0,
             "y": 307
          },
-         "id": 121,
+         "id": 122,
          "panels": [
             {
                "aliasColors": { },
@@ -9822,7 +9912,7 @@
                   "x": 0,
                   "y": 308
                },
-               "id": 122,
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -9912,7 +10002,7 @@
                   "x": 6,
                   "y": 308
                },
-               "id": 123,
+               "id": 124,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10002,7 +10092,7 @@
                   "x": 12,
                   "y": 308
                },
-               "id": 124,
+               "id": 125,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10092,7 +10182,7 @@
                   "x": 18,
                   "y": 308
                },
-               "id": 125,
+               "id": 126,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10182,7 +10272,7 @@
                   "x": 0,
                   "y": 316
                },
-               "id": 126,
+               "id": 127,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10272,7 +10362,7 @@
                   "x": 6,
                   "y": 316
                },
-               "id": 127,
+               "id": 128,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10362,7 +10452,7 @@
                   "x": 12,
                   "y": 316
                },
-               "id": 128,
+               "id": 129,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10452,7 +10542,7 @@
                   "x": 18,
                   "y": 316
                },
-               "id": 129,
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10542,7 +10632,7 @@
                   "x": 0,
                   "y": 324
                },
-               "id": 130,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10632,7 +10722,7 @@
                   "x": 8,
                   "y": 324
                },
-               "id": 131,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10722,7 +10812,7 @@
                   "x": 16,
                   "y": 324
                },
-               "id": 132,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10812,7 +10902,7 @@
                   "x": 0,
                   "y": 332
                },
-               "id": 133,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10902,7 +10992,7 @@
                   "x": 8,
                   "y": 332
                },
-               "id": 134,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -10992,7 +11082,7 @@
                   "x": 16,
                   "y": 332
                },
-               "id": 135,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11082,7 +11172,7 @@
                   "x": 0,
                   "y": 340
                },
-               "id": 136,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11172,7 +11262,7 @@
                   "x": 8,
                   "y": 340
                },
-               "id": 137,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11262,7 +11352,7 @@
                   "x": 16,
                   "y": 340
                },
-               "id": 138,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11352,7 +11442,7 @@
                   "x": 0,
                   "y": 348
                },
-               "id": 139,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11442,7 +11532,7 @@
                   "x": 8,
                   "y": 348
                },
-               "id": 140,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -11532,7 +11622,7 @@
                   "x": 16,
                   "y": 348
                },
-               "id": 141,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11622,7 +11712,7 @@
                   "x": 0,
                   "y": 356
                },
-               "id": 142,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11712,7 +11802,7 @@
                   "x": 0,
                   "y": 366
                },
-               "id": 143,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11802,7 +11892,7 @@
                   "x": 6,
                   "y": 366
                },
-               "id": 144,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11892,7 +11982,7 @@
                   "x": 12,
                   "y": 366
                },
-               "id": 145,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11982,7 +12072,7 @@
                   "x": 18,
                   "y": 366
                },
-               "id": 146,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12075,7 +12165,7 @@
             "x": 0,
             "y": 374
          },
-         "id": 147,
+         "id": 148,
          "panels": [
             {
                "aliasColors": { },
@@ -12092,7 +12182,7 @@
                   "x": 0,
                   "y": 375
                },
-               "id": 148,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12182,7 +12272,7 @@
                   "x": 12,
                   "y": 375
                },
-               "id": 149,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12272,7 +12362,7 @@
                   "x": 0,
                   "y": 383
                },
-               "id": 150,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12362,7 +12452,7 @@
                   "x": 12,
                   "y": 383
                },
-               "id": 151,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12452,7 +12542,7 @@
                   "x": 0,
                   "y": 391
                },
-               "id": 152,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12542,7 +12632,7 @@
                   "x": 8,
                   "y": 391
                },
-               "id": 153,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12632,7 +12722,7 @@
                   "x": 16,
                   "y": 391
                },
-               "id": 154,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12722,7 +12812,7 @@
                   "x": 0,
                   "y": 399
                },
-               "id": 155,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12812,7 +12902,7 @@
                   "x": 8,
                   "y": 399
                },
-               "id": 156,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12902,7 +12992,7 @@
                   "x": 16,
                   "y": 399
                },
-               "id": 157,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12992,7 +13082,7 @@
                   "x": 0,
                   "y": 407
                },
-               "id": 158,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13082,7 +13172,7 @@
                   "x": 6,
                   "y": 407
                },
-               "id": 159,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13172,7 +13262,7 @@
                   "x": 12,
                   "y": 407
                },
-               "id": 160,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13262,7 +13352,7 @@
                   "x": 18,
                   "y": 407
                },
-               "id": 161,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13352,7 +13442,7 @@
                   "x": 0,
                   "y": 415
                },
-               "id": 162,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13442,7 +13532,7 @@
                   "x": 12,
                   "y": 415
                },
-               "id": 163,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13535,7 +13625,7 @@
             "x": 0,
             "y": 423
          },
-         "id": 164,
+         "id": 165,
          "panels": [
             {
                "aliasColors": { },
@@ -13552,7 +13642,7 @@
                   "x": 0,
                   "y": 424
                },
-               "id": 165,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -13642,7 +13732,7 @@
                   "x": 12,
                   "y": 424
                },
-               "id": 166,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13732,7 +13822,7 @@
                   "x": 0,
                   "y": 432
                },
-               "id": 167,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13822,7 +13912,7 @@
                   "x": 12,
                   "y": 432
                },
-               "id": 168,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13915,7 +14005,7 @@
             "x": 0,
             "y": 440
          },
-         "id": 169,
+         "id": 170,
          "panels": [
             {
                "aliasColors": { },
@@ -13932,7 +14022,7 @@
                   "x": 0,
                   "y": 441
                },
-               "id": 170,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -14022,7 +14112,7 @@
                   "x": 12,
                   "y": 441
                },
-               "id": 171,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -14115,7 +14205,7 @@
             "x": 0,
             "y": 449
          },
-         "id": 172,
+         "id": 173,
          "panels": [
             {
                "aliasColors": { },
@@ -14132,7 +14222,7 @@
                   "x": 0,
                   "y": 450
                },
-               "id": 173,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14222,7 +14312,7 @@
                   "x": 12,
                   "y": 450
                },
-               "id": 174,
+               "id": 175,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14312,7 +14402,7 @@
                   "x": 0,
                   "y": 458
                },
-               "id": 175,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14402,7 +14492,7 @@
                   "x": 12,
                   "y": 458
                },
-               "id": 176,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14495,7 +14585,7 @@
             "x": 0,
             "y": 466
          },
-         "id": 177,
+         "id": 178,
          "panels": [
             {
                "aliasColors": { },
@@ -14512,7 +14602,7 @@
                   "x": 0,
                   "y": 467
                },
-               "id": 178,
+               "id": 179,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14602,7 +14692,7 @@
                   "x": 12,
                   "y": 467
                },
-               "id": 179,
+               "id": 180,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14692,7 +14782,7 @@
                   "x": 0,
                   "y": 475
                },
-               "id": 180,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14782,7 +14872,7 @@
                   "x": 12,
                   "y": 475
                },
-               "id": 181,
+               "id": 182,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14875,7 +14965,7 @@
             "x": 0,
             "y": 483
          },
-         "id": 182,
+         "id": 183,
          "panels": [
             {
                "aliasColors": { },
@@ -14892,7 +14982,7 @@
                   "x": 0,
                   "y": 484
                },
-               "id": 183,
+               "id": 184,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -14982,7 +15072,7 @@
                   "x": 8,
                   "y": 484
                },
-               "id": 184,
+               "id": 185,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15072,7 +15162,7 @@
                   "x": 16,
                   "y": 484
                },
-               "id": 185,
+               "id": 186,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15162,7 +15252,7 @@
                   "x": 0,
                   "y": 492
                },
-               "id": 186,
+               "id": 187,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15252,7 +15342,7 @@
                   "x": 8,
                   "y": 492
                },
-               "id": 187,
+               "id": 188,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15342,7 +15432,7 @@
                   "x": 16,
                   "y": 492
                },
-               "id": 188,
+               "id": 189,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15435,7 +15525,7 @@
             "x": 0,
             "y": 500
          },
-         "id": 189,
+         "id": 190,
          "panels": [
             {
                "aliasColors": { },
@@ -15452,7 +15542,7 @@
                   "x": 0,
                   "y": 501
                },
-               "id": 190,
+               "id": 191,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15542,7 +15632,7 @@
                   "x": 8,
                   "y": 501
                },
-               "id": 191,
+               "id": 192,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15632,7 +15722,7 @@
                   "x": 16,
                   "y": 501
                },
-               "id": 192,
+               "id": 193,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15722,7 +15812,7 @@
                   "x": 0,
                   "y": 509
                },
-               "id": 193,
+               "id": 194,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15812,7 +15902,7 @@
                   "x": 8,
                   "y": 509
                },
-               "id": 194,
+               "id": 195,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15902,7 +15992,7 @@
                   "x": 16,
                   "y": 509
                },
-               "id": 195,
+               "id": 196,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15995,7 +16085,7 @@
             "x": 0,
             "y": 517
          },
-         "id": 196,
+         "id": 197,
          "panels": [
             {
                "aliasColors": { },
@@ -16012,7 +16102,7 @@
                   "x": 0,
                   "y": 518
                },
-               "id": 197,
+               "id": 198,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16102,7 +16192,7 @@
                   "x": 6,
                   "y": 518
                },
-               "id": 198,
+               "id": 199,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16192,7 +16282,7 @@
                   "x": 12,
                   "y": 518
                },
-               "id": 199,
+               "id": 200,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16282,7 +16372,7 @@
                   "x": 18,
                   "y": 518
                },
-               "id": 200,
+               "id": 201,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16372,7 +16462,7 @@
                   "x": 0,
                   "y": 526
                },
-               "id": 201,
+               "id": 202,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16462,7 +16552,7 @@
                   "x": 12,
                   "y": 526
                },
-               "id": 202,
+               "id": 203,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16552,7 +16642,7 @@
                   "x": 0,
                   "y": 534
                },
-               "id": 203,
+               "id": 204,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16642,7 +16732,7 @@
                   "x": 6,
                   "y": 534
                },
-               "id": 204,
+               "id": 205,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16732,7 +16822,7 @@
                   "x": 12,
                   "y": 534
                },
-               "id": 205,
+               "id": 206,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16822,7 +16912,7 @@
                   "x": 18,
                   "y": 534
                },
-               "id": 206,
+               "id": 207,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16912,7 +17002,7 @@
                   "x": 0,
                   "y": 542
                },
-               "id": 207,
+               "id": 208,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17002,7 +17092,7 @@
                   "x": 6,
                   "y": 542
                },
-               "id": 208,
+               "id": 209,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17092,7 +17182,7 @@
                   "x": 12,
                   "y": 542
                },
-               "id": 209,
+               "id": 210,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17182,7 +17272,7 @@
                   "x": 18,
                   "y": 542
                },
-               "id": 210,
+               "id": 211,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17272,7 +17362,7 @@
                   "x": 0,
                   "y": 550
                },
-               "id": 211,
+               "id": 212,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17362,7 +17452,7 @@
                   "x": 6,
                   "y": 550
                },
-               "id": 212,
+               "id": 213,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17452,7 +17542,7 @@
                   "x": 12,
                   "y": 550
                },
-               "id": 213,
+               "id": 214,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17542,7 +17632,7 @@
                   "x": 18,
                   "y": 550
                },
-               "id": 214,
+               "id": 215,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17635,7 +17725,7 @@
             "x": 0,
             "y": 558
          },
-         "id": 215,
+         "id": 216,
          "panels": [
             {
                "aliasColors": { },
@@ -17652,7 +17742,7 @@
                   "x": 0,
                   "y": 559
                },
-               "id": 216,
+               "id": 217,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17742,7 +17832,7 @@
                   "x": 8,
                   "y": 559
                },
-               "id": 217,
+               "id": 218,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17832,7 +17922,7 @@
                   "x": 16,
                   "y": 559
                },
-               "id": 218,
+               "id": 219,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17922,7 +18012,7 @@
                   "x": 0,
                   "y": 567
                },
-               "id": 219,
+               "id": 220,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18012,7 +18102,7 @@
                   "x": 8,
                   "y": 567
                },
-               "id": 220,
+               "id": 221,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18102,7 +18192,7 @@
                   "x": 16,
                   "y": 567
                },
-               "id": 221,
+               "id": 222,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18192,7 +18282,7 @@
                   "x": 0,
                   "y": 575
                },
-               "id": 222,
+               "id": 223,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18282,7 +18372,7 @@
                   "x": 8,
                   "y": 575
                },
-               "id": 223,
+               "id": 224,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18372,7 +18462,7 @@
                   "x": 16,
                   "y": 575
                },
-               "id": 224,
+               "id": 225,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18462,7 +18552,7 @@
                   "x": 0,
                   "y": 583
                },
-               "id": 225,
+               "id": 226,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18552,7 +18642,7 @@
                   "x": 8,
                   "y": 583
                },
-               "id": 226,
+               "id": 227,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18642,7 +18732,7 @@
                   "x": 16,
                   "y": 583
                },
-               "id": 227,
+               "id": 228,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18735,7 +18825,7 @@
             "x": 0,
             "y": 591
          },
-         "id": 228,
+         "id": 229,
          "panels": [
             {
                "aliasColors": { },
@@ -18752,7 +18842,7 @@
                   "x": 0,
                   "y": 592
                },
-               "id": 229,
+               "id": 230,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18842,7 +18932,7 @@
                   "x": 8,
                   "y": 592
                },
-               "id": 230,
+               "id": 231,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18932,7 +19022,7 @@
                   "x": 16,
                   "y": 592
                },
-               "id": 231,
+               "id": 232,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19022,7 +19112,7 @@
                   "x": 0,
                   "y": 600
                },
-               "id": 232,
+               "id": 233,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -19112,7 +19202,7 @@
                   "x": 12,
                   "y": 600
                },
-               "id": 233,
+               "id": 234,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19202,7 +19292,7 @@
                   "x": 0,
                   "y": 608
                },
-               "id": 234,
+               "id": 235,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19292,7 +19382,7 @@
                   "x": 6,
                   "y": 608
                },
-               "id": 235,
+               "id": 236,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19382,7 +19472,7 @@
                   "x": 12,
                   "y": 608
                },
-               "id": 236,
+               "id": 237,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19472,7 +19562,7 @@
                   "x": 18,
                   "y": 608
                },
-               "id": 237,
+               "id": 238,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19562,7 +19652,7 @@
                   "x": 0,
                   "y": 616
                },
-               "id": 238,
+               "id": 239,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -19652,7 +19742,7 @@
                   "x": 12,
                   "y": 616
                },
-               "id": 239,
+               "id": 240,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19742,7 +19832,7 @@
                   "x": 0,
                   "y": 624
                },
-               "id": 240,
+               "id": 241,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19832,7 +19922,7 @@
                   "x": 8,
                   "y": 624
                },
-               "id": 241,
+               "id": 242,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19922,7 +20012,7 @@
                   "x": 16,
                   "y": 624
                },
-               "id": 242,
+               "id": 243,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20012,7 +20102,7 @@
                   "x": 0,
                   "y": 632
                },
-               "id": 243,
+               "id": 244,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -20102,7 +20192,7 @@
                   "x": 12,
                   "y": 632
                },
-               "id": 244,
+               "id": 245,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_with_custom_panels_compiled.json
+++ b/tests/Prometheus/dashboard_with_custom_panels_compiled.json
@@ -5720,11 +5720,11 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 3,
-               "description": "Memory used for the Lua runtime.\nLua memory is bounded by 2 GB per instance. \n",
+               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance. \n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 185
                },
@@ -5768,7 +5768,97 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "Lua runtime memory",
+               "title": "Lua memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 3,
+               "description": "Memory used by runtime arena.\nRuntime arena stores network buffers, tuples\ncreated with box.tuple.new and other objects\nallocated by application not covered by basic\nLua mechanisms (spaces data and indexes\nare not included here, see memtx/vinyl arena).\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 185
+               },
+               "id": 75,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_runtime_used{job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Runtime arena memory",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -5814,11 +5904,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 185
                },
-               "id": 75,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5908,7 +5998,7 @@
                   "x": 0,
                   "y": 193
                },
-               "id": 76,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5998,7 +6088,7 @@
                   "x": 12,
                   "y": 193
                },
-               "id": 77,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6088,7 +6178,7 @@
                   "x": 0,
                   "y": 201
                },
-               "id": 78,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6178,7 +6268,7 @@
                   "x": 8,
                   "y": 201
                },
-               "id": 79,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6268,7 +6358,7 @@
                   "x": 16,
                   "y": 201
                },
-               "id": 80,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6361,7 +6451,7 @@
             "x": 0,
             "y": 209
          },
-         "id": 81,
+         "id": 82,
          "panels": [
             {
                "aliasColors": { },
@@ -6378,7 +6468,7 @@
                   "x": 0,
                   "y": 210
                },
-               "id": 82,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6468,7 +6558,7 @@
                   "x": 6,
                   "y": 210
                },
-               "id": 83,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6558,7 +6648,7 @@
                   "x": 12,
                   "y": 210
                },
-               "id": 84,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6648,7 +6738,7 @@
                   "x": 18,
                   "y": 210
                },
-               "id": 85,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6738,7 +6828,7 @@
                   "x": 0,
                   "y": 218
                },
-               "id": 86,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6828,7 +6918,7 @@
                   "x": 12,
                   "y": 218
                },
-               "id": 87,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6918,7 +7008,7 @@
                   "x": 0,
                   "y": 226
                },
-               "id": 88,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7008,7 +7098,7 @@
                   "x": 8,
                   "y": 226
                },
-               "id": 89,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7098,7 +7188,7 @@
                   "x": 16,
                   "y": 226
                },
-               "id": 90,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7188,7 +7278,7 @@
                   "x": 0,
                   "y": 234
                },
-               "id": 91,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7278,7 +7368,7 @@
                   "x": 8,
                   "y": 234
                },
-               "id": 92,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7368,7 +7458,7 @@
                   "x": 16,
                   "y": 234
                },
-               "id": 93,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7458,7 +7548,7 @@
                   "x": 0,
                   "y": 242
                },
-               "id": 94,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7548,7 +7638,7 @@
                   "x": 6,
                   "y": 242
                },
-               "id": 95,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7638,7 +7728,7 @@
                   "x": 12,
                   "y": 242
                },
-               "id": 96,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7728,7 +7818,7 @@
                   "x": 18,
                   "y": 242
                },
-               "id": 97,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7818,7 +7908,7 @@
                   "x": 0,
                   "y": 250
                },
-               "id": 98,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7908,7 +7998,7 @@
                   "x": 8,
                   "y": 250
                },
-               "id": 99,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7998,7 +8088,7 @@
                   "x": 16,
                   "y": 250
                },
-               "id": 100,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8091,7 +8181,7 @@
             "x": 0,
             "y": 258
          },
-         "id": 101,
+         "id": 102,
          "panels": [
             {
                "aliasColors": { },
@@ -8108,7 +8198,7 @@
                   "x": 0,
                   "y": 259
                },
-               "id": 102,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8198,7 +8288,7 @@
                   "x": 8,
                   "y": 259
                },
-               "id": 103,
+               "id": 104,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8288,7 +8378,7 @@
                   "x": 16,
                   "y": 259
                },
-               "id": 104,
+               "id": 105,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8378,7 +8468,7 @@
                   "x": 0,
                   "y": 267
                },
-               "id": 105,
+               "id": 106,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8468,7 +8558,7 @@
                   "x": 8,
                   "y": 267
                },
-               "id": 106,
+               "id": 107,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8558,7 +8648,7 @@
                   "x": 16,
                   "y": 267
                },
-               "id": 107,
+               "id": 108,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8648,7 +8738,7 @@
                   "x": 0,
                   "y": 275
                },
-               "id": 108,
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8738,7 +8828,7 @@
                   "x": 8,
                   "y": 275
                },
-               "id": 109,
+               "id": 110,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8828,7 +8918,7 @@
                   "x": 16,
                   "y": 275
                },
-               "id": 110,
+               "id": 111,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8918,7 +9008,7 @@
                   "x": 0,
                   "y": 283
                },
-               "id": 111,
+               "id": 112,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9008,7 +9098,7 @@
                   "x": 8,
                   "y": 283
                },
-               "id": 112,
+               "id": 113,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9098,7 +9188,7 @@
                   "x": 16,
                   "y": 283
                },
-               "id": 113,
+               "id": 114,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9191,7 +9281,7 @@
             "x": 0,
             "y": 291
          },
-         "id": 114,
+         "id": 115,
          "panels": [
             {
                "aliasColors": { },
@@ -9208,7 +9298,7 @@
                   "x": 0,
                   "y": 292
                },
-               "id": 115,
+               "id": 116,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9298,7 +9388,7 @@
                   "x": 6,
                   "y": 292
                },
-               "id": 116,
+               "id": 117,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9388,7 +9478,7 @@
                   "x": 12,
                   "y": 292
                },
-               "id": 117,
+               "id": 118,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9478,7 +9568,7 @@
                   "x": 18,
                   "y": 292
                },
-               "id": 118,
+               "id": 119,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9568,7 +9658,7 @@
                   "x": 0,
                   "y": 300
                },
-               "id": 119,
+               "id": 120,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9658,7 +9748,7 @@
                   "x": 8,
                   "y": 300
                },
-               "id": 120,
+               "id": 121,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9748,7 +9838,7 @@
                   "x": 16,
                   "y": 300
                },
-               "id": 121,
+               "id": 122,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9838,7 +9928,7 @@
                   "x": 0,
                   "y": 308
                },
-               "id": 122,
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9928,7 +10018,7 @@
                   "x": 6,
                   "y": 308
                },
-               "id": 123,
+               "id": 124,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10018,7 +10108,7 @@
                   "x": 12,
                   "y": 308
                },
-               "id": 124,
+               "id": 125,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10108,7 +10198,7 @@
                   "x": 18,
                   "y": 308
                },
-               "id": 125,
+               "id": 126,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10198,7 +10288,7 @@
                   "x": 0,
                   "y": 316
                },
-               "id": 126,
+               "id": 127,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10288,7 +10378,7 @@
                   "x": 6,
                   "y": 316
                },
-               "id": 127,
+               "id": 128,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10378,7 +10468,7 @@
                   "x": 12,
                   "y": 316
                },
-               "id": 128,
+               "id": 129,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10468,7 +10558,7 @@
                   "x": 18,
                   "y": 316
                },
-               "id": 129,
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10558,7 +10648,7 @@
                   "x": 0,
                   "y": 324
                },
-               "id": 130,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10648,7 +10738,7 @@
                   "x": 6,
                   "y": 324
                },
-               "id": 131,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10738,7 +10828,7 @@
                   "x": 12,
                   "y": 324
                },
-               "id": 132,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10828,7 +10918,7 @@
                   "x": 18,
                   "y": 324
                },
-               "id": 133,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10918,7 +11008,7 @@
                   "x": 0,
                   "y": 332
                },
-               "id": 134,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11008,7 +11098,7 @@
                   "x": 6,
                   "y": 332
                },
-               "id": 135,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11098,7 +11188,7 @@
                   "x": 12,
                   "y": 332
                },
-               "id": 136,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11188,7 +11278,7 @@
                   "x": 18,
                   "y": 332
                },
-               "id": 137,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11278,7 +11368,7 @@
                   "x": 0,
                   "y": 340
                },
-               "id": 138,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11368,7 +11458,7 @@
                   "x": 6,
                   "y": 340
                },
-               "id": 139,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11458,7 +11548,7 @@
                   "x": 12,
                   "y": 340
                },
-               "id": 140,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11548,7 +11638,7 @@
                   "x": 18,
                   "y": 340
                },
-               "id": 141,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11638,7 +11728,7 @@
                   "x": 0,
                   "y": 348
                },
-               "id": 142,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11728,7 +11818,7 @@
                   "x": 6,
                   "y": 348
                },
-               "id": 143,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11818,7 +11908,7 @@
                   "x": 12,
                   "y": 348
                },
-               "id": 144,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11908,7 +11998,7 @@
                   "x": 18,
                   "y": 348
                },
-               "id": 145,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11998,7 +12088,7 @@
                   "x": 0,
                   "y": 356
                },
-               "id": 146,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12088,7 +12178,7 @@
                   "x": 6,
                   "y": 356
                },
-               "id": 147,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12178,7 +12268,7 @@
                   "x": 12,
                   "y": 356
                },
-               "id": 148,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12268,7 +12358,7 @@
                   "x": 18,
                   "y": 356
                },
-               "id": 149,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12358,7 +12448,7 @@
                   "x": 0,
                   "y": 364
                },
-               "id": 150,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12448,7 +12538,7 @@
                   "x": 6,
                   "y": 364
                },
-               "id": 151,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12538,7 +12628,7 @@
                   "x": 12,
                   "y": 364
                },
-               "id": 152,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12628,7 +12718,7 @@
                   "x": 18,
                   "y": 364
                },
-               "id": 153,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12718,7 +12808,7 @@
                   "x": 0,
                   "y": 372
                },
-               "id": 154,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12808,7 +12898,7 @@
                   "x": 6,
                   "y": 372
                },
-               "id": 155,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12898,7 +12988,7 @@
                   "x": 12,
                   "y": 372
                },
-               "id": 156,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12988,7 +13078,7 @@
                   "x": 18,
                   "y": 372
                },
-               "id": 157,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13078,7 +13168,7 @@
                   "x": 0,
                   "y": 380
                },
-               "id": 158,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13168,7 +13258,7 @@
                   "x": 6,
                   "y": 380
                },
-               "id": 159,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13258,7 +13348,7 @@
                   "x": 12,
                   "y": 380
                },
-               "id": 160,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13348,7 +13438,7 @@
                   "x": 18,
                   "y": 380
                },
-               "id": 161,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13438,7 +13528,7 @@
                   "x": 0,
                   "y": 388
                },
-               "id": 162,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13528,7 +13618,7 @@
                   "x": 6,
                   "y": 388
                },
-               "id": 163,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13618,7 +13708,7 @@
                   "x": 12,
                   "y": 388
                },
-               "id": 164,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13708,7 +13798,7 @@
                   "x": 18,
                   "y": 388
                },
-               "id": 165,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13798,7 +13888,7 @@
                   "x": 0,
                   "y": 396
                },
-               "id": 166,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13888,7 +13978,7 @@
                   "x": 6,
                   "y": 396
                },
-               "id": 167,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13978,7 +14068,7 @@
                   "x": 12,
                   "y": 396
                },
-               "id": 168,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14068,7 +14158,7 @@
                   "x": 18,
                   "y": 396
                },
-               "id": 169,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14158,7 +14248,7 @@
                   "x": 0,
                   "y": 404
                },
-               "id": 170,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14248,7 +14338,7 @@
                   "x": 6,
                   "y": 404
                },
-               "id": 171,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14338,7 +14428,7 @@
                   "x": 12,
                   "y": 404
                },
-               "id": 172,
+               "id": 173,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14428,7 +14518,7 @@
                   "x": 18,
                   "y": 404
                },
-               "id": 173,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14521,7 +14611,7 @@
             "x": 0,
             "y": 412
          },
-         "id": 174,
+         "id": 175,
          "panels": [
             {
                "aliasColors": { },
@@ -14538,7 +14628,7 @@
                   "x": 0,
                   "y": 413
                },
-               "id": 175,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14628,7 +14718,7 @@
                   "x": 12,
                   "y": 413
                },
-               "id": 176,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14718,7 +14808,7 @@
                   "x": 0,
                   "y": 421
                },
-               "id": 177,
+               "id": 178,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14808,7 +14898,7 @@
                   "x": 12,
                   "y": 421
                },
-               "id": 178,
+               "id": 179,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14901,7 +14991,7 @@
             "x": 0,
             "y": 429
          },
-         "id": 179,
+         "id": 180,
          "panels": [
             {
                "aliasColors": { },
@@ -14918,7 +15008,7 @@
                   "x": 0,
                   "y": 430
                },
-               "id": 180,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15008,7 +15098,7 @@
                   "x": 0,
                   "y": 436
                },
-               "id": 181,
+               "id": 182,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15098,7 +15188,7 @@
                   "x": 12,
                   "y": 436
                },
-               "id": 182,
+               "id": 183,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,


### PR DESCRIPTION
Merge after #169 

Add "Runtime arena memory" panel to "Tarantool runtime overview" section. It displays `tnt_runtime_used` default metric.

![image](https://user-images.githubusercontent.com/20455996/182105986-28f7f110-fe5d-4300-b92a-7ac9148c7b95.png)

Rename "Lua runtime memory" panel to "Lua memory" to not confuse users after adding "Runtime arena memory" panel. Update panel description so it would be easier to understand the differences between two panels.

Closes #140