### PR TITLE
Add vinyl memory panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 - Options to build static dashboards
 - Runtime arena memory panel
+- Vinyl tuple cache and level 0 memory panels
 
 ## Changed
 - Set default Prometheus job to `tarantool`

--- a/dashboard/panels/vinyl.libsonnet
+++ b/dashboard/panels/vinyl.libsonnet
@@ -86,6 +86,8 @@ local prometheus = grafana.prometheus;
       Amount of memory in bytes currently used to store indexes.
       If the metric value is close to box.cfg.vinyl_memory, this
       indicates that vinyl_page_size was chosen incorrectly.
+
+      Panel works with `metrics >= 0.8.0`.
     |||,
     datasource_type=null,
     datasource=null,

--- a/dashboard/panels/vinyl.libsonnet
+++ b/dashboard/panels/vinyl.libsonnet
@@ -80,6 +80,33 @@ local prometheus = grafana.prometheus;
     metric_name='tnt_vinyl_disk_index_size',
   ),
 
+  tuples_cache_memory(
+    title='Tuples cache memory',
+    description=|||
+      Amount of memory in bytes currently used to store tuples (data).
+
+      Panel works with `metrics >= 0.8.0`.
+    |||,
+    datasource_type=null,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+  ):: common.default_graph(
+    title=title,
+    description=description,
+    datasource=datasource,
+    format='bytes',
+    labelY1='in bytes',
+    panel_width=8,
+  ).addTarget(common.default_metric_target(
+    datasource_type,
+    'tnt_vinyl_memory_tuple_cache',
+    job,
+    policy,
+    measurement
+  )),
+
   index_memory(
     title='Index memory',
     description=|||
@@ -100,7 +127,7 @@ local prometheus = grafana.prometheus;
     datasource=datasource,
     format='bytes',
     labelY1='in bytes',
-    panel_width=12,
+    panel_width=8,
   ).addTarget(common.default_metric_target(
     datasource_type,
     'tnt_vinyl_memory_page_index',
@@ -125,7 +152,7 @@ local prometheus = grafana.prometheus;
     datasource=datasource,
     format='bytes',
     labelY1='in bytes',
-    panel_width=12,
+    panel_width=8,
   ).addTarget(common.default_metric_target(
     datasource_type,
     'tnt_vinyl_memory_bloom_filter',
@@ -235,6 +262,39 @@ local prometheus = grafana.prometheus;
     metric_name='tnt_vinyl_regulator_rate_limit',
   ),
 
+  memory_level0(
+    title='Level 0 memory',
+    description=|||
+      «Level 0» (L0) memory area in bytes. L0 is the area that
+      vinyl can use for in-memory storage of an LSM tree.
+      By monitoring this metric, you can see when L0 is getting
+      close to its maximum (tnt_vinyl_regulator_dump_watermark),
+      at which time a dump will occur. You can expect L0 = 0
+      immediately after the dump operation is completed.
+
+      Panel works with `metrics >= 0.8.0`.
+    |||,
+
+    datasource_type=null,
+    datasource=null,
+    policy=null,
+    measurement=null,
+    job=null,
+  ):: common.default_graph(
+    title=title,
+    description=description,
+    datasource=datasource,
+    format='bytes',
+    legend_avg=false,
+    panel_width=8,
+  ).addTarget(common.default_metric_target(
+    datasource_type,
+    'tnt_vinyl_memory_level0',
+    job,
+    policy,
+    measurement,
+  )),
+
   regulator_dump_watermark(
     title='Vinyl regulator dump watermark',
     description=|||
@@ -259,7 +319,7 @@ local prometheus = grafana.prometheus;
     format='bytes',
     legend_avg=false,
     legend_max=false,
-    panel_width=12,
+    panel_width=8,
   ).addTarget(common.default_metric_target(
     datasource_type,
     'tnt_vinyl_regulator_dump_watermark',
@@ -288,7 +348,7 @@ local prometheus = grafana.prometheus;
     legend_avg=false,
     legend_max=false,
     labelY1='fibers',
-    panel_width=12,
+    panel_width=8,
   ).addTarget(common.default_metric_target(
     datasource_type,
     'tnt_vinyl_regulator_blocked_writers',
@@ -449,56 +509,6 @@ local prometheus = grafana.prometheus;
     policy,
     measurement,
   )),
-
-  memory_tuple_cache(
-    title='Vinyl tuple cache memory',
-    description=|||
-      The amount of memory that is being used for storing vinyl tuples (data).
-
-      Panel works with `metrics >= 0.8.0`.
-    |||,
-    datasource_type=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-  ):: memory(
-    title=title,
-    description=description,
-    datasource_type=datasource_type,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    metric_name='tnt_vinyl_memory_tuple_cache',
-  ),
-
-  memory_level0(
-    title='Vinyl level 0 memory',
-    description=|||
-      The “level 0” (L0) memory area.
-      L0 is the area that vinyl can use for in-memory storage of an LSM tree.
-      By monitoring the metric, you can see when L0 is getting close to its maximum
-      (regulator dump watermark) at which a dump will be taken.
-      You can expect L0 = 0 immediately after the dump operation is completed.
-
-      Panel works with `metrics >= 0.8.0`.
-    |||,
-    datasource_type=null,
-    datasource=null,
-    policy=null,
-    measurement=null,
-    job=null,
-  ):: memory(
-    title=title,
-    description=description,
-    datasource_type=datasource_type,
-    datasource=datasource,
-    policy=policy,
-    measurement=measurement,
-    job=job,
-    metric_name='tnt_vinyl_memory_level0',
-  ),
 
   memory_page_index(
     title='Vinyl index memory',

--- a/dashboard/section.libsonnet
+++ b/dashboard/section.libsonnet
@@ -439,6 +439,14 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       job=job,
     ),
 
+    vinyl.tuples_cache_memory(
+      datasource_type=datasource_type,
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+    ),
+
     vinyl.index_memory(
       datasource_type=datasource_type,
       datasource=datasource,
@@ -472,6 +480,14 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
     ),
 
     vinyl.regulator_rate_limit(
+      datasource_type=datasource_type,
+      datasource=datasource,
+      policy=policy,
+      measurement=measurement,
+      job=job,
+    ),
+
+    vinyl.memory_level0(
       datasource_type=datasource_type,
       datasource=datasource,
       policy=policy,

--- a/tests/InfluxDB/dashboard_compiled.json
+++ b/tests/InfluxDB/dashboard_compiled.json
@@ -5651,7 +5651,7 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 3,
-               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n",
+               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,

--- a/tests/InfluxDB/dashboard_compiled.json
+++ b/tests/InfluxDB/dashboard_compiled.json
@@ -5651,15 +5651,146 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 3,
-               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "description": "Amount of memory in bytes currently used to store tuples (data).\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 127
                },
                "id": 48,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_memory_tuple_cache"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Tuples cache memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 3,
+               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 127
+               },
+               "id": 49,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5786,11 +5917,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 127
                },
-               "id": 49,
+               "id": 50,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5921,7 +6052,7 @@
                   "x": 0,
                   "y": 135
                },
-               "id": 50,
+               "id": 51,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6052,7 +6183,7 @@
                   "x": 8,
                   "y": 135
                },
-               "id": 51,
+               "id": 52,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6183,7 +6314,7 @@
                   "x": 16,
                   "y": 135
                },
-               "id": 52,
+               "id": 53,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6306,15 +6437,146 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 3,
+               "description": "«Level 0» (L0) memory area in bytes. L0 is the area that\nvinyl can use for in-memory storage of an LSM tree.\nBy monitoring this metric, you can see when L0 is getting\nclose to its maximum (tnt_vinyl_regulator_dump_watermark),\nat which time a dump will occur. You can expect L0 = 0\nimmediately after the dump operation is completed.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 143
+               },
+               "id": 54,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_memory_level0"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Level 0 memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 3,
                "description": "The maximum amount of memory used for in-memory storing of a vinyl LSM tree.\nWhen accessing this maximum, the dumping must occur.\nFor details, see https://www.tarantool.io/en/doc/latest/book/box/engines/#engines-algorithm-filling-lsm.\nThe value is slightly smaller than the amount of memory allocated for vinyl trees,\nwhich is the `vinyl_memory` parameter.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 0,
+                  "w": 8,
+                  "x": 8,
                   "y": 143
                },
-               "id": 53,
+               "id": 55,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6441,11 +6703,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 143
                },
-               "id": 54,
+               "id": 56,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6576,7 +6838,7 @@
                   "x": 0,
                   "y": 151
                },
-               "id": 55,
+               "id": 57,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6713,7 +6975,7 @@
                   "x": 6,
                   "y": 151
                },
-               "id": 56,
+               "id": 58,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6850,7 +7112,7 @@
                   "x": 12,
                   "y": 151
                },
-               "id": 57,
+               "id": 59,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6987,7 +7249,7 @@
                   "x": 18,
                   "y": 151
                },
-               "id": 58,
+               "id": 60,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7118,7 +7380,7 @@
                   "x": 0,
                   "y": 159
                },
-               "id": 59,
+               "id": 61,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -7255,7 +7517,7 @@
                   "x": 6,
                   "y": 159
                },
-               "id": 60,
+               "id": 62,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -7398,7 +7660,7 @@
                   "x": 12,
                   "y": 159
                },
-               "id": 61,
+               "id": 63,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7535,7 +7797,7 @@
                   "x": 18,
                   "y": 159
                },
-               "id": 62,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7675,7 +7937,7 @@
             "x": 0,
             "y": 167
          },
-         "id": 63,
+         "id": 65,
          "panels": [
             {
                "aliasColors": { },
@@ -7692,7 +7954,7 @@
                   "x": 0,
                   "y": 168
                },
-               "id": 64,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7829,7 +8091,7 @@
                   "x": 12,
                   "y": 168
                },
-               "id": 65,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7969,7 +8231,7 @@
             "x": 0,
             "y": 176
          },
-         "id": 66,
+         "id": 68,
          "panels": [
             {
                "aliasColors": { },
@@ -7986,7 +8248,7 @@
                   "x": 0,
                   "y": 177
                },
-               "id": 67,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8117,7 +8379,7 @@
                   "x": 8,
                   "y": 177
                },
-               "id": 68,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -8248,7 +8510,7 @@
                   "x": 16,
                   "y": 177
                },
-               "id": 69,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8379,7 +8641,7 @@
                   "x": 0,
                   "y": 185
                },
-               "id": 70,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8510,7 +8772,7 @@
                   "x": 12,
                   "y": 185
                },
-               "id": 71,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8641,7 +8903,7 @@
                   "x": 0,
                   "y": 193
                },
-               "id": 72,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -8772,7 +9034,7 @@
                   "x": 8,
                   "y": 193
                },
-               "id": 73,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8903,7 +9165,7 @@
                   "x": 16,
                   "y": 193
                },
-               "id": 74,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9037,7 +9299,7 @@
             "x": 0,
             "y": 201
          },
-         "id": 75,
+         "id": 77,
          "panels": [
             {
                "aliasColors": { },
@@ -9054,7 +9316,7 @@
                   "x": 0,
                   "y": 202
                },
-               "id": 76,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9191,7 +9453,7 @@
                   "x": 6,
                   "y": 202
                },
-               "id": 77,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9328,7 +9590,7 @@
                   "x": 12,
                   "y": 202
                },
-               "id": 78,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9465,7 +9727,7 @@
                   "x": 18,
                   "y": 202
                },
-               "id": 79,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9596,7 +9858,7 @@
                   "x": 0,
                   "y": 210
                },
-               "id": 80,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9733,7 +9995,7 @@
                   "x": 12,
                   "y": 210
                },
-               "id": 81,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9870,7 +10132,7 @@
                   "x": 0,
                   "y": 218
                },
-               "id": 82,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10007,7 +10269,7 @@
                   "x": 8,
                   "y": 218
                },
-               "id": 83,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10144,7 +10406,7 @@
                   "x": 16,
                   "y": 218
                },
-               "id": 84,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10281,7 +10543,7 @@
                   "x": 0,
                   "y": 226
                },
-               "id": 85,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10418,7 +10680,7 @@
                   "x": 8,
                   "y": 226
                },
-               "id": 86,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10555,7 +10817,7 @@
                   "x": 16,
                   "y": 226
                },
-               "id": 87,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10692,7 +10954,7 @@
                   "x": 0,
                   "y": 234
                },
-               "id": 88,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10823,7 +11085,7 @@
                   "x": 6,
                   "y": 234
                },
-               "id": 89,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10954,7 +11216,7 @@
                   "x": 12,
                   "y": 234
                },
-               "id": 90,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11085,7 +11347,7 @@
                   "x": 18,
                   "y": 234
                },
-               "id": 91,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11216,7 +11478,7 @@
                   "x": 0,
                   "y": 242
                },
-               "id": 92,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11347,7 +11609,7 @@
                   "x": 8,
                   "y": 242
                },
-               "id": 93,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11484,7 +11746,7 @@
                   "x": 16,
                   "y": 242
                },
-               "id": 94,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11624,7 +11886,7 @@
             "x": 0,
             "y": 250
          },
-         "id": 95,
+         "id": 97,
          "panels": [
             {
                "aliasColors": { },
@@ -11641,7 +11903,7 @@
                   "x": 0,
                   "y": 251
                },
-               "id": 96,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11784,7 +12046,7 @@
                   "x": 8,
                   "y": 251
                },
-               "id": 97,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11927,7 +12189,7 @@
                   "x": 16,
                   "y": 251
                },
-               "id": 98,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12070,7 +12332,7 @@
                   "x": 0,
                   "y": 259
                },
-               "id": 99,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12213,7 +12475,7 @@
                   "x": 8,
                   "y": 259
                },
-               "id": 100,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12356,7 +12618,7 @@
                   "x": 16,
                   "y": 259
                },
-               "id": 101,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12499,7 +12761,7 @@
                   "x": 0,
                   "y": 267
                },
-               "id": 102,
+               "id": 104,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12642,7 +12904,7 @@
                   "x": 8,
                   "y": 267
                },
-               "id": 103,
+               "id": 105,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12785,7 +13047,7 @@
                   "x": 16,
                   "y": 267
                },
-               "id": 104,
+               "id": 106,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12928,7 +13190,7 @@
                   "x": 0,
                   "y": 275
                },
-               "id": 105,
+               "id": 107,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13071,7 +13333,7 @@
                   "x": 8,
                   "y": 275
                },
-               "id": 106,
+               "id": 108,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13214,7 +13476,7 @@
                   "x": 16,
                   "y": 275
                },
-               "id": 107,
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13360,7 +13622,7 @@
             "x": 0,
             "y": 283
          },
-         "id": 108,
+         "id": 110,
          "panels": [
             {
                "aliasColors": { },
@@ -13377,7 +13639,7 @@
                   "x": 0,
                   "y": 284
                },
-               "id": 109,
+               "id": 111,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13532,7 +13794,7 @@
                   "x": 6,
                   "y": 284
                },
-               "id": 110,
+               "id": 112,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13687,7 +13949,7 @@
                   "x": 12,
                   "y": 284
                },
-               "id": 111,
+               "id": 113,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13842,7 +14104,7 @@
                   "x": 18,
                   "y": 284
                },
-               "id": 112,
+               "id": 114,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13997,7 +14259,7 @@
                   "x": 0,
                   "y": 292
                },
-               "id": 113,
+               "id": 115,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14104,7 +14366,7 @@
                   "x": 8,
                   "y": 292
                },
-               "id": 114,
+               "id": 116,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14211,7 +14473,7 @@
                   "x": 16,
                   "y": 292
                },
-               "id": 115,
+               "id": 117,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14360,7 +14622,7 @@
                   "x": 0,
                   "y": 300
                },
-               "id": 116,
+               "id": 118,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14515,7 +14777,7 @@
                   "x": 6,
                   "y": 300
                },
-               "id": 117,
+               "id": 119,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14670,7 +14932,7 @@
                   "x": 12,
                   "y": 300
                },
-               "id": 118,
+               "id": 120,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14825,7 +15087,7 @@
                   "x": 18,
                   "y": 300
                },
-               "id": 119,
+               "id": 121,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14980,7 +15242,7 @@
                   "x": 0,
                   "y": 308
                },
-               "id": 120,
+               "id": 122,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15135,7 +15397,7 @@
                   "x": 6,
                   "y": 308
                },
-               "id": 121,
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15290,7 +15552,7 @@
                   "x": 12,
                   "y": 308
                },
-               "id": 122,
+               "id": 124,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15445,7 +15707,7 @@
                   "x": 18,
                   "y": 308
                },
-               "id": 123,
+               "id": 125,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15600,7 +15862,7 @@
                   "x": 0,
                   "y": 316
                },
-               "id": 124,
+               "id": 126,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15755,7 +16017,7 @@
                   "x": 6,
                   "y": 316
                },
-               "id": 125,
+               "id": 127,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15910,7 +16172,7 @@
                   "x": 12,
                   "y": 316
                },
-               "id": 126,
+               "id": 128,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16065,7 +16327,7 @@
                   "x": 18,
                   "y": 316
                },
-               "id": 127,
+               "id": 129,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16220,7 +16482,7 @@
                   "x": 0,
                   "y": 324
                },
-               "id": 128,
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16375,7 +16637,7 @@
                   "x": 6,
                   "y": 324
                },
-               "id": 129,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16530,7 +16792,7 @@
                   "x": 12,
                   "y": 324
                },
-               "id": 130,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16685,7 +16947,7 @@
                   "x": 18,
                   "y": 324
                },
-               "id": 131,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16840,7 +17102,7 @@
                   "x": 0,
                   "y": 332
                },
-               "id": 132,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16995,7 +17257,7 @@
                   "x": 6,
                   "y": 332
                },
-               "id": 133,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17150,7 +17412,7 @@
                   "x": 12,
                   "y": 332
                },
-               "id": 134,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17305,7 +17567,7 @@
                   "x": 18,
                   "y": 332
                },
-               "id": 135,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17460,7 +17722,7 @@
                   "x": 0,
                   "y": 340
                },
-               "id": 136,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17615,7 +17877,7 @@
                   "x": 6,
                   "y": 340
                },
-               "id": 137,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17770,7 +18032,7 @@
                   "x": 12,
                   "y": 340
                },
-               "id": 138,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17925,7 +18187,7 @@
                   "x": 18,
                   "y": 340
                },
-               "id": 139,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18080,7 +18342,7 @@
                   "x": 0,
                   "y": 348
                },
-               "id": 140,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18235,7 +18497,7 @@
                   "x": 6,
                   "y": 348
                },
-               "id": 141,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18390,7 +18652,7 @@
                   "x": 12,
                   "y": 348
                },
-               "id": 142,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18545,7 +18807,7 @@
                   "x": 18,
                   "y": 348
                },
-               "id": 143,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18700,7 +18962,7 @@
                   "x": 0,
                   "y": 356
                },
-               "id": 144,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18855,7 +19117,7 @@
                   "x": 6,
                   "y": 356
                },
-               "id": 145,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19010,7 +19272,7 @@
                   "x": 12,
                   "y": 356
                },
-               "id": 146,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19165,7 +19427,7 @@
                   "x": 18,
                   "y": 356
                },
-               "id": 147,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19320,7 +19582,7 @@
                   "x": 0,
                   "y": 364
                },
-               "id": 148,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19475,7 +19737,7 @@
                   "x": 6,
                   "y": 364
                },
-               "id": 149,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19630,7 +19892,7 @@
                   "x": 12,
                   "y": 364
                },
-               "id": 150,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19785,7 +20047,7 @@
                   "x": 18,
                   "y": 364
                },
-               "id": 151,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19940,7 +20202,7 @@
                   "x": 0,
                   "y": 372
                },
-               "id": 152,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20095,7 +20357,7 @@
                   "x": 6,
                   "y": 372
                },
-               "id": 153,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20250,7 +20512,7 @@
                   "x": 12,
                   "y": 372
                },
-               "id": 154,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20405,7 +20667,7 @@
                   "x": 18,
                   "y": 372
                },
-               "id": 155,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20560,7 +20822,7 @@
                   "x": 0,
                   "y": 380
                },
-               "id": 156,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20715,7 +20977,7 @@
                   "x": 6,
                   "y": 380
                },
-               "id": 157,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20870,7 +21132,7 @@
                   "x": 12,
                   "y": 380
                },
-               "id": 158,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21025,7 +21287,7 @@
                   "x": 18,
                   "y": 380
                },
-               "id": 159,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21180,7 +21442,7 @@
                   "x": 0,
                   "y": 388
                },
-               "id": 160,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21335,7 +21597,7 @@
                   "x": 6,
                   "y": 388
                },
-               "id": 161,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21490,7 +21752,7 @@
                   "x": 12,
                   "y": 388
                },
-               "id": 162,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21645,7 +21907,7 @@
                   "x": 18,
                   "y": 388
                },
-               "id": 163,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21800,7 +22062,7 @@
                   "x": 0,
                   "y": 396
                },
-               "id": 164,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21955,7 +22217,7 @@
                   "x": 6,
                   "y": 396
                },
-               "id": 165,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22110,7 +22372,7 @@
                   "x": 12,
                   "y": 396
                },
-               "id": 166,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22265,7 +22527,7 @@
                   "x": 18,
                   "y": 396
                },
-               "id": 167,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22423,7 +22685,7 @@
             "x": 0,
             "y": 404
          },
-         "id": 168,
+         "id": 170,
          "panels": [
             {
                "aliasColors": { },
@@ -22440,7 +22702,7 @@
                   "x": 0,
                   "y": 405
                },
-               "id": 169,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22583,7 +22845,7 @@
                   "x": 12,
                   "y": 405
                },
-               "id": 170,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22726,7 +22988,7 @@
                   "x": 0,
                   "y": 413
                },
-               "id": 171,
+               "id": 173,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22863,7 +23125,7 @@
                   "x": 12,
                   "y": 413
                },
-               "id": 172,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/InfluxDB/dashboard_static_compiled.json
+++ b/tests/InfluxDB/dashboard_static_compiled.json
@@ -5628,15 +5628,146 @@
                "dashes": false,
                "datasource": "influxdb",
                "decimals": 3,
-               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "description": "Amount of memory in bytes currently used to store tuples (data).\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 127
                },
                "id": 48,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_memory_tuple_cache"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Tuples cache memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "influxdb",
+               "decimals": 3,
+               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 127
+               },
+               "id": 49,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5763,11 +5894,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 127
                },
-               "id": 49,
+               "id": 50,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5898,7 +6029,7 @@
                   "x": 0,
                   "y": 135
                },
-               "id": 50,
+               "id": 51,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6029,7 +6160,7 @@
                   "x": 8,
                   "y": 135
                },
-               "id": 51,
+               "id": 52,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6160,7 +6291,7 @@
                   "x": 16,
                   "y": 135
                },
-               "id": 52,
+               "id": 53,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6283,15 +6414,146 @@
                "dashes": false,
                "datasource": "influxdb",
                "decimals": 3,
+               "description": "«Level 0» (L0) memory area in bytes. L0 is the area that\nvinyl can use for in-memory storage of an LSM tree.\nBy monitoring this metric, you can see when L0 is getting\nclose to its maximum (tnt_vinyl_regulator_dump_watermark),\nat which time a dump will occur. You can expect L0 = 0\nimmediately after the dump operation is completed.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 143
+               },
+               "id": 54,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_memory_level0"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Level 0 memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "influxdb",
+               "decimals": 3,
                "description": "The maximum amount of memory used for in-memory storing of a vinyl LSM tree.\nWhen accessing this maximum, the dumping must occur.\nFor details, see https://www.tarantool.io/en/doc/latest/book/box/engines/#engines-algorithm-filling-lsm.\nThe value is slightly smaller than the amount of memory allocated for vinyl trees,\nwhich is the `vinyl_memory` parameter.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 0,
+                  "w": 8,
+                  "x": 8,
                   "y": 143
                },
-               "id": 53,
+               "id": 55,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6418,11 +6680,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 143
                },
-               "id": 54,
+               "id": 56,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6553,7 +6815,7 @@
                   "x": 0,
                   "y": 151
                },
-               "id": 55,
+               "id": 57,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6690,7 +6952,7 @@
                   "x": 6,
                   "y": 151
                },
-               "id": 56,
+               "id": 58,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6827,7 +7089,7 @@
                   "x": 12,
                   "y": 151
                },
-               "id": 57,
+               "id": 59,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6964,7 +7226,7 @@
                   "x": 18,
                   "y": 151
                },
-               "id": 58,
+               "id": 60,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7095,7 +7357,7 @@
                   "x": 0,
                   "y": 159
                },
-               "id": 59,
+               "id": 61,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -7232,7 +7494,7 @@
                   "x": 6,
                   "y": 159
                },
-               "id": 60,
+               "id": 62,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -7375,7 +7637,7 @@
                   "x": 12,
                   "y": 159
                },
-               "id": 61,
+               "id": 63,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7512,7 +7774,7 @@
                   "x": 18,
                   "y": 159
                },
-               "id": 62,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7652,7 +7914,7 @@
             "x": 0,
             "y": 167
          },
-         "id": 63,
+         "id": 65,
          "panels": [
             {
                "aliasColors": { },
@@ -7669,7 +7931,7 @@
                   "x": 0,
                   "y": 168
                },
-               "id": 64,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7806,7 +8068,7 @@
                   "x": 12,
                   "y": 168
                },
-               "id": 65,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7946,7 +8208,7 @@
             "x": 0,
             "y": 176
          },
-         "id": 66,
+         "id": 68,
          "panels": [
             {
                "aliasColors": { },
@@ -7963,7 +8225,7 @@
                   "x": 0,
                   "y": 177
                },
-               "id": 67,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8094,7 +8356,7 @@
                   "x": 8,
                   "y": 177
                },
-               "id": 68,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -8225,7 +8487,7 @@
                   "x": 16,
                   "y": 177
                },
-               "id": 69,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8356,7 +8618,7 @@
                   "x": 0,
                   "y": 185
                },
-               "id": 70,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8487,7 +8749,7 @@
                   "x": 12,
                   "y": 185
                },
-               "id": 71,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8618,7 +8880,7 @@
                   "x": 0,
                   "y": 193
                },
-               "id": 72,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -8749,7 +9011,7 @@
                   "x": 8,
                   "y": 193
                },
-               "id": 73,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8880,7 +9142,7 @@
                   "x": 16,
                   "y": 193
                },
-               "id": 74,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9014,7 +9276,7 @@
             "x": 0,
             "y": 201
          },
-         "id": 75,
+         "id": 77,
          "panels": [
             {
                "aliasColors": { },
@@ -9031,7 +9293,7 @@
                   "x": 0,
                   "y": 202
                },
-               "id": 76,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9168,7 +9430,7 @@
                   "x": 6,
                   "y": 202
                },
-               "id": 77,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9305,7 +9567,7 @@
                   "x": 12,
                   "y": 202
                },
-               "id": 78,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9442,7 +9704,7 @@
                   "x": 18,
                   "y": 202
                },
-               "id": 79,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9573,7 +9835,7 @@
                   "x": 0,
                   "y": 210
                },
-               "id": 80,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9710,7 +9972,7 @@
                   "x": 12,
                   "y": 210
                },
-               "id": 81,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9847,7 +10109,7 @@
                   "x": 0,
                   "y": 218
                },
-               "id": 82,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9984,7 +10246,7 @@
                   "x": 8,
                   "y": 218
                },
-               "id": 83,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10121,7 +10383,7 @@
                   "x": 16,
                   "y": 218
                },
-               "id": 84,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10258,7 +10520,7 @@
                   "x": 0,
                   "y": 226
                },
-               "id": 85,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10395,7 +10657,7 @@
                   "x": 8,
                   "y": 226
                },
-               "id": 86,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10532,7 +10794,7 @@
                   "x": 16,
                   "y": 226
                },
-               "id": 87,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10669,7 +10931,7 @@
                   "x": 0,
                   "y": 234
                },
-               "id": 88,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10800,7 +11062,7 @@
                   "x": 6,
                   "y": 234
                },
-               "id": 89,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10931,7 +11193,7 @@
                   "x": 12,
                   "y": 234
                },
-               "id": 90,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11062,7 +11324,7 @@
                   "x": 18,
                   "y": 234
                },
-               "id": 91,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11193,7 +11455,7 @@
                   "x": 0,
                   "y": 242
                },
-               "id": 92,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11324,7 +11586,7 @@
                   "x": 8,
                   "y": 242
                },
-               "id": 93,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11461,7 +11723,7 @@
                   "x": 16,
                   "y": 242
                },
-               "id": 94,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11601,7 +11863,7 @@
             "x": 0,
             "y": 250
          },
-         "id": 95,
+         "id": 97,
          "panels": [
             {
                "aliasColors": { },
@@ -11618,7 +11880,7 @@
                   "x": 0,
                   "y": 251
                },
-               "id": 96,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11761,7 +12023,7 @@
                   "x": 8,
                   "y": 251
                },
-               "id": 97,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11904,7 +12166,7 @@
                   "x": 16,
                   "y": 251
                },
-               "id": 98,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12047,7 +12309,7 @@
                   "x": 0,
                   "y": 259
                },
-               "id": 99,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12190,7 +12452,7 @@
                   "x": 8,
                   "y": 259
                },
-               "id": 100,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12333,7 +12595,7 @@
                   "x": 16,
                   "y": 259
                },
-               "id": 101,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12476,7 +12738,7 @@
                   "x": 0,
                   "y": 267
                },
-               "id": 102,
+               "id": 104,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12619,7 +12881,7 @@
                   "x": 8,
                   "y": 267
                },
-               "id": 103,
+               "id": 105,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12762,7 +13024,7 @@
                   "x": 16,
                   "y": 267
                },
-               "id": 104,
+               "id": 106,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12905,7 +13167,7 @@
                   "x": 0,
                   "y": 275
                },
-               "id": 105,
+               "id": 107,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13048,7 +13310,7 @@
                   "x": 8,
                   "y": 275
                },
-               "id": 106,
+               "id": 108,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13191,7 +13453,7 @@
                   "x": 16,
                   "y": 275
                },
-               "id": 107,
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13337,7 +13599,7 @@
             "x": 0,
             "y": 283
          },
-         "id": 108,
+         "id": 110,
          "panels": [
             {
                "aliasColors": { },
@@ -13354,7 +13616,7 @@
                   "x": 0,
                   "y": 284
                },
-               "id": 109,
+               "id": 111,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13509,7 +13771,7 @@
                   "x": 6,
                   "y": 284
                },
-               "id": 110,
+               "id": 112,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13664,7 +13926,7 @@
                   "x": 12,
                   "y": 284
                },
-               "id": 111,
+               "id": 113,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13819,7 +14081,7 @@
                   "x": 18,
                   "y": 284
                },
-               "id": 112,
+               "id": 114,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13974,7 +14236,7 @@
                   "x": 0,
                   "y": 292
                },
-               "id": 113,
+               "id": 115,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14081,7 +14343,7 @@
                   "x": 8,
                   "y": 292
                },
-               "id": 114,
+               "id": 116,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14188,7 +14450,7 @@
                   "x": 16,
                   "y": 292
                },
-               "id": 115,
+               "id": 117,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14337,7 +14599,7 @@
                   "x": 0,
                   "y": 300
                },
-               "id": 116,
+               "id": 118,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14492,7 +14754,7 @@
                   "x": 6,
                   "y": 300
                },
-               "id": 117,
+               "id": 119,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14647,7 +14909,7 @@
                   "x": 12,
                   "y": 300
                },
-               "id": 118,
+               "id": 120,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14802,7 +15064,7 @@
                   "x": 18,
                   "y": 300
                },
-               "id": 119,
+               "id": 121,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14957,7 +15219,7 @@
                   "x": 0,
                   "y": 308
                },
-               "id": 120,
+               "id": 122,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15112,7 +15374,7 @@
                   "x": 6,
                   "y": 308
                },
-               "id": 121,
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15267,7 +15529,7 @@
                   "x": 12,
                   "y": 308
                },
-               "id": 122,
+               "id": 124,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15422,7 +15684,7 @@
                   "x": 18,
                   "y": 308
                },
-               "id": 123,
+               "id": 125,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15577,7 +15839,7 @@
                   "x": 0,
                   "y": 316
                },
-               "id": 124,
+               "id": 126,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15732,7 +15994,7 @@
                   "x": 6,
                   "y": 316
                },
-               "id": 125,
+               "id": 127,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15887,7 +16149,7 @@
                   "x": 12,
                   "y": 316
                },
-               "id": 126,
+               "id": 128,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16042,7 +16304,7 @@
                   "x": 18,
                   "y": 316
                },
-               "id": 127,
+               "id": 129,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16197,7 +16459,7 @@
                   "x": 0,
                   "y": 324
                },
-               "id": 128,
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16352,7 +16614,7 @@
                   "x": 6,
                   "y": 324
                },
-               "id": 129,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16507,7 +16769,7 @@
                   "x": 12,
                   "y": 324
                },
-               "id": 130,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16662,7 +16924,7 @@
                   "x": 18,
                   "y": 324
                },
-               "id": 131,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16817,7 +17079,7 @@
                   "x": 0,
                   "y": 332
                },
-               "id": 132,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16972,7 +17234,7 @@
                   "x": 6,
                   "y": 332
                },
-               "id": 133,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17127,7 +17389,7 @@
                   "x": 12,
                   "y": 332
                },
-               "id": 134,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17282,7 +17544,7 @@
                   "x": 18,
                   "y": 332
                },
-               "id": 135,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17437,7 +17699,7 @@
                   "x": 0,
                   "y": 340
                },
-               "id": 136,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17592,7 +17854,7 @@
                   "x": 6,
                   "y": 340
                },
-               "id": 137,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17747,7 +18009,7 @@
                   "x": 12,
                   "y": 340
                },
-               "id": 138,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17902,7 +18164,7 @@
                   "x": 18,
                   "y": 340
                },
-               "id": 139,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18057,7 +18319,7 @@
                   "x": 0,
                   "y": 348
                },
-               "id": 140,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18212,7 +18474,7 @@
                   "x": 6,
                   "y": 348
                },
-               "id": 141,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18367,7 +18629,7 @@
                   "x": 12,
                   "y": 348
                },
-               "id": 142,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18522,7 +18784,7 @@
                   "x": 18,
                   "y": 348
                },
-               "id": 143,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18677,7 +18939,7 @@
                   "x": 0,
                   "y": 356
                },
-               "id": 144,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18832,7 +19094,7 @@
                   "x": 6,
                   "y": 356
                },
-               "id": 145,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18987,7 +19249,7 @@
                   "x": 12,
                   "y": 356
                },
-               "id": 146,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19142,7 +19404,7 @@
                   "x": 18,
                   "y": 356
                },
-               "id": 147,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19297,7 +19559,7 @@
                   "x": 0,
                   "y": 364
                },
-               "id": 148,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19452,7 +19714,7 @@
                   "x": 6,
                   "y": 364
                },
-               "id": 149,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19607,7 +19869,7 @@
                   "x": 12,
                   "y": 364
                },
-               "id": 150,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19762,7 +20024,7 @@
                   "x": 18,
                   "y": 364
                },
-               "id": 151,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19917,7 +20179,7 @@
                   "x": 0,
                   "y": 372
                },
-               "id": 152,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20072,7 +20334,7 @@
                   "x": 6,
                   "y": 372
                },
-               "id": 153,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20227,7 +20489,7 @@
                   "x": 12,
                   "y": 372
                },
-               "id": 154,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20382,7 +20644,7 @@
                   "x": 18,
                   "y": 372
                },
-               "id": 155,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20537,7 +20799,7 @@
                   "x": 0,
                   "y": 380
                },
-               "id": 156,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20692,7 +20954,7 @@
                   "x": 6,
                   "y": 380
                },
-               "id": 157,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20847,7 +21109,7 @@
                   "x": 12,
                   "y": 380
                },
-               "id": 158,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21002,7 +21264,7 @@
                   "x": 18,
                   "y": 380
                },
-               "id": 159,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21157,7 +21419,7 @@
                   "x": 0,
                   "y": 388
                },
-               "id": 160,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21312,7 +21574,7 @@
                   "x": 6,
                   "y": 388
                },
-               "id": 161,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21467,7 +21729,7 @@
                   "x": 12,
                   "y": 388
                },
-               "id": 162,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21622,7 +21884,7 @@
                   "x": 18,
                   "y": 388
                },
-               "id": 163,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21777,7 +22039,7 @@
                   "x": 0,
                   "y": 396
                },
-               "id": 164,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21932,7 +22194,7 @@
                   "x": 6,
                   "y": 396
                },
-               "id": 165,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22087,7 +22349,7 @@
                   "x": 12,
                   "y": 396
                },
-               "id": 166,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22242,7 +22504,7 @@
                   "x": 18,
                   "y": 396
                },
-               "id": 167,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22400,7 +22662,7 @@
             "x": 0,
             "y": 404
          },
-         "id": 168,
+         "id": 170,
          "panels": [
             {
                "aliasColors": { },
@@ -22417,7 +22679,7 @@
                   "x": 0,
                   "y": 405
                },
-               "id": 169,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22560,7 +22822,7 @@
                   "x": 12,
                   "y": 405
                },
-               "id": 170,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22703,7 +22965,7 @@
                   "x": 0,
                   "y": 413
                },
-               "id": 171,
+               "id": 173,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22840,7 +23102,7 @@
                   "x": 12,
                   "y": 413
                },
-               "id": 172,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/InfluxDB/dashboard_static_compiled.json
+++ b/tests/InfluxDB/dashboard_static_compiled.json
@@ -5628,7 +5628,7 @@
                "dashes": false,
                "datasource": "influxdb",
                "decimals": 3,
-               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n",
+               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,

--- a/tests/InfluxDB/dashboard_tdg_compiled.json
+++ b/tests/InfluxDB/dashboard_tdg_compiled.json
@@ -4665,7 +4665,7 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 3,
-               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n",
+               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,

--- a/tests/InfluxDB/dashboard_tdg_compiled.json
+++ b/tests/InfluxDB/dashboard_tdg_compiled.json
@@ -4665,15 +4665,146 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 3,
-               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "description": "Amount of memory in bytes currently used to store tuples (data).\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 110
                },
                "id": 41,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_memory_tuple_cache"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Tuples cache memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 3,
+               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 110
+               },
+               "id": 42,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4800,11 +4931,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 110
                },
-               "id": 42,
+               "id": 43,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4935,7 +5066,7 @@
                   "x": 0,
                   "y": 118
                },
-               "id": 43,
+               "id": 44,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5066,7 +5197,7 @@
                   "x": 8,
                   "y": 118
                },
-               "id": 44,
+               "id": 45,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5197,7 +5328,7 @@
                   "x": 16,
                   "y": 118
                },
-               "id": 45,
+               "id": 46,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5320,15 +5451,146 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 3,
+               "description": "«Level 0» (L0) memory area in bytes. L0 is the area that\nvinyl can use for in-memory storage of an LSM tree.\nBy monitoring this metric, you can see when L0 is getting\nclose to its maximum (tnt_vinyl_regulator_dump_watermark),\nat which time a dump will occur. You can expect L0 = 0\nimmediately after the dump operation is completed.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 126
+               },
+               "id": 47,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_memory_level0"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Level 0 memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 3,
                "description": "The maximum amount of memory used for in-memory storing of a vinyl LSM tree.\nWhen accessing this maximum, the dumping must occur.\nFor details, see https://www.tarantool.io/en/doc/latest/book/box/engines/#engines-algorithm-filling-lsm.\nThe value is slightly smaller than the amount of memory allocated for vinyl trees,\nwhich is the `vinyl_memory` parameter.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 0,
+                  "w": 8,
+                  "x": 8,
                   "y": 126
                },
-               "id": 46,
+               "id": 48,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5455,11 +5717,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 126
                },
-               "id": 47,
+               "id": 49,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5590,7 +5852,7 @@
                   "x": 0,
                   "y": 134
                },
-               "id": 48,
+               "id": 50,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5727,7 +5989,7 @@
                   "x": 6,
                   "y": 134
                },
-               "id": 49,
+               "id": 51,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5864,7 +6126,7 @@
                   "x": 12,
                   "y": 134
                },
-               "id": 50,
+               "id": 52,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6001,7 +6263,7 @@
                   "x": 18,
                   "y": 134
                },
-               "id": 51,
+               "id": 53,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6132,7 +6394,7 @@
                   "x": 0,
                   "y": 142
                },
-               "id": 52,
+               "id": 54,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6269,7 +6531,7 @@
                   "x": 6,
                   "y": 142
                },
-               "id": 53,
+               "id": 55,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6412,7 +6674,7 @@
                   "x": 12,
                   "y": 142
                },
-               "id": 54,
+               "id": 56,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6549,7 +6811,7 @@
                   "x": 18,
                   "y": 142
                },
-               "id": 55,
+               "id": 57,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6689,7 +6951,7 @@
             "x": 0,
             "y": 150
          },
-         "id": 56,
+         "id": 58,
          "panels": [
             {
                "aliasColors": { },
@@ -6706,7 +6968,7 @@
                   "x": 0,
                   "y": 151
                },
-               "id": 57,
+               "id": 59,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6843,7 +7105,7 @@
                   "x": 12,
                   "y": 151
                },
-               "id": 58,
+               "id": 60,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6980,7 +7242,7 @@
                   "x": 0,
                   "y": 159
                },
-               "id": 59,
+               "id": 61,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7129,7 +7391,7 @@
                   "x": 12,
                   "y": 159
                },
-               "id": 60,
+               "id": 62,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7281,7 +7543,7 @@
             "x": 0,
             "y": 167
          },
-         "id": 61,
+         "id": 63,
          "panels": [
             {
                "aliasColors": { },
@@ -7298,7 +7560,7 @@
                   "x": 0,
                   "y": 168
                },
-               "id": 62,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7429,7 +7691,7 @@
                   "x": 8,
                   "y": 168
                },
-               "id": 63,
+               "id": 65,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -7560,7 +7822,7 @@
                   "x": 16,
                   "y": 168
                },
-               "id": 64,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7691,7 +7953,7 @@
                   "x": 0,
                   "y": 176
                },
-               "id": 65,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7822,7 +8084,7 @@
                   "x": 12,
                   "y": 176
                },
-               "id": 66,
+               "id": 68,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7953,7 +8215,7 @@
                   "x": 0,
                   "y": 184
                },
-               "id": 67,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -8084,7 +8346,7 @@
                   "x": 8,
                   "y": 184
                },
-               "id": 68,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8215,7 +8477,7 @@
                   "x": 16,
                   "y": 184
                },
-               "id": 69,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8349,7 +8611,7 @@
             "x": 0,
             "y": 192
          },
-         "id": 70,
+         "id": 72,
          "panels": [
             {
                "aliasColors": { },
@@ -8366,7 +8628,7 @@
                   "x": 0,
                   "y": 193
                },
-               "id": 71,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8503,7 +8765,7 @@
                   "x": 6,
                   "y": 193
                },
-               "id": 72,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8640,7 +8902,7 @@
                   "x": 12,
                   "y": 193
                },
-               "id": 73,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8777,7 +9039,7 @@
                   "x": 18,
                   "y": 193
                },
-               "id": 74,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8908,7 +9170,7 @@
                   "x": 0,
                   "y": 201
                },
-               "id": 75,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9045,7 +9307,7 @@
                   "x": 12,
                   "y": 201
                },
-               "id": 76,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9182,7 +9444,7 @@
                   "x": 0,
                   "y": 209
                },
-               "id": 77,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9319,7 +9581,7 @@
                   "x": 8,
                   "y": 209
                },
-               "id": 78,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9456,7 +9718,7 @@
                   "x": 16,
                   "y": 209
                },
-               "id": 79,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9593,7 +9855,7 @@
                   "x": 0,
                   "y": 217
                },
-               "id": 80,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9730,7 +9992,7 @@
                   "x": 8,
                   "y": 217
                },
-               "id": 81,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9867,7 +10129,7 @@
                   "x": 16,
                   "y": 217
                },
-               "id": 82,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10004,7 +10266,7 @@
                   "x": 0,
                   "y": 225
                },
-               "id": 83,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10135,7 +10397,7 @@
                   "x": 6,
                   "y": 225
                },
-               "id": 84,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10266,7 +10528,7 @@
                   "x": 12,
                   "y": 225
                },
-               "id": 85,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10397,7 +10659,7 @@
                   "x": 18,
                   "y": 225
                },
-               "id": 86,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10528,7 +10790,7 @@
                   "x": 0,
                   "y": 233
                },
-               "id": 87,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10659,7 +10921,7 @@
                   "x": 8,
                   "y": 233
                },
-               "id": 88,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10796,7 +11058,7 @@
                   "x": 16,
                   "y": 233
                },
-               "id": 89,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10936,7 +11198,7 @@
             "x": 0,
             "y": 241
          },
-         "id": 90,
+         "id": 92,
          "panels": [
             {
                "aliasColors": { },
@@ -10953,7 +11215,7 @@
                   "x": 0,
                   "y": 242
                },
-               "id": 91,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11096,7 +11358,7 @@
                   "x": 8,
                   "y": 242
                },
-               "id": 92,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11239,7 +11501,7 @@
                   "x": 16,
                   "y": 242
                },
-               "id": 93,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11382,7 +11644,7 @@
                   "x": 0,
                   "y": 250
                },
-               "id": 94,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11525,7 +11787,7 @@
                   "x": 8,
                   "y": 250
                },
-               "id": 95,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11668,7 +11930,7 @@
                   "x": 16,
                   "y": 250
                },
-               "id": 96,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11811,7 +12073,7 @@
                   "x": 0,
                   "y": 258
                },
-               "id": 97,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11954,7 +12216,7 @@
                   "x": 8,
                   "y": 258
                },
-               "id": 98,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12097,7 +12359,7 @@
                   "x": 16,
                   "y": 258
                },
-               "id": 99,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12240,7 +12502,7 @@
                   "x": 0,
                   "y": 266
                },
-               "id": 100,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12383,7 +12645,7 @@
                   "x": 8,
                   "y": 266
                },
-               "id": 101,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12526,7 +12788,7 @@
                   "x": 16,
                   "y": 266
                },
-               "id": 102,
+               "id": 104,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12672,7 +12934,7 @@
             "x": 0,
             "y": 274
          },
-         "id": 103,
+         "id": 105,
          "panels": [
             {
                "aliasColors": { },
@@ -12689,7 +12951,7 @@
                   "x": 0,
                   "y": 275
                },
-               "id": 104,
+               "id": 106,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12838,7 +13100,7 @@
                   "x": 8,
                   "y": 275
                },
-               "id": 105,
+               "id": 107,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12987,7 +13249,7 @@
                   "x": 16,
                   "y": 275
                },
-               "id": 106,
+               "id": 108,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13136,7 +13398,7 @@
                   "x": 0,
                   "y": 283
                },
-               "id": 107,
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13291,7 +13553,7 @@
                   "x": 6,
                   "y": 283
                },
-               "id": 108,
+               "id": 110,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13446,7 +13708,7 @@
                   "x": 12,
                   "y": 283
                },
-               "id": 109,
+               "id": 111,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13601,7 +13863,7 @@
                   "x": 18,
                   "y": 283
                },
-               "id": 110,
+               "id": 112,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13756,7 +14018,7 @@
                   "x": 0,
                   "y": 291
                },
-               "id": 111,
+               "id": 113,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13911,7 +14173,7 @@
                   "x": 6,
                   "y": 291
                },
-               "id": 112,
+               "id": 114,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14066,7 +14328,7 @@
                   "x": 12,
                   "y": 291
                },
-               "id": 113,
+               "id": 115,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14221,7 +14483,7 @@
                   "x": 18,
                   "y": 291
                },
-               "id": 114,
+               "id": 116,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14379,7 +14641,7 @@
             "x": 0,
             "y": 299
          },
-         "id": 115,
+         "id": 117,
          "panels": [
             {
                "aliasColors": { },
@@ -14396,7 +14658,7 @@
                   "x": 0,
                   "y": 300
                },
-               "id": 116,
+               "id": 118,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -14551,7 +14813,7 @@
                   "x": 6,
                   "y": 300
                },
-               "id": 117,
+               "id": 119,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14712,7 +14974,7 @@
                   "x": 12,
                   "y": 300
                },
-               "id": 118,
+               "id": 120,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14873,7 +15135,7 @@
                   "x": 18,
                   "y": 300
                },
-               "id": 119,
+               "id": 121,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15034,7 +15296,7 @@
                   "x": 0,
                   "y": 308
                },
-               "id": 120,
+               "id": 122,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15189,7 +15451,7 @@
                   "x": 6,
                   "y": 308
                },
-               "id": 121,
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15344,7 +15606,7 @@
                   "x": 12,
                   "y": 308
                },
-               "id": 122,
+               "id": 124,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15499,7 +15761,7 @@
                   "x": 18,
                   "y": 308
                },
-               "id": 123,
+               "id": 125,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15654,7 +15916,7 @@
                   "x": 0,
                   "y": 316
                },
-               "id": 124,
+               "id": 126,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15815,7 +16077,7 @@
                   "x": 8,
                   "y": 316
                },
-               "id": 125,
+               "id": 127,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15976,7 +16238,7 @@
                   "x": 16,
                   "y": 316
                },
-               "id": 126,
+               "id": 128,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16137,7 +16399,7 @@
                   "x": 0,
                   "y": 324
                },
-               "id": 127,
+               "id": 129,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16298,7 +16560,7 @@
                   "x": 8,
                   "y": 324
                },
-               "id": 128,
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -16453,7 +16715,7 @@
                   "x": 16,
                   "y": 324
                },
-               "id": 129,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16614,7 +16876,7 @@
                   "x": 0,
                   "y": 332
                },
-               "id": 130,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16775,7 +17037,7 @@
                   "x": 8,
                   "y": 332
                },
-               "id": 131,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16936,7 +17198,7 @@
                   "x": 16,
                   "y": 332
                },
-               "id": 132,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17097,7 +17359,7 @@
                   "x": 0,
                   "y": 340
                },
-               "id": 133,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17258,7 +17520,7 @@
                   "x": 8,
                   "y": 340
                },
-               "id": 134,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -17413,7 +17675,7 @@
                   "x": 16,
                   "y": 340
                },
-               "id": 135,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17574,7 +17836,7 @@
                   "x": 0,
                   "y": 348
                },
-               "id": 136,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17741,7 +18003,7 @@
                   "x": 0,
                   "y": 358
                },
-               "id": 137,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17902,7 +18164,7 @@
                   "x": 6,
                   "y": 358
                },
-               "id": 138,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18063,7 +18325,7 @@
                   "x": 12,
                   "y": 358
                },
-               "id": 139,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18224,7 +18486,7 @@
                   "x": 18,
                   "y": 358
                },
-               "id": 140,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18388,7 +18650,7 @@
             "x": 0,
             "y": 366
          },
-         "id": 141,
+         "id": 143,
          "panels": [
             {
                "aliasColors": { },
@@ -18405,7 +18667,7 @@
                   "x": 0,
                   "y": 367
                },
-               "id": 142,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18560,7 +18822,7 @@
                   "x": 12,
                   "y": 367
                },
-               "id": 143,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18715,7 +18977,7 @@
                   "x": 0,
                   "y": 375
                },
-               "id": 144,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18876,7 +19138,7 @@
                   "x": 12,
                   "y": 375
                },
-               "id": 145,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19037,7 +19299,7 @@
                   "x": 0,
                   "y": 383
                },
-               "id": 146,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19198,7 +19460,7 @@
                   "x": 8,
                   "y": 383
                },
-               "id": 147,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19359,7 +19621,7 @@
                   "x": 16,
                   "y": 383
                },
-               "id": 148,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19520,7 +19782,7 @@
                   "x": 0,
                   "y": 391
                },
-               "id": 149,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19681,7 +19943,7 @@
                   "x": 8,
                   "y": 391
                },
-               "id": 150,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19842,7 +20104,7 @@
                   "x": 16,
                   "y": 391
                },
-               "id": 151,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20003,7 +20265,7 @@
                   "x": 0,
                   "y": 399
                },
-               "id": 152,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20170,7 +20432,7 @@
                   "x": 6,
                   "y": 399
                },
-               "id": 153,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20337,7 +20599,7 @@
                   "x": 12,
                   "y": 399
                },
-               "id": 154,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20504,7 +20766,7 @@
                   "x": 18,
                   "y": 399
                },
-               "id": 155,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20671,7 +20933,7 @@
                   "x": 0,
                   "y": 407
                },
-               "id": 156,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20838,7 +21100,7 @@
                   "x": 12,
                   "y": 407
                },
-               "id": 157,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21002,7 +21264,7 @@
             "x": 0,
             "y": 415
          },
-         "id": 158,
+         "id": 160,
          "panels": [
             {
                "aliasColors": { },
@@ -21019,7 +21281,7 @@
                   "x": 0,
                   "y": 416
                },
-               "id": 159,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -21168,7 +21430,7 @@
                   "x": 12,
                   "y": 416
                },
-               "id": 160,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21317,7 +21579,7 @@
                   "x": 0,
                   "y": 424
                },
-               "id": 161,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21472,7 +21734,7 @@
                   "x": 12,
                   "y": 424
                },
-               "id": 162,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21624,7 +21886,7 @@
             "x": 0,
             "y": 432
          },
-         "id": 163,
+         "id": 165,
          "panels": [
             {
                "aliasColors": { },
@@ -21641,7 +21903,7 @@
                   "x": 0,
                   "y": 433
                },
-               "id": 164,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -21790,7 +22052,7 @@
                   "x": 12,
                   "y": 433
                },
-               "id": 165,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -21942,7 +22204,7 @@
             "x": 0,
             "y": 441
          },
-         "id": 166,
+         "id": 168,
          "panels": [
             {
                "aliasColors": { },
@@ -21959,7 +22221,7 @@
                   "x": 0,
                   "y": 442
                },
-               "id": 167,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22102,7 +22364,7 @@
                   "x": 12,
                   "y": 442
                },
-               "id": 168,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22245,7 +22507,7 @@
                   "x": 0,
                   "y": 450
                },
-               "id": 169,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22382,7 +22644,7 @@
                   "x": 12,
                   "y": 450
                },
-               "id": 170,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22522,7 +22784,7 @@
             "x": 0,
             "y": 458
          },
-         "id": 171,
+         "id": 173,
          "panels": [
             {
                "aliasColors": { },
@@ -22539,7 +22801,7 @@
                   "x": 0,
                   "y": 459
                },
-               "id": 172,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22646,7 +22908,7 @@
                   "x": 12,
                   "y": 459
                },
-               "id": 173,
+               "id": 175,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22753,7 +23015,7 @@
                   "x": 0,
                   "y": 467
                },
-               "id": 174,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22884,7 +23146,7 @@
                   "x": 12,
                   "y": 467
                },
-               "id": 175,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23018,7 +23280,7 @@
             "x": 0,
             "y": 475
          },
-         "id": 176,
+         "id": 178,
          "panels": [
             {
                "aliasColors": { },
@@ -23035,7 +23297,7 @@
                   "x": 0,
                   "y": 476
                },
-               "id": 177,
+               "id": 179,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -23172,7 +23434,7 @@
                   "x": 8,
                   "y": 476
                },
-               "id": 178,
+               "id": 180,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -23309,7 +23571,7 @@
                   "x": 16,
                   "y": 476
                },
-               "id": 179,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -23446,7 +23708,7 @@
                   "x": 0,
                   "y": 484
                },
-               "id": 180,
+               "id": 182,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -23583,7 +23845,7 @@
                   "x": 8,
                   "y": 484
                },
-               "id": 181,
+               "id": 183,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -23720,7 +23982,7 @@
                   "x": 16,
                   "y": 484
                },
-               "id": 182,
+               "id": 184,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -23860,7 +24122,7 @@
             "x": 0,
             "y": 492
          },
-         "id": 183,
+         "id": 185,
          "panels": [
             {
                "aliasColors": { },
@@ -23877,7 +24139,7 @@
                   "x": 0,
                   "y": 493
                },
-               "id": 184,
+               "id": 186,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24032,7 +24294,7 @@
                   "x": 8,
                   "y": 493
                },
-               "id": 185,
+               "id": 187,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24139,7 +24401,7 @@
                   "x": 16,
                   "y": 493
                },
-               "id": 186,
+               "id": 188,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24294,7 +24556,7 @@
                   "x": 0,
                   "y": 501
                },
-               "id": 187,
+               "id": 189,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24449,7 +24711,7 @@
                   "x": 8,
                   "y": 501
                },
-               "id": 188,
+               "id": 190,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24556,7 +24818,7 @@
                   "x": 16,
                   "y": 501
                },
-               "id": 189,
+               "id": 191,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24714,7 +24976,7 @@
             "x": 0,
             "y": 509
          },
-         "id": 190,
+         "id": 192,
          "panels": [
             {
                "aliasColors": { },
@@ -24731,7 +24993,7 @@
                   "x": 0,
                   "y": 510
                },
-               "id": 191,
+               "id": 193,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24880,7 +25142,7 @@
                   "x": 6,
                   "y": 510
                },
-               "id": 192,
+               "id": 194,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25029,7 +25291,7 @@
                   "x": 12,
                   "y": 510
                },
-               "id": 193,
+               "id": 195,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25178,7 +25440,7 @@
                   "x": 18,
                   "y": 510
                },
-               "id": 194,
+               "id": 196,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25327,7 +25589,7 @@
                   "x": 0,
                   "y": 518
                },
-               "id": 195,
+               "id": 197,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25476,7 +25738,7 @@
                   "x": 12,
                   "y": 518
                },
-               "id": 196,
+               "id": 198,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25625,7 +25887,7 @@
                   "x": 0,
                   "y": 526
                },
-               "id": 197,
+               "id": 199,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25774,7 +26036,7 @@
                   "x": 6,
                   "y": 526
                },
-               "id": 198,
+               "id": 200,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25923,7 +26185,7 @@
                   "x": 12,
                   "y": 526
                },
-               "id": 199,
+               "id": 201,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26072,7 +26334,7 @@
                   "x": 18,
                   "y": 526
                },
-               "id": 200,
+               "id": 202,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26221,7 +26483,7 @@
                   "x": 0,
                   "y": 534
                },
-               "id": 201,
+               "id": 203,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26370,7 +26632,7 @@
                   "x": 6,
                   "y": 534
                },
-               "id": 202,
+               "id": 204,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26519,7 +26781,7 @@
                   "x": 12,
                   "y": 534
                },
-               "id": 203,
+               "id": 205,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26668,7 +26930,7 @@
                   "x": 18,
                   "y": 534
                },
-               "id": 204,
+               "id": 206,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26817,7 +27079,7 @@
                   "x": 0,
                   "y": 542
                },
-               "id": 205,
+               "id": 207,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26966,7 +27228,7 @@
                   "x": 6,
                   "y": 542
                },
-               "id": 206,
+               "id": 208,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27115,7 +27377,7 @@
                   "x": 12,
                   "y": 542
                },
-               "id": 207,
+               "id": 209,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27264,7 +27526,7 @@
                   "x": 18,
                   "y": 542
                },
-               "id": 208,
+               "id": 210,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27416,7 +27678,7 @@
             "x": 0,
             "y": 550
          },
-         "id": 209,
+         "id": 211,
          "panels": [
             {
                "aliasColors": { },
@@ -27433,7 +27695,7 @@
                   "x": 0,
                   "y": 551
                },
-               "id": 210,
+               "id": 212,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27600,7 +27862,7 @@
                   "x": 8,
                   "y": 551
                },
-               "id": 211,
+               "id": 213,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27767,7 +28029,7 @@
                   "x": 16,
                   "y": 551
                },
-               "id": 212,
+               "id": 214,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27934,7 +28196,7 @@
                   "x": 0,
                   "y": 559
                },
-               "id": 213,
+               "id": 215,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28101,7 +28363,7 @@
                   "x": 8,
                   "y": 559
                },
-               "id": 214,
+               "id": 216,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28268,7 +28530,7 @@
                   "x": 16,
                   "y": 559
                },
-               "id": 215,
+               "id": 217,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28435,7 +28697,7 @@
                   "x": 0,
                   "y": 567
                },
-               "id": 216,
+               "id": 218,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28602,7 +28864,7 @@
                   "x": 8,
                   "y": 567
                },
-               "id": 217,
+               "id": 219,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28769,7 +29031,7 @@
                   "x": 16,
                   "y": 567
                },
-               "id": 218,
+               "id": 220,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28936,7 +29198,7 @@
                   "x": 0,
                   "y": 575
                },
-               "id": 219,
+               "id": 221,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29103,7 +29365,7 @@
                   "x": 8,
                   "y": 575
                },
-               "id": 220,
+               "id": 222,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29270,7 +29532,7 @@
                   "x": 16,
                   "y": 575
                },
-               "id": 221,
+               "id": 223,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29440,7 +29702,7 @@
             "x": 0,
             "y": 583
          },
-         "id": 222,
+         "id": 224,
          "panels": [
             {
                "aliasColors": { },
@@ -29457,7 +29719,7 @@
                   "x": 0,
                   "y": 584
                },
-               "id": 223,
+               "id": 225,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29606,7 +29868,7 @@
                   "x": 8,
                   "y": 584
                },
-               "id": 224,
+               "id": 226,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29755,7 +30017,7 @@
                   "x": 16,
                   "y": 584
                },
-               "id": 225,
+               "id": 227,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29904,7 +30166,7 @@
                   "x": 0,
                   "y": 592
                },
-               "id": 226,
+               "id": 228,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -30047,7 +30309,7 @@
                   "x": 12,
                   "y": 592
                },
-               "id": 227,
+               "id": 229,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30154,7 +30416,7 @@
                   "x": 0,
                   "y": 600
                },
-               "id": 228,
+               "id": 230,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30303,7 +30565,7 @@
                   "x": 6,
                   "y": 600
                },
-               "id": 229,
+               "id": 231,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30452,7 +30714,7 @@
                   "x": 12,
                   "y": 600
                },
-               "id": 230,
+               "id": 232,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30601,7 +30863,7 @@
                   "x": 18,
                   "y": 600
                },
-               "id": 231,
+               "id": 233,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30750,7 +31012,7 @@
                   "x": 0,
                   "y": 608
                },
-               "id": 232,
+               "id": 234,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -30893,7 +31155,7 @@
                   "x": 12,
                   "y": 608
                },
-               "id": 233,
+               "id": 235,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31000,7 +31262,7 @@
                   "x": 0,
                   "y": 616
                },
-               "id": 234,
+               "id": 236,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31149,7 +31411,7 @@
                   "x": 8,
                   "y": 616
                },
-               "id": 235,
+               "id": 237,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31298,7 +31560,7 @@
                   "x": 16,
                   "y": 616
                },
-               "id": 236,
+               "id": 238,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31447,7 +31709,7 @@
                   "x": 0,
                   "y": 624
                },
-               "id": 237,
+               "id": 239,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -31590,7 +31852,7 @@
                   "x": 12,
                   "y": 624
                },
-               "id": 238,
+               "id": 240,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/InfluxDB/dashboard_tdg_static_compiled.json
+++ b/tests/InfluxDB/dashboard_tdg_static_compiled.json
@@ -4642,7 +4642,7 @@
                "dashes": false,
                "datasource": "influxdb",
                "decimals": 3,
-               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n",
+               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,

--- a/tests/InfluxDB/dashboard_tdg_static_compiled.json
+++ b/tests/InfluxDB/dashboard_tdg_static_compiled.json
@@ -4642,15 +4642,146 @@
                "dashes": false,
                "datasource": "influxdb",
                "decimals": 3,
-               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "description": "Amount of memory in bytes currently used to store tuples (data).\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 110
                },
                "id": 41,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_memory_tuple_cache"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Tuples cache memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "influxdb",
+               "decimals": 3,
+               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 110
+               },
+               "id": 42,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4777,11 +4908,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 110
                },
-               "id": 42,
+               "id": 43,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4912,7 +5043,7 @@
                   "x": 0,
                   "y": 118
                },
-               "id": 43,
+               "id": 44,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5043,7 +5174,7 @@
                   "x": 8,
                   "y": 118
                },
-               "id": 44,
+               "id": 45,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5174,7 +5305,7 @@
                   "x": 16,
                   "y": 118
                },
-               "id": 45,
+               "id": 46,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5297,15 +5428,146 @@
                "dashes": false,
                "datasource": "influxdb",
                "decimals": 3,
+               "description": "«Level 0» (L0) memory area in bytes. L0 is the area that\nvinyl can use for in-memory storage of an LSM tree.\nBy monitoring this metric, you can see when L0 is getting\nclose to its maximum (tnt_vinyl_regulator_dump_watermark),\nat which time a dump will occur. You can expect L0 = 0\nimmediately after the dump operation is completed.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 126
+               },
+               "id": 47,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_memory_level0"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Level 0 memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "influxdb",
+               "decimals": 3,
                "description": "The maximum amount of memory used for in-memory storing of a vinyl LSM tree.\nWhen accessing this maximum, the dumping must occur.\nFor details, see https://www.tarantool.io/en/doc/latest/book/box/engines/#engines-algorithm-filling-lsm.\nThe value is slightly smaller than the amount of memory allocated for vinyl trees,\nwhich is the `vinyl_memory` parameter.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 0,
+                  "w": 8,
+                  "x": 8,
                   "y": 126
                },
-               "id": 46,
+               "id": 48,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5432,11 +5694,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 126
                },
-               "id": 47,
+               "id": 49,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5567,7 +5829,7 @@
                   "x": 0,
                   "y": 134
                },
-               "id": 48,
+               "id": 50,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5704,7 +5966,7 @@
                   "x": 6,
                   "y": 134
                },
-               "id": 49,
+               "id": 51,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5841,7 +6103,7 @@
                   "x": 12,
                   "y": 134
                },
-               "id": 50,
+               "id": 52,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5978,7 +6240,7 @@
                   "x": 18,
                   "y": 134
                },
-               "id": 51,
+               "id": 53,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6109,7 +6371,7 @@
                   "x": 0,
                   "y": 142
                },
-               "id": 52,
+               "id": 54,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6246,7 +6508,7 @@
                   "x": 6,
                   "y": 142
                },
-               "id": 53,
+               "id": 55,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6389,7 +6651,7 @@
                   "x": 12,
                   "y": 142
                },
-               "id": 54,
+               "id": 56,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6526,7 +6788,7 @@
                   "x": 18,
                   "y": 142
                },
-               "id": 55,
+               "id": 57,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6666,7 +6928,7 @@
             "x": 0,
             "y": 150
          },
-         "id": 56,
+         "id": 58,
          "panels": [
             {
                "aliasColors": { },
@@ -6683,7 +6945,7 @@
                   "x": 0,
                   "y": 151
                },
-               "id": 57,
+               "id": 59,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6820,7 +7082,7 @@
                   "x": 12,
                   "y": 151
                },
-               "id": 58,
+               "id": 60,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6957,7 +7219,7 @@
                   "x": 0,
                   "y": 159
                },
-               "id": 59,
+               "id": 61,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7106,7 +7368,7 @@
                   "x": 12,
                   "y": 159
                },
-               "id": 60,
+               "id": 62,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7258,7 +7520,7 @@
             "x": 0,
             "y": 167
          },
-         "id": 61,
+         "id": 63,
          "panels": [
             {
                "aliasColors": { },
@@ -7275,7 +7537,7 @@
                   "x": 0,
                   "y": 168
                },
-               "id": 62,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7406,7 +7668,7 @@
                   "x": 8,
                   "y": 168
                },
-               "id": 63,
+               "id": 65,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -7537,7 +7799,7 @@
                   "x": 16,
                   "y": 168
                },
-               "id": 64,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7668,7 +7930,7 @@
                   "x": 0,
                   "y": 176
                },
-               "id": 65,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7799,7 +8061,7 @@
                   "x": 12,
                   "y": 176
                },
-               "id": 66,
+               "id": 68,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7930,7 +8192,7 @@
                   "x": 0,
                   "y": 184
                },
-               "id": 67,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -8061,7 +8323,7 @@
                   "x": 8,
                   "y": 184
                },
-               "id": 68,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8192,7 +8454,7 @@
                   "x": 16,
                   "y": 184
                },
-               "id": 69,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8326,7 +8588,7 @@
             "x": 0,
             "y": 192
          },
-         "id": 70,
+         "id": 72,
          "panels": [
             {
                "aliasColors": { },
@@ -8343,7 +8605,7 @@
                   "x": 0,
                   "y": 193
                },
-               "id": 71,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8480,7 +8742,7 @@
                   "x": 6,
                   "y": 193
                },
-               "id": 72,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8617,7 +8879,7 @@
                   "x": 12,
                   "y": 193
                },
-               "id": 73,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8754,7 +9016,7 @@
                   "x": 18,
                   "y": 193
                },
-               "id": 74,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8885,7 +9147,7 @@
                   "x": 0,
                   "y": 201
                },
-               "id": 75,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9022,7 +9284,7 @@
                   "x": 12,
                   "y": 201
                },
-               "id": 76,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9159,7 +9421,7 @@
                   "x": 0,
                   "y": 209
                },
-               "id": 77,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9296,7 +9558,7 @@
                   "x": 8,
                   "y": 209
                },
-               "id": 78,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9433,7 +9695,7 @@
                   "x": 16,
                   "y": 209
                },
-               "id": 79,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9570,7 +9832,7 @@
                   "x": 0,
                   "y": 217
                },
-               "id": 80,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9707,7 +9969,7 @@
                   "x": 8,
                   "y": 217
                },
-               "id": 81,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9844,7 +10106,7 @@
                   "x": 16,
                   "y": 217
                },
-               "id": 82,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9981,7 +10243,7 @@
                   "x": 0,
                   "y": 225
                },
-               "id": 83,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10112,7 +10374,7 @@
                   "x": 6,
                   "y": 225
                },
-               "id": 84,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10243,7 +10505,7 @@
                   "x": 12,
                   "y": 225
                },
-               "id": 85,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10374,7 +10636,7 @@
                   "x": 18,
                   "y": 225
                },
-               "id": 86,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10505,7 +10767,7 @@
                   "x": 0,
                   "y": 233
                },
-               "id": 87,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10636,7 +10898,7 @@
                   "x": 8,
                   "y": 233
                },
-               "id": 88,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10773,7 +11035,7 @@
                   "x": 16,
                   "y": 233
                },
-               "id": 89,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10913,7 +11175,7 @@
             "x": 0,
             "y": 241
          },
-         "id": 90,
+         "id": 92,
          "panels": [
             {
                "aliasColors": { },
@@ -10930,7 +11192,7 @@
                   "x": 0,
                   "y": 242
                },
-               "id": 91,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11073,7 +11335,7 @@
                   "x": 8,
                   "y": 242
                },
-               "id": 92,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11216,7 +11478,7 @@
                   "x": 16,
                   "y": 242
                },
-               "id": 93,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11359,7 +11621,7 @@
                   "x": 0,
                   "y": 250
                },
-               "id": 94,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11502,7 +11764,7 @@
                   "x": 8,
                   "y": 250
                },
-               "id": 95,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11645,7 +11907,7 @@
                   "x": 16,
                   "y": 250
                },
-               "id": 96,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11788,7 +12050,7 @@
                   "x": 0,
                   "y": 258
                },
-               "id": 97,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11931,7 +12193,7 @@
                   "x": 8,
                   "y": 258
                },
-               "id": 98,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12074,7 +12336,7 @@
                   "x": 16,
                   "y": 258
                },
-               "id": 99,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12217,7 +12479,7 @@
                   "x": 0,
                   "y": 266
                },
-               "id": 100,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12360,7 +12622,7 @@
                   "x": 8,
                   "y": 266
                },
-               "id": 101,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12503,7 +12765,7 @@
                   "x": 16,
                   "y": 266
                },
-               "id": 102,
+               "id": 104,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12649,7 +12911,7 @@
             "x": 0,
             "y": 274
          },
-         "id": 103,
+         "id": 105,
          "panels": [
             {
                "aliasColors": { },
@@ -12666,7 +12928,7 @@
                   "x": 0,
                   "y": 275
                },
-               "id": 104,
+               "id": 106,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12815,7 +13077,7 @@
                   "x": 8,
                   "y": 275
                },
-               "id": 105,
+               "id": 107,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12964,7 +13226,7 @@
                   "x": 16,
                   "y": 275
                },
-               "id": 106,
+               "id": 108,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13113,7 +13375,7 @@
                   "x": 0,
                   "y": 283
                },
-               "id": 107,
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13268,7 +13530,7 @@
                   "x": 6,
                   "y": 283
                },
-               "id": 108,
+               "id": 110,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13423,7 +13685,7 @@
                   "x": 12,
                   "y": 283
                },
-               "id": 109,
+               "id": 111,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13578,7 +13840,7 @@
                   "x": 18,
                   "y": 283
                },
-               "id": 110,
+               "id": 112,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13733,7 +13995,7 @@
                   "x": 0,
                   "y": 291
                },
-               "id": 111,
+               "id": 113,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13888,7 +14150,7 @@
                   "x": 6,
                   "y": 291
                },
-               "id": 112,
+               "id": 114,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14043,7 +14305,7 @@
                   "x": 12,
                   "y": 291
                },
-               "id": 113,
+               "id": 115,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14198,7 +14460,7 @@
                   "x": 18,
                   "y": 291
                },
-               "id": 114,
+               "id": 116,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14356,7 +14618,7 @@
             "x": 0,
             "y": 299
          },
-         "id": 115,
+         "id": 117,
          "panels": [
             {
                "aliasColors": { },
@@ -14373,7 +14635,7 @@
                   "x": 0,
                   "y": 300
                },
-               "id": 116,
+               "id": 118,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -14528,7 +14790,7 @@
                   "x": 6,
                   "y": 300
                },
-               "id": 117,
+               "id": 119,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14689,7 +14951,7 @@
                   "x": 12,
                   "y": 300
                },
-               "id": 118,
+               "id": 120,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14850,7 +15112,7 @@
                   "x": 18,
                   "y": 300
                },
-               "id": 119,
+               "id": 121,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15011,7 +15273,7 @@
                   "x": 0,
                   "y": 308
                },
-               "id": 120,
+               "id": 122,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15166,7 +15428,7 @@
                   "x": 6,
                   "y": 308
                },
-               "id": 121,
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15321,7 +15583,7 @@
                   "x": 12,
                   "y": 308
                },
-               "id": 122,
+               "id": 124,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15476,7 +15738,7 @@
                   "x": 18,
                   "y": 308
                },
-               "id": 123,
+               "id": 125,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15631,7 +15893,7 @@
                   "x": 0,
                   "y": 316
                },
-               "id": 124,
+               "id": 126,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15792,7 +16054,7 @@
                   "x": 8,
                   "y": 316
                },
-               "id": 125,
+               "id": 127,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15953,7 +16215,7 @@
                   "x": 16,
                   "y": 316
                },
-               "id": 126,
+               "id": 128,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16114,7 +16376,7 @@
                   "x": 0,
                   "y": 324
                },
-               "id": 127,
+               "id": 129,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16275,7 +16537,7 @@
                   "x": 8,
                   "y": 324
                },
-               "id": 128,
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -16430,7 +16692,7 @@
                   "x": 16,
                   "y": 324
                },
-               "id": 129,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16591,7 +16853,7 @@
                   "x": 0,
                   "y": 332
                },
-               "id": 130,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16752,7 +17014,7 @@
                   "x": 8,
                   "y": 332
                },
-               "id": 131,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16913,7 +17175,7 @@
                   "x": 16,
                   "y": 332
                },
-               "id": 132,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17074,7 +17336,7 @@
                   "x": 0,
                   "y": 340
                },
-               "id": 133,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17235,7 +17497,7 @@
                   "x": 8,
                   "y": 340
                },
-               "id": 134,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -17390,7 +17652,7 @@
                   "x": 16,
                   "y": 340
                },
-               "id": 135,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17551,7 +17813,7 @@
                   "x": 0,
                   "y": 348
                },
-               "id": 136,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17718,7 +17980,7 @@
                   "x": 0,
                   "y": 358
                },
-               "id": 137,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17879,7 +18141,7 @@
                   "x": 6,
                   "y": 358
                },
-               "id": 138,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18040,7 +18302,7 @@
                   "x": 12,
                   "y": 358
                },
-               "id": 139,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18201,7 +18463,7 @@
                   "x": 18,
                   "y": 358
                },
-               "id": 140,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18365,7 +18627,7 @@
             "x": 0,
             "y": 366
          },
-         "id": 141,
+         "id": 143,
          "panels": [
             {
                "aliasColors": { },
@@ -18382,7 +18644,7 @@
                   "x": 0,
                   "y": 367
                },
-               "id": 142,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18537,7 +18799,7 @@
                   "x": 12,
                   "y": 367
                },
-               "id": 143,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18692,7 +18954,7 @@
                   "x": 0,
                   "y": 375
                },
-               "id": 144,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18853,7 +19115,7 @@
                   "x": 12,
                   "y": 375
                },
-               "id": 145,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19014,7 +19276,7 @@
                   "x": 0,
                   "y": 383
                },
-               "id": 146,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19175,7 +19437,7 @@
                   "x": 8,
                   "y": 383
                },
-               "id": 147,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19336,7 +19598,7 @@
                   "x": 16,
                   "y": 383
                },
-               "id": 148,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19497,7 +19759,7 @@
                   "x": 0,
                   "y": 391
                },
-               "id": 149,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19658,7 +19920,7 @@
                   "x": 8,
                   "y": 391
                },
-               "id": 150,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19819,7 +20081,7 @@
                   "x": 16,
                   "y": 391
                },
-               "id": 151,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19980,7 +20242,7 @@
                   "x": 0,
                   "y": 399
                },
-               "id": 152,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20147,7 +20409,7 @@
                   "x": 6,
                   "y": 399
                },
-               "id": 153,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20314,7 +20576,7 @@
                   "x": 12,
                   "y": 399
                },
-               "id": 154,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20481,7 +20743,7 @@
                   "x": 18,
                   "y": 399
                },
-               "id": 155,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20648,7 +20910,7 @@
                   "x": 0,
                   "y": 407
                },
-               "id": 156,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20815,7 +21077,7 @@
                   "x": 12,
                   "y": 407
                },
-               "id": 157,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20979,7 +21241,7 @@
             "x": 0,
             "y": 415
          },
-         "id": 158,
+         "id": 160,
          "panels": [
             {
                "aliasColors": { },
@@ -20996,7 +21258,7 @@
                   "x": 0,
                   "y": 416
                },
-               "id": 159,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -21145,7 +21407,7 @@
                   "x": 12,
                   "y": 416
                },
-               "id": 160,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21294,7 +21556,7 @@
                   "x": 0,
                   "y": 424
                },
-               "id": 161,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21449,7 +21711,7 @@
                   "x": 12,
                   "y": 424
                },
-               "id": 162,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21601,7 +21863,7 @@
             "x": 0,
             "y": 432
          },
-         "id": 163,
+         "id": 165,
          "panels": [
             {
                "aliasColors": { },
@@ -21618,7 +21880,7 @@
                   "x": 0,
                   "y": 433
                },
-               "id": 164,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -21767,7 +22029,7 @@
                   "x": 12,
                   "y": 433
                },
-               "id": 165,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -21919,7 +22181,7 @@
             "x": 0,
             "y": 441
          },
-         "id": 166,
+         "id": 168,
          "panels": [
             {
                "aliasColors": { },
@@ -21936,7 +22198,7 @@
                   "x": 0,
                   "y": 442
                },
-               "id": 167,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22079,7 +22341,7 @@
                   "x": 12,
                   "y": 442
                },
-               "id": 168,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22222,7 +22484,7 @@
                   "x": 0,
                   "y": 450
                },
-               "id": 169,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22359,7 +22621,7 @@
                   "x": 12,
                   "y": 450
                },
-               "id": 170,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22499,7 +22761,7 @@
             "x": 0,
             "y": 458
          },
-         "id": 171,
+         "id": 173,
          "panels": [
             {
                "aliasColors": { },
@@ -22516,7 +22778,7 @@
                   "x": 0,
                   "y": 459
                },
-               "id": 172,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22623,7 +22885,7 @@
                   "x": 12,
                   "y": 459
                },
-               "id": 173,
+               "id": 175,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22730,7 +22992,7 @@
                   "x": 0,
                   "y": 467
                },
-               "id": 174,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22861,7 +23123,7 @@
                   "x": 12,
                   "y": 467
                },
-               "id": 175,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22995,7 +23257,7 @@
             "x": 0,
             "y": 475
          },
-         "id": 176,
+         "id": 178,
          "panels": [
             {
                "aliasColors": { },
@@ -23012,7 +23274,7 @@
                   "x": 0,
                   "y": 476
                },
-               "id": 177,
+               "id": 179,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -23149,7 +23411,7 @@
                   "x": 8,
                   "y": 476
                },
-               "id": 178,
+               "id": 180,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -23286,7 +23548,7 @@
                   "x": 16,
                   "y": 476
                },
-               "id": 179,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -23423,7 +23685,7 @@
                   "x": 0,
                   "y": 484
                },
-               "id": 180,
+               "id": 182,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -23560,7 +23822,7 @@
                   "x": 8,
                   "y": 484
                },
-               "id": 181,
+               "id": 183,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -23697,7 +23959,7 @@
                   "x": 16,
                   "y": 484
                },
-               "id": 182,
+               "id": 184,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -23837,7 +24099,7 @@
             "x": 0,
             "y": 492
          },
-         "id": 183,
+         "id": 185,
          "panels": [
             {
                "aliasColors": { },
@@ -23854,7 +24116,7 @@
                   "x": 0,
                   "y": 493
                },
-               "id": 184,
+               "id": 186,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24009,7 +24271,7 @@
                   "x": 8,
                   "y": 493
                },
-               "id": 185,
+               "id": 187,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24116,7 +24378,7 @@
                   "x": 16,
                   "y": 493
                },
-               "id": 186,
+               "id": 188,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24271,7 +24533,7 @@
                   "x": 0,
                   "y": 501
                },
-               "id": 187,
+               "id": 189,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24426,7 +24688,7 @@
                   "x": 8,
                   "y": 501
                },
-               "id": 188,
+               "id": 190,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24533,7 +24795,7 @@
                   "x": 16,
                   "y": 501
                },
-               "id": 189,
+               "id": 191,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24691,7 +24953,7 @@
             "x": 0,
             "y": 509
          },
-         "id": 190,
+         "id": 192,
          "panels": [
             {
                "aliasColors": { },
@@ -24708,7 +24970,7 @@
                   "x": 0,
                   "y": 510
                },
-               "id": 191,
+               "id": 193,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24857,7 +25119,7 @@
                   "x": 6,
                   "y": 510
                },
-               "id": 192,
+               "id": 194,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25006,7 +25268,7 @@
                   "x": 12,
                   "y": 510
                },
-               "id": 193,
+               "id": 195,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25155,7 +25417,7 @@
                   "x": 18,
                   "y": 510
                },
-               "id": 194,
+               "id": 196,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25304,7 +25566,7 @@
                   "x": 0,
                   "y": 518
                },
-               "id": 195,
+               "id": 197,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25453,7 +25715,7 @@
                   "x": 12,
                   "y": 518
                },
-               "id": 196,
+               "id": 198,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25602,7 +25864,7 @@
                   "x": 0,
                   "y": 526
                },
-               "id": 197,
+               "id": 199,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25751,7 +26013,7 @@
                   "x": 6,
                   "y": 526
                },
-               "id": 198,
+               "id": 200,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25900,7 +26162,7 @@
                   "x": 12,
                   "y": 526
                },
-               "id": 199,
+               "id": 201,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26049,7 +26311,7 @@
                   "x": 18,
                   "y": 526
                },
-               "id": 200,
+               "id": 202,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26198,7 +26460,7 @@
                   "x": 0,
                   "y": 534
                },
-               "id": 201,
+               "id": 203,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26347,7 +26609,7 @@
                   "x": 6,
                   "y": 534
                },
-               "id": 202,
+               "id": 204,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26496,7 +26758,7 @@
                   "x": 12,
                   "y": 534
                },
-               "id": 203,
+               "id": 205,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26645,7 +26907,7 @@
                   "x": 18,
                   "y": 534
                },
-               "id": 204,
+               "id": 206,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26794,7 +27056,7 @@
                   "x": 0,
                   "y": 542
                },
-               "id": 205,
+               "id": 207,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26943,7 +27205,7 @@
                   "x": 6,
                   "y": 542
                },
-               "id": 206,
+               "id": 208,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27092,7 +27354,7 @@
                   "x": 12,
                   "y": 542
                },
-               "id": 207,
+               "id": 209,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27241,7 +27503,7 @@
                   "x": 18,
                   "y": 542
                },
-               "id": 208,
+               "id": 210,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27393,7 +27655,7 @@
             "x": 0,
             "y": 550
          },
-         "id": 209,
+         "id": 211,
          "panels": [
             {
                "aliasColors": { },
@@ -27410,7 +27672,7 @@
                   "x": 0,
                   "y": 551
                },
-               "id": 210,
+               "id": 212,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27577,7 +27839,7 @@
                   "x": 8,
                   "y": 551
                },
-               "id": 211,
+               "id": 213,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27744,7 +28006,7 @@
                   "x": 16,
                   "y": 551
                },
-               "id": 212,
+               "id": 214,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27911,7 +28173,7 @@
                   "x": 0,
                   "y": 559
                },
-               "id": 213,
+               "id": 215,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28078,7 +28340,7 @@
                   "x": 8,
                   "y": 559
                },
-               "id": 214,
+               "id": 216,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28245,7 +28507,7 @@
                   "x": 16,
                   "y": 559
                },
-               "id": 215,
+               "id": 217,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28412,7 +28674,7 @@
                   "x": 0,
                   "y": 567
                },
-               "id": 216,
+               "id": 218,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28579,7 +28841,7 @@
                   "x": 8,
                   "y": 567
                },
-               "id": 217,
+               "id": 219,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28746,7 +29008,7 @@
                   "x": 16,
                   "y": 567
                },
-               "id": 218,
+               "id": 220,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28913,7 +29175,7 @@
                   "x": 0,
                   "y": 575
                },
-               "id": 219,
+               "id": 221,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29080,7 +29342,7 @@
                   "x": 8,
                   "y": 575
                },
-               "id": 220,
+               "id": 222,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29247,7 +29509,7 @@
                   "x": 16,
                   "y": 575
                },
-               "id": 221,
+               "id": 223,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29417,7 +29679,7 @@
             "x": 0,
             "y": 583
          },
-         "id": 222,
+         "id": 224,
          "panels": [
             {
                "aliasColors": { },
@@ -29434,7 +29696,7 @@
                   "x": 0,
                   "y": 584
                },
-               "id": 223,
+               "id": 225,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29583,7 +29845,7 @@
                   "x": 8,
                   "y": 584
                },
-               "id": 224,
+               "id": 226,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29732,7 +29994,7 @@
                   "x": 16,
                   "y": 584
                },
-               "id": 225,
+               "id": 227,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29881,7 +30143,7 @@
                   "x": 0,
                   "y": 592
                },
-               "id": 226,
+               "id": 228,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -30024,7 +30286,7 @@
                   "x": 12,
                   "y": 592
                },
-               "id": 227,
+               "id": 229,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30131,7 +30393,7 @@
                   "x": 0,
                   "y": 600
                },
-               "id": 228,
+               "id": 230,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30280,7 +30542,7 @@
                   "x": 6,
                   "y": 600
                },
-               "id": 229,
+               "id": 231,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30429,7 +30691,7 @@
                   "x": 12,
                   "y": 600
                },
-               "id": 230,
+               "id": 232,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30578,7 +30840,7 @@
                   "x": 18,
                   "y": 600
                },
-               "id": 231,
+               "id": 233,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30727,7 +30989,7 @@
                   "x": 0,
                   "y": 608
                },
-               "id": 232,
+               "id": 234,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -30870,7 +31132,7 @@
                   "x": 12,
                   "y": 608
                },
-               "id": 233,
+               "id": 235,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30977,7 +31239,7 @@
                   "x": 0,
                   "y": 616
                },
-               "id": 234,
+               "id": 236,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31126,7 +31388,7 @@
                   "x": 8,
                   "y": 616
                },
-               "id": 235,
+               "id": 237,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31275,7 +31537,7 @@
                   "x": 16,
                   "y": 616
                },
-               "id": 236,
+               "id": 238,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31424,7 +31686,7 @@
                   "x": 0,
                   "y": 624
                },
-               "id": 237,
+               "id": 239,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -31567,7 +31829,7 @@
                   "x": 12,
                   "y": 624
                },
-               "id": 238,
+               "id": 240,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
+++ b/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
@@ -5651,15 +5651,146 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 3,
-               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "description": "Amount of memory in bytes currently used to store tuples (data).\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 127
                },
                "id": 48,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_memory_tuple_cache"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Tuples cache memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 3,
+               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 127
+               },
+               "id": 49,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5786,11 +5917,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 127
                },
-               "id": 49,
+               "id": 50,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5921,7 +6052,7 @@
                   "x": 0,
                   "y": 135
                },
-               "id": 50,
+               "id": 51,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6052,7 +6183,7 @@
                   "x": 8,
                   "y": 135
                },
-               "id": 51,
+               "id": 52,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6183,7 +6314,7 @@
                   "x": 16,
                   "y": 135
                },
-               "id": 52,
+               "id": 53,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6306,15 +6437,146 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 3,
+               "description": "«Level 0» (L0) memory area in bytes. L0 is the area that\nvinyl can use for in-memory storage of an LSM tree.\nBy monitoring this metric, you can see when L0 is getting\nclose to its maximum (tnt_vinyl_regulator_dump_watermark),\nat which time a dump will occur. You can expect L0 = 0\nimmediately after the dump operation is completed.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 143
+               },
+               "id": 54,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "${INFLUXDB_MEASUREMENT}",
+                     "policy": "${INFLUXDB_POLICY}",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_memory_level0"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Level 0 memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_INFLUXDB}",
+               "decimals": 3,
                "description": "The maximum amount of memory used for in-memory storing of a vinyl LSM tree.\nWhen accessing this maximum, the dumping must occur.\nFor details, see https://www.tarantool.io/en/doc/latest/book/box/engines/#engines-algorithm-filling-lsm.\nThe value is slightly smaller than the amount of memory allocated for vinyl trees,\nwhich is the `vinyl_memory` parameter.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 0,
+                  "w": 8,
+                  "x": 8,
                   "y": 143
                },
-               "id": 53,
+               "id": 55,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6441,11 +6703,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 143
                },
-               "id": 54,
+               "id": 56,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6576,7 +6838,7 @@
                   "x": 0,
                   "y": 151
                },
-               "id": 55,
+               "id": 57,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6713,7 +6975,7 @@
                   "x": 6,
                   "y": 151
                },
-               "id": 56,
+               "id": 58,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6850,7 +7112,7 @@
                   "x": 12,
                   "y": 151
                },
-               "id": 57,
+               "id": 59,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6987,7 +7249,7 @@
                   "x": 18,
                   "y": 151
                },
-               "id": 58,
+               "id": 60,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7118,7 +7380,7 @@
                   "x": 0,
                   "y": 159
                },
-               "id": 59,
+               "id": 61,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -7255,7 +7517,7 @@
                   "x": 6,
                   "y": 159
                },
-               "id": 60,
+               "id": 62,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -7398,7 +7660,7 @@
                   "x": 12,
                   "y": 159
                },
-               "id": 61,
+               "id": 63,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7535,7 +7797,7 @@
                   "x": 18,
                   "y": 159
                },
-               "id": 62,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7675,7 +7937,7 @@
             "x": 0,
             "y": 167
          },
-         "id": 63,
+         "id": 65,
          "panels": [
             {
                "aliasColors": { },
@@ -7692,7 +7954,7 @@
                   "x": 0,
                   "y": 168
                },
-               "id": 64,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7829,7 +8091,7 @@
                   "x": 12,
                   "y": 168
                },
-               "id": 65,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7969,7 +8231,7 @@
             "x": 0,
             "y": 176
          },
-         "id": 66,
+         "id": 68,
          "panels": [
             {
                "aliasColors": { },
@@ -7986,7 +8248,7 @@
                   "x": 0,
                   "y": 177
                },
-               "id": 67,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8117,7 +8379,7 @@
                   "x": 8,
                   "y": 177
                },
-               "id": 68,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -8248,7 +8510,7 @@
                   "x": 16,
                   "y": 177
                },
-               "id": 69,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8379,7 +8641,7 @@
                   "x": 0,
                   "y": 185
                },
-               "id": 70,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8510,7 +8772,7 @@
                   "x": 12,
                   "y": 185
                },
-               "id": 71,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8641,7 +8903,7 @@
                   "x": 0,
                   "y": 193
                },
-               "id": 72,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -8772,7 +9034,7 @@
                   "x": 8,
                   "y": 193
                },
-               "id": 73,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8903,7 +9165,7 @@
                   "x": 16,
                   "y": 193
                },
-               "id": 74,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9037,7 +9299,7 @@
             "x": 0,
             "y": 201
          },
-         "id": 75,
+         "id": 77,
          "panels": [
             {
                "aliasColors": { },
@@ -9054,7 +9316,7 @@
                   "x": 0,
                   "y": 202
                },
-               "id": 76,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9191,7 +9453,7 @@
                   "x": 6,
                   "y": 202
                },
-               "id": 77,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9328,7 +9590,7 @@
                   "x": 12,
                   "y": 202
                },
-               "id": 78,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9465,7 +9727,7 @@
                   "x": 18,
                   "y": 202
                },
-               "id": 79,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9596,7 +9858,7 @@
                   "x": 0,
                   "y": 210
                },
-               "id": 80,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9733,7 +9995,7 @@
                   "x": 12,
                   "y": 210
                },
-               "id": 81,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9870,7 +10132,7 @@
                   "x": 0,
                   "y": 218
                },
-               "id": 82,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10007,7 +10269,7 @@
                   "x": 8,
                   "y": 218
                },
-               "id": 83,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10144,7 +10406,7 @@
                   "x": 16,
                   "y": 218
                },
-               "id": 84,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10281,7 +10543,7 @@
                   "x": 0,
                   "y": 226
                },
-               "id": 85,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10418,7 +10680,7 @@
                   "x": 8,
                   "y": 226
                },
-               "id": 86,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10555,7 +10817,7 @@
                   "x": 16,
                   "y": 226
                },
-               "id": 87,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10692,7 +10954,7 @@
                   "x": 0,
                   "y": 234
                },
-               "id": 88,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10823,7 +11085,7 @@
                   "x": 6,
                   "y": 234
                },
-               "id": 89,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10954,7 +11216,7 @@
                   "x": 12,
                   "y": 234
                },
-               "id": 90,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11085,7 +11347,7 @@
                   "x": 18,
                   "y": 234
                },
-               "id": 91,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11216,7 +11478,7 @@
                   "x": 0,
                   "y": 242
                },
-               "id": 92,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11347,7 +11609,7 @@
                   "x": 8,
                   "y": 242
                },
-               "id": 93,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11484,7 +11746,7 @@
                   "x": 16,
                   "y": 242
                },
-               "id": 94,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11624,7 +11886,7 @@
             "x": 0,
             "y": 250
          },
-         "id": 95,
+         "id": 97,
          "panels": [
             {
                "aliasColors": { },
@@ -11641,7 +11903,7 @@
                   "x": 0,
                   "y": 251
                },
-               "id": 96,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11784,7 +12046,7 @@
                   "x": 8,
                   "y": 251
                },
-               "id": 97,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11927,7 +12189,7 @@
                   "x": 16,
                   "y": 251
                },
-               "id": 98,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12070,7 +12332,7 @@
                   "x": 0,
                   "y": 259
                },
-               "id": 99,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12213,7 +12475,7 @@
                   "x": 8,
                   "y": 259
                },
-               "id": 100,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12356,7 +12618,7 @@
                   "x": 16,
                   "y": 259
                },
-               "id": 101,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12499,7 +12761,7 @@
                   "x": 0,
                   "y": 267
                },
-               "id": 102,
+               "id": 104,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12642,7 +12904,7 @@
                   "x": 8,
                   "y": 267
                },
-               "id": 103,
+               "id": 105,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12785,7 +13047,7 @@
                   "x": 16,
                   "y": 267
                },
-               "id": 104,
+               "id": 106,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12928,7 +13190,7 @@
                   "x": 0,
                   "y": 275
                },
-               "id": 105,
+               "id": 107,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13071,7 +13333,7 @@
                   "x": 8,
                   "y": 275
                },
-               "id": 106,
+               "id": 108,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13214,7 +13476,7 @@
                   "x": 16,
                   "y": 275
                },
-               "id": 107,
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13360,7 +13622,7 @@
             "x": 0,
             "y": 283
          },
-         "id": 108,
+         "id": 110,
          "panels": [
             {
                "aliasColors": { },
@@ -13377,7 +13639,7 @@
                   "x": 0,
                   "y": 284
                },
-               "id": 109,
+               "id": 111,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13532,7 +13794,7 @@
                   "x": 6,
                   "y": 284
                },
-               "id": 110,
+               "id": 112,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13687,7 +13949,7 @@
                   "x": 12,
                   "y": 284
                },
-               "id": 111,
+               "id": 113,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13842,7 +14104,7 @@
                   "x": 18,
                   "y": 284
                },
-               "id": 112,
+               "id": 114,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13997,7 +14259,7 @@
                   "x": 0,
                   "y": 292
                },
-               "id": 113,
+               "id": 115,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14104,7 +14366,7 @@
                   "x": 8,
                   "y": 292
                },
-               "id": 114,
+               "id": 116,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14211,7 +14473,7 @@
                   "x": 16,
                   "y": 292
                },
-               "id": 115,
+               "id": 117,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14360,7 +14622,7 @@
                   "x": 0,
                   "y": 300
                },
-               "id": 116,
+               "id": 118,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14515,7 +14777,7 @@
                   "x": 6,
                   "y": 300
                },
-               "id": 117,
+               "id": 119,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14670,7 +14932,7 @@
                   "x": 12,
                   "y": 300
                },
-               "id": 118,
+               "id": 120,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14825,7 +15087,7 @@
                   "x": 18,
                   "y": 300
                },
-               "id": 119,
+               "id": 121,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14980,7 +15242,7 @@
                   "x": 0,
                   "y": 308
                },
-               "id": 120,
+               "id": 122,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15135,7 +15397,7 @@
                   "x": 6,
                   "y": 308
                },
-               "id": 121,
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15290,7 +15552,7 @@
                   "x": 12,
                   "y": 308
                },
-               "id": 122,
+               "id": 124,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15445,7 +15707,7 @@
                   "x": 18,
                   "y": 308
                },
-               "id": 123,
+               "id": 125,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15600,7 +15862,7 @@
                   "x": 0,
                   "y": 316
                },
-               "id": 124,
+               "id": 126,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15755,7 +16017,7 @@
                   "x": 6,
                   "y": 316
                },
-               "id": 125,
+               "id": 127,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15910,7 +16172,7 @@
                   "x": 12,
                   "y": 316
                },
-               "id": 126,
+               "id": 128,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16065,7 +16327,7 @@
                   "x": 18,
                   "y": 316
                },
-               "id": 127,
+               "id": 129,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16220,7 +16482,7 @@
                   "x": 0,
                   "y": 324
                },
-               "id": 128,
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16375,7 +16637,7 @@
                   "x": 6,
                   "y": 324
                },
-               "id": 129,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16530,7 +16792,7 @@
                   "x": 12,
                   "y": 324
                },
-               "id": 130,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16685,7 +16947,7 @@
                   "x": 18,
                   "y": 324
                },
-               "id": 131,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16840,7 +17102,7 @@
                   "x": 0,
                   "y": 332
                },
-               "id": 132,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16995,7 +17257,7 @@
                   "x": 6,
                   "y": 332
                },
-               "id": 133,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17150,7 +17412,7 @@
                   "x": 12,
                   "y": 332
                },
-               "id": 134,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17305,7 +17567,7 @@
                   "x": 18,
                   "y": 332
                },
-               "id": 135,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17460,7 +17722,7 @@
                   "x": 0,
                   "y": 340
                },
-               "id": 136,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17615,7 +17877,7 @@
                   "x": 6,
                   "y": 340
                },
-               "id": 137,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17770,7 +18032,7 @@
                   "x": 12,
                   "y": 340
                },
-               "id": 138,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17925,7 +18187,7 @@
                   "x": 18,
                   "y": 340
                },
-               "id": 139,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18080,7 +18342,7 @@
                   "x": 0,
                   "y": 348
                },
-               "id": 140,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18235,7 +18497,7 @@
                   "x": 6,
                   "y": 348
                },
-               "id": 141,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18390,7 +18652,7 @@
                   "x": 12,
                   "y": 348
                },
-               "id": 142,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18545,7 +18807,7 @@
                   "x": 18,
                   "y": 348
                },
-               "id": 143,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18700,7 +18962,7 @@
                   "x": 0,
                   "y": 356
                },
-               "id": 144,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18855,7 +19117,7 @@
                   "x": 6,
                   "y": 356
                },
-               "id": 145,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19010,7 +19272,7 @@
                   "x": 12,
                   "y": 356
                },
-               "id": 146,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19165,7 +19427,7 @@
                   "x": 18,
                   "y": 356
                },
-               "id": 147,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19320,7 +19582,7 @@
                   "x": 0,
                   "y": 364
                },
-               "id": 148,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19475,7 +19737,7 @@
                   "x": 6,
                   "y": 364
                },
-               "id": 149,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19630,7 +19892,7 @@
                   "x": 12,
                   "y": 364
                },
-               "id": 150,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19785,7 +20047,7 @@
                   "x": 18,
                   "y": 364
                },
-               "id": 151,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19940,7 +20202,7 @@
                   "x": 0,
                   "y": 372
                },
-               "id": 152,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20095,7 +20357,7 @@
                   "x": 6,
                   "y": 372
                },
-               "id": 153,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20250,7 +20512,7 @@
                   "x": 12,
                   "y": 372
                },
-               "id": 154,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20405,7 +20667,7 @@
                   "x": 18,
                   "y": 372
                },
-               "id": 155,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20560,7 +20822,7 @@
                   "x": 0,
                   "y": 380
                },
-               "id": 156,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20715,7 +20977,7 @@
                   "x": 6,
                   "y": 380
                },
-               "id": 157,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20870,7 +21132,7 @@
                   "x": 12,
                   "y": 380
                },
-               "id": 158,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21025,7 +21287,7 @@
                   "x": 18,
                   "y": 380
                },
-               "id": 159,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21180,7 +21442,7 @@
                   "x": 0,
                   "y": 388
                },
-               "id": 160,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21335,7 +21597,7 @@
                   "x": 6,
                   "y": 388
                },
-               "id": 161,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21490,7 +21752,7 @@
                   "x": 12,
                   "y": 388
                },
-               "id": 162,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21645,7 +21907,7 @@
                   "x": 18,
                   "y": 388
                },
-               "id": 163,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21800,7 +22062,7 @@
                   "x": 0,
                   "y": 396
                },
-               "id": 164,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21955,7 +22217,7 @@
                   "x": 6,
                   "y": 396
                },
-               "id": 165,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22110,7 +22372,7 @@
                   "x": 12,
                   "y": 396
                },
-               "id": 166,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22265,7 +22527,7 @@
                   "x": 18,
                   "y": 396
                },
-               "id": 167,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22423,7 +22685,7 @@
             "x": 0,
             "y": 404
          },
-         "id": 168,
+         "id": 170,
          "panels": [
             {
                "aliasColors": { },
@@ -22440,7 +22702,7 @@
                   "x": 0,
                   "y": 405
                },
-               "id": 169,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22583,7 +22845,7 @@
                   "x": 12,
                   "y": 405
                },
-               "id": 170,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22726,7 +22988,7 @@
                   "x": 0,
                   "y": 413
                },
-               "id": 171,
+               "id": 173,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22863,7 +23125,7 @@
                   "x": 12,
                   "y": 413
                },
-               "id": 172,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23003,7 +23265,7 @@
             "x": 0,
             "y": 421
          },
-         "id": 173,
+         "id": 175,
          "panels": [
             {
                "aliasColors": { },
@@ -23020,7 +23282,7 @@
                   "x": 0,
                   "y": 422
                },
-               "id": 174,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23151,7 +23413,7 @@
                   "x": 0,
                   "y": 428
                },
-               "id": 175,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23288,7 +23550,7 @@
                   "x": 12,
                   "y": 428
                },
-               "id": 176,
+               "id": 178,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
+++ b/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
@@ -5651,7 +5651,7 @@
                "dashes": false,
                "datasource": "${DS_INFLUXDB}",
                "decimals": 3,
-               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n",
+               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,

--- a/tests/Prometheus/dashboard_compiled.json
+++ b/tests/Prometheus/dashboard_compiled.json
@@ -4150,15 +4150,105 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 3,
-               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "description": "Amount of memory in bytes currently used to store tuples (data).\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 135
                },
                "id": 55,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_vinyl_memory_tuple_cache{job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Tuples cache memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 3,
+               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 135
+               },
+               "id": 56,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4244,11 +4334,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 135
                },
-               "id": 56,
+               "id": 57,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4338,7 +4428,7 @@
                   "x": 0,
                   "y": 143
                },
-               "id": 57,
+               "id": 58,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4428,7 +4518,7 @@
                   "x": 8,
                   "y": 143
                },
-               "id": 58,
+               "id": 59,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4518,7 +4608,7 @@
                   "x": 16,
                   "y": 143
                },
-               "id": 59,
+               "id": 60,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4600,15 +4690,105 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 3,
+               "description": "«Level 0» (L0) memory area in bytes. L0 is the area that\nvinyl can use for in-memory storage of an LSM tree.\nBy monitoring this metric, you can see when L0 is getting\nclose to its maximum (tnt_vinyl_regulator_dump_watermark),\nat which time a dump will occur. You can expect L0 = 0\nimmediately after the dump operation is completed.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 151
+               },
+               "id": 61,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_vinyl_memory_level0{job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Level 0 memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 3,
                "description": "The maximum amount of memory used for in-memory storing of a vinyl LSM tree.\nWhen accessing this maximum, the dumping must occur.\nFor details, see https://www.tarantool.io/en/doc/latest/book/box/engines/#engines-algorithm-filling-lsm.\nThe value is slightly smaller than the amount of memory allocated for vinyl trees,\nwhich is the `vinyl_memory` parameter.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 0,
+                  "w": 8,
+                  "x": 8,
                   "y": 151
                },
-               "id": 60,
+               "id": 62,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4694,11 +4874,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 151
                },
-               "id": 61,
+               "id": 63,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4788,7 +4968,7 @@
                   "x": 0,
                   "y": 159
                },
-               "id": 62,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4878,7 +5058,7 @@
                   "x": 6,
                   "y": 159
                },
-               "id": 63,
+               "id": 65,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4968,7 +5148,7 @@
                   "x": 12,
                   "y": 159
                },
-               "id": 64,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5058,7 +5238,7 @@
                   "x": 18,
                   "y": 159
                },
-               "id": 65,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5148,7 +5328,7 @@
                   "x": 0,
                   "y": 167
                },
-               "id": 66,
+               "id": 68,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5238,7 +5418,7 @@
                   "x": 6,
                   "y": 167
                },
-               "id": 67,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5328,7 +5508,7 @@
                   "x": 12,
                   "y": 167
                },
-               "id": 68,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5418,7 +5598,7 @@
                   "x": 18,
                   "y": 167
                },
-               "id": 69,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5511,7 +5691,7 @@
             "x": 0,
             "y": 175
          },
-         "id": 70,
+         "id": 72,
          "panels": [
             {
                "aliasColors": { },
@@ -5528,7 +5708,7 @@
                   "x": 0,
                   "y": 176
                },
-               "id": 71,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5618,7 +5798,7 @@
                   "x": 12,
                   "y": 176
                },
-               "id": 72,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5711,7 +5891,7 @@
             "x": 0,
             "y": 184
          },
-         "id": 73,
+         "id": 75,
          "panels": [
             {
                "aliasColors": { },
@@ -5728,7 +5908,7 @@
                   "x": 0,
                   "y": 185
                },
-               "id": 74,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5818,7 +5998,7 @@
                   "x": 8,
                   "y": 185
                },
-               "id": 75,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5908,7 +6088,7 @@
                   "x": 16,
                   "y": 185
                },
-               "id": 76,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5998,7 +6178,7 @@
                   "x": 0,
                   "y": 193
                },
-               "id": 77,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6088,7 +6268,7 @@
                   "x": 12,
                   "y": 193
                },
-               "id": 78,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6178,7 +6358,7 @@
                   "x": 0,
                   "y": 201
                },
-               "id": 79,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6268,7 +6448,7 @@
                   "x": 8,
                   "y": 201
                },
-               "id": 80,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6358,7 +6538,7 @@
                   "x": 16,
                   "y": 201
                },
-               "id": 81,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6451,7 +6631,7 @@
             "x": 0,
             "y": 209
          },
-         "id": 82,
+         "id": 84,
          "panels": [
             {
                "aliasColors": { },
@@ -6468,7 +6648,7 @@
                   "x": 0,
                   "y": 210
                },
-               "id": 83,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6558,7 +6738,7 @@
                   "x": 6,
                   "y": 210
                },
-               "id": 84,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6648,7 +6828,7 @@
                   "x": 12,
                   "y": 210
                },
-               "id": 85,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6738,7 +6918,7 @@
                   "x": 18,
                   "y": 210
                },
-               "id": 86,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6828,7 +7008,7 @@
                   "x": 0,
                   "y": 218
                },
-               "id": 87,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6918,7 +7098,7 @@
                   "x": 12,
                   "y": 218
                },
-               "id": 88,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7008,7 +7188,7 @@
                   "x": 0,
                   "y": 226
                },
-               "id": 89,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7098,7 +7278,7 @@
                   "x": 8,
                   "y": 226
                },
-               "id": 90,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7188,7 +7368,7 @@
                   "x": 16,
                   "y": 226
                },
-               "id": 91,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7278,7 +7458,7 @@
                   "x": 0,
                   "y": 234
                },
-               "id": 92,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7368,7 +7548,7 @@
                   "x": 8,
                   "y": 234
                },
-               "id": 93,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7458,7 +7638,7 @@
                   "x": 16,
                   "y": 234
                },
-               "id": 94,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7548,7 +7728,7 @@
                   "x": 0,
                   "y": 242
                },
-               "id": 95,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7638,7 +7818,7 @@
                   "x": 6,
                   "y": 242
                },
-               "id": 96,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7728,7 +7908,7 @@
                   "x": 12,
                   "y": 242
                },
-               "id": 97,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7818,7 +7998,7 @@
                   "x": 18,
                   "y": 242
                },
-               "id": 98,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7908,7 +8088,7 @@
                   "x": 0,
                   "y": 250
                },
-               "id": 99,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7998,7 +8178,7 @@
                   "x": 8,
                   "y": 250
                },
-               "id": 100,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8088,7 +8268,7 @@
                   "x": 16,
                   "y": 250
                },
-               "id": 101,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8181,7 +8361,7 @@
             "x": 0,
             "y": 258
          },
-         "id": 102,
+         "id": 104,
          "panels": [
             {
                "aliasColors": { },
@@ -8198,7 +8378,7 @@
                   "x": 0,
                   "y": 259
                },
-               "id": 103,
+               "id": 105,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8288,7 +8468,7 @@
                   "x": 8,
                   "y": 259
                },
-               "id": 104,
+               "id": 106,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8378,7 +8558,7 @@
                   "x": 16,
                   "y": 259
                },
-               "id": 105,
+               "id": 107,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8468,7 +8648,7 @@
                   "x": 0,
                   "y": 267
                },
-               "id": 106,
+               "id": 108,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8558,7 +8738,7 @@
                   "x": 8,
                   "y": 267
                },
-               "id": 107,
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8648,7 +8828,7 @@
                   "x": 16,
                   "y": 267
                },
-               "id": 108,
+               "id": 110,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8738,7 +8918,7 @@
                   "x": 0,
                   "y": 275
                },
-               "id": 109,
+               "id": 111,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8828,7 +9008,7 @@
                   "x": 8,
                   "y": 275
                },
-               "id": 110,
+               "id": 112,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8918,7 +9098,7 @@
                   "x": 16,
                   "y": 275
                },
-               "id": 111,
+               "id": 113,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9008,7 +9188,7 @@
                   "x": 0,
                   "y": 283
                },
-               "id": 112,
+               "id": 114,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9098,7 +9278,7 @@
                   "x": 8,
                   "y": 283
                },
-               "id": 113,
+               "id": 115,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9188,7 +9368,7 @@
                   "x": 16,
                   "y": 283
                },
-               "id": 114,
+               "id": 116,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9281,7 +9461,7 @@
             "x": 0,
             "y": 291
          },
-         "id": 115,
+         "id": 117,
          "panels": [
             {
                "aliasColors": { },
@@ -9298,7 +9478,7 @@
                   "x": 0,
                   "y": 292
                },
-               "id": 116,
+               "id": 118,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9388,7 +9568,7 @@
                   "x": 6,
                   "y": 292
                },
-               "id": 117,
+               "id": 119,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9478,7 +9658,7 @@
                   "x": 12,
                   "y": 292
                },
-               "id": 118,
+               "id": 120,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9568,7 +9748,7 @@
                   "x": 18,
                   "y": 292
                },
-               "id": 119,
+               "id": 121,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9658,7 +9838,7 @@
                   "x": 0,
                   "y": 300
                },
-               "id": 120,
+               "id": 122,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9748,7 +9928,7 @@
                   "x": 8,
                   "y": 300
                },
-               "id": 121,
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9838,7 +10018,7 @@
                   "x": 16,
                   "y": 300
                },
-               "id": 122,
+               "id": 124,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9928,7 +10108,7 @@
                   "x": 0,
                   "y": 308
                },
-               "id": 123,
+               "id": 125,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10018,7 +10198,7 @@
                   "x": 6,
                   "y": 308
                },
-               "id": 124,
+               "id": 126,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10108,7 +10288,7 @@
                   "x": 12,
                   "y": 308
                },
-               "id": 125,
+               "id": 127,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10198,7 +10378,7 @@
                   "x": 18,
                   "y": 308
                },
-               "id": 126,
+               "id": 128,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10288,7 +10468,7 @@
                   "x": 0,
                   "y": 316
                },
-               "id": 127,
+               "id": 129,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10378,7 +10558,7 @@
                   "x": 6,
                   "y": 316
                },
-               "id": 128,
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10468,7 +10648,7 @@
                   "x": 12,
                   "y": 316
                },
-               "id": 129,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10558,7 +10738,7 @@
                   "x": 18,
                   "y": 316
                },
-               "id": 130,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10648,7 +10828,7 @@
                   "x": 0,
                   "y": 324
                },
-               "id": 131,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10738,7 +10918,7 @@
                   "x": 6,
                   "y": 324
                },
-               "id": 132,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10828,7 +11008,7 @@
                   "x": 12,
                   "y": 324
                },
-               "id": 133,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10918,7 +11098,7 @@
                   "x": 18,
                   "y": 324
                },
-               "id": 134,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11008,7 +11188,7 @@
                   "x": 0,
                   "y": 332
                },
-               "id": 135,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11098,7 +11278,7 @@
                   "x": 6,
                   "y": 332
                },
-               "id": 136,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11188,7 +11368,7 @@
                   "x": 12,
                   "y": 332
                },
-               "id": 137,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11278,7 +11458,7 @@
                   "x": 18,
                   "y": 332
                },
-               "id": 138,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11368,7 +11548,7 @@
                   "x": 0,
                   "y": 340
                },
-               "id": 139,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11458,7 +11638,7 @@
                   "x": 6,
                   "y": 340
                },
-               "id": 140,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11548,7 +11728,7 @@
                   "x": 12,
                   "y": 340
                },
-               "id": 141,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11638,7 +11818,7 @@
                   "x": 18,
                   "y": 340
                },
-               "id": 142,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11728,7 +11908,7 @@
                   "x": 0,
                   "y": 348
                },
-               "id": 143,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11818,7 +11998,7 @@
                   "x": 6,
                   "y": 348
                },
-               "id": 144,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11908,7 +12088,7 @@
                   "x": 12,
                   "y": 348
                },
-               "id": 145,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11998,7 +12178,7 @@
                   "x": 18,
                   "y": 348
                },
-               "id": 146,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12088,7 +12268,7 @@
                   "x": 0,
                   "y": 356
                },
-               "id": 147,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12178,7 +12358,7 @@
                   "x": 6,
                   "y": 356
                },
-               "id": 148,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12268,7 +12448,7 @@
                   "x": 12,
                   "y": 356
                },
-               "id": 149,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12358,7 +12538,7 @@
                   "x": 18,
                   "y": 356
                },
-               "id": 150,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12448,7 +12628,7 @@
                   "x": 0,
                   "y": 364
                },
-               "id": 151,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12538,7 +12718,7 @@
                   "x": 6,
                   "y": 364
                },
-               "id": 152,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12628,7 +12808,7 @@
                   "x": 12,
                   "y": 364
                },
-               "id": 153,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12718,7 +12898,7 @@
                   "x": 18,
                   "y": 364
                },
-               "id": 154,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12808,7 +12988,7 @@
                   "x": 0,
                   "y": 372
                },
-               "id": 155,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12898,7 +13078,7 @@
                   "x": 6,
                   "y": 372
                },
-               "id": 156,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12988,7 +13168,7 @@
                   "x": 12,
                   "y": 372
                },
-               "id": 157,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13078,7 +13258,7 @@
                   "x": 18,
                   "y": 372
                },
-               "id": 158,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13168,7 +13348,7 @@
                   "x": 0,
                   "y": 380
                },
-               "id": 159,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13258,7 +13438,7 @@
                   "x": 6,
                   "y": 380
                },
-               "id": 160,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13348,7 +13528,7 @@
                   "x": 12,
                   "y": 380
                },
-               "id": 161,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13438,7 +13618,7 @@
                   "x": 18,
                   "y": 380
                },
-               "id": 162,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13528,7 +13708,7 @@
                   "x": 0,
                   "y": 388
                },
-               "id": 163,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13618,7 +13798,7 @@
                   "x": 6,
                   "y": 388
                },
-               "id": 164,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13708,7 +13888,7 @@
                   "x": 12,
                   "y": 388
                },
-               "id": 165,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13798,7 +13978,7 @@
                   "x": 18,
                   "y": 388
                },
-               "id": 166,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13888,7 +14068,7 @@
                   "x": 0,
                   "y": 396
                },
-               "id": 167,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13978,7 +14158,7 @@
                   "x": 6,
                   "y": 396
                },
-               "id": 168,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14068,7 +14248,7 @@
                   "x": 12,
                   "y": 396
                },
-               "id": 169,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14158,7 +14338,7 @@
                   "x": 18,
                   "y": 396
                },
-               "id": 170,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14248,7 +14428,7 @@
                   "x": 0,
                   "y": 404
                },
-               "id": 171,
+               "id": 173,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14338,7 +14518,7 @@
                   "x": 6,
                   "y": 404
                },
-               "id": 172,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14428,7 +14608,7 @@
                   "x": 12,
                   "y": 404
                },
-               "id": 173,
+               "id": 175,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14518,7 +14698,7 @@
                   "x": 18,
                   "y": 404
                },
-               "id": 174,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14611,7 +14791,7 @@
             "x": 0,
             "y": 412
          },
-         "id": 175,
+         "id": 177,
          "panels": [
             {
                "aliasColors": { },
@@ -14628,7 +14808,7 @@
                   "x": 0,
                   "y": 413
                },
-               "id": 176,
+               "id": 178,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14718,7 +14898,7 @@
                   "x": 12,
                   "y": 413
                },
-               "id": 177,
+               "id": 179,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14808,7 +14988,7 @@
                   "x": 0,
                   "y": 421
                },
-               "id": 178,
+               "id": 180,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14898,7 +15078,7 @@
                   "x": 12,
                   "y": 421
                },
-               "id": 179,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_compiled.json
+++ b/tests/Prometheus/dashboard_compiled.json
@@ -4150,7 +4150,7 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 3,
-               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n",
+               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,

--- a/tests/Prometheus/dashboard_static_compiled.json
+++ b/tests/Prometheus/dashboard_static_compiled.json
@@ -4134,15 +4134,105 @@
                "dashes": false,
                "datasource": "Prometheus",
                "decimals": 3,
-               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "description": "Amount of memory in bytes currently used to store tuples (data).\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 135
                },
                "id": 55,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_vinyl_memory_tuple_cache{job=~\"tarantool\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Tuples cache memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 135
+               },
+               "id": 56,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4228,11 +4318,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 135
                },
-               "id": 56,
+               "id": 57,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4322,7 +4412,7 @@
                   "x": 0,
                   "y": 143
                },
-               "id": 57,
+               "id": 58,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4412,7 +4502,7 @@
                   "x": 8,
                   "y": 143
                },
-               "id": 58,
+               "id": 59,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4502,7 +4592,7 @@
                   "x": 16,
                   "y": 143
                },
-               "id": 59,
+               "id": 60,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4584,15 +4674,105 @@
                "dashes": false,
                "datasource": "Prometheus",
                "decimals": 3,
+               "description": "«Level 0» (L0) memory area in bytes. L0 is the area that\nvinyl can use for in-memory storage of an LSM tree.\nBy monitoring this metric, you can see when L0 is getting\nclose to its maximum (tnt_vinyl_regulator_dump_watermark),\nat which time a dump will occur. You can expect L0 = 0\nimmediately after the dump operation is completed.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 151
+               },
+               "id": 61,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_vinyl_memory_level0{job=~\"tarantool\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Level 0 memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
                "description": "The maximum amount of memory used for in-memory storing of a vinyl LSM tree.\nWhen accessing this maximum, the dumping must occur.\nFor details, see https://www.tarantool.io/en/doc/latest/book/box/engines/#engines-algorithm-filling-lsm.\nThe value is slightly smaller than the amount of memory allocated for vinyl trees,\nwhich is the `vinyl_memory` parameter.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 0,
+                  "w": 8,
+                  "x": 8,
                   "y": 151
                },
-               "id": 60,
+               "id": 62,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4678,11 +4858,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 151
                },
-               "id": 61,
+               "id": 63,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4772,7 +4952,7 @@
                   "x": 0,
                   "y": 159
                },
-               "id": 62,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4862,7 +5042,7 @@
                   "x": 6,
                   "y": 159
                },
-               "id": 63,
+               "id": 65,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4952,7 +5132,7 @@
                   "x": 12,
                   "y": 159
                },
-               "id": 64,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5042,7 +5222,7 @@
                   "x": 18,
                   "y": 159
                },
-               "id": 65,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5132,7 +5312,7 @@
                   "x": 0,
                   "y": 167
                },
-               "id": 66,
+               "id": 68,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5222,7 +5402,7 @@
                   "x": 6,
                   "y": 167
                },
-               "id": 67,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5312,7 +5492,7 @@
                   "x": 12,
                   "y": 167
                },
-               "id": 68,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5402,7 +5582,7 @@
                   "x": 18,
                   "y": 167
                },
-               "id": 69,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5495,7 +5675,7 @@
             "x": 0,
             "y": 175
          },
-         "id": 70,
+         "id": 72,
          "panels": [
             {
                "aliasColors": { },
@@ -5512,7 +5692,7 @@
                   "x": 0,
                   "y": 176
                },
-               "id": 71,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5602,7 +5782,7 @@
                   "x": 12,
                   "y": 176
                },
-               "id": 72,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5695,7 +5875,7 @@
             "x": 0,
             "y": 184
          },
-         "id": 73,
+         "id": 75,
          "panels": [
             {
                "aliasColors": { },
@@ -5712,7 +5892,7 @@
                   "x": 0,
                   "y": 185
                },
-               "id": 74,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5802,7 +5982,7 @@
                   "x": 8,
                   "y": 185
                },
-               "id": 75,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5892,7 +6072,7 @@
                   "x": 16,
                   "y": 185
                },
-               "id": 76,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5982,7 +6162,7 @@
                   "x": 0,
                   "y": 193
                },
-               "id": 77,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6072,7 +6252,7 @@
                   "x": 12,
                   "y": 193
                },
-               "id": 78,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6162,7 +6342,7 @@
                   "x": 0,
                   "y": 201
                },
-               "id": 79,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6252,7 +6432,7 @@
                   "x": 8,
                   "y": 201
                },
-               "id": 80,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6342,7 +6522,7 @@
                   "x": 16,
                   "y": 201
                },
-               "id": 81,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6435,7 +6615,7 @@
             "x": 0,
             "y": 209
          },
-         "id": 82,
+         "id": 84,
          "panels": [
             {
                "aliasColors": { },
@@ -6452,7 +6632,7 @@
                   "x": 0,
                   "y": 210
                },
-               "id": 83,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6542,7 +6722,7 @@
                   "x": 6,
                   "y": 210
                },
-               "id": 84,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6632,7 +6812,7 @@
                   "x": 12,
                   "y": 210
                },
-               "id": 85,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6722,7 +6902,7 @@
                   "x": 18,
                   "y": 210
                },
-               "id": 86,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6812,7 +6992,7 @@
                   "x": 0,
                   "y": 218
                },
-               "id": 87,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6902,7 +7082,7 @@
                   "x": 12,
                   "y": 218
                },
-               "id": 88,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6992,7 +7172,7 @@
                   "x": 0,
                   "y": 226
                },
-               "id": 89,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7082,7 +7262,7 @@
                   "x": 8,
                   "y": 226
                },
-               "id": 90,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7172,7 +7352,7 @@
                   "x": 16,
                   "y": 226
                },
-               "id": 91,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7262,7 +7442,7 @@
                   "x": 0,
                   "y": 234
                },
-               "id": 92,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7352,7 +7532,7 @@
                   "x": 8,
                   "y": 234
                },
-               "id": 93,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7442,7 +7622,7 @@
                   "x": 16,
                   "y": 234
                },
-               "id": 94,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7532,7 +7712,7 @@
                   "x": 0,
                   "y": 242
                },
-               "id": 95,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7622,7 +7802,7 @@
                   "x": 6,
                   "y": 242
                },
-               "id": 96,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7712,7 +7892,7 @@
                   "x": 12,
                   "y": 242
                },
-               "id": 97,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7802,7 +7982,7 @@
                   "x": 18,
                   "y": 242
                },
-               "id": 98,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7892,7 +8072,7 @@
                   "x": 0,
                   "y": 250
                },
-               "id": 99,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7982,7 +8162,7 @@
                   "x": 8,
                   "y": 250
                },
-               "id": 100,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8072,7 +8252,7 @@
                   "x": 16,
                   "y": 250
                },
-               "id": 101,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8165,7 +8345,7 @@
             "x": 0,
             "y": 258
          },
-         "id": 102,
+         "id": 104,
          "panels": [
             {
                "aliasColors": { },
@@ -8182,7 +8362,7 @@
                   "x": 0,
                   "y": 259
                },
-               "id": 103,
+               "id": 105,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8272,7 +8452,7 @@
                   "x": 8,
                   "y": 259
                },
-               "id": 104,
+               "id": 106,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8362,7 +8542,7 @@
                   "x": 16,
                   "y": 259
                },
-               "id": 105,
+               "id": 107,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8452,7 +8632,7 @@
                   "x": 0,
                   "y": 267
                },
-               "id": 106,
+               "id": 108,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8542,7 +8722,7 @@
                   "x": 8,
                   "y": 267
                },
-               "id": 107,
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8632,7 +8812,7 @@
                   "x": 16,
                   "y": 267
                },
-               "id": 108,
+               "id": 110,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8722,7 +8902,7 @@
                   "x": 0,
                   "y": 275
                },
-               "id": 109,
+               "id": 111,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8812,7 +8992,7 @@
                   "x": 8,
                   "y": 275
                },
-               "id": 110,
+               "id": 112,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8902,7 +9082,7 @@
                   "x": 16,
                   "y": 275
                },
-               "id": 111,
+               "id": 113,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8992,7 +9172,7 @@
                   "x": 0,
                   "y": 283
                },
-               "id": 112,
+               "id": 114,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9082,7 +9262,7 @@
                   "x": 8,
                   "y": 283
                },
-               "id": 113,
+               "id": 115,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9172,7 +9352,7 @@
                   "x": 16,
                   "y": 283
                },
-               "id": 114,
+               "id": 116,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9265,7 +9445,7 @@
             "x": 0,
             "y": 291
          },
-         "id": 115,
+         "id": 117,
          "panels": [
             {
                "aliasColors": { },
@@ -9282,7 +9462,7 @@
                   "x": 0,
                   "y": 292
                },
-               "id": 116,
+               "id": 118,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9372,7 +9552,7 @@
                   "x": 6,
                   "y": 292
                },
-               "id": 117,
+               "id": 119,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9462,7 +9642,7 @@
                   "x": 12,
                   "y": 292
                },
-               "id": 118,
+               "id": 120,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9552,7 +9732,7 @@
                   "x": 18,
                   "y": 292
                },
-               "id": 119,
+               "id": 121,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9642,7 +9822,7 @@
                   "x": 0,
                   "y": 300
                },
-               "id": 120,
+               "id": 122,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9732,7 +9912,7 @@
                   "x": 8,
                   "y": 300
                },
-               "id": 121,
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9822,7 +10002,7 @@
                   "x": 16,
                   "y": 300
                },
-               "id": 122,
+               "id": 124,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9912,7 +10092,7 @@
                   "x": 0,
                   "y": 308
                },
-               "id": 123,
+               "id": 125,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10002,7 +10182,7 @@
                   "x": 6,
                   "y": 308
                },
-               "id": 124,
+               "id": 126,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10092,7 +10272,7 @@
                   "x": 12,
                   "y": 308
                },
-               "id": 125,
+               "id": 127,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10182,7 +10362,7 @@
                   "x": 18,
                   "y": 308
                },
-               "id": 126,
+               "id": 128,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10272,7 +10452,7 @@
                   "x": 0,
                   "y": 316
                },
-               "id": 127,
+               "id": 129,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10362,7 +10542,7 @@
                   "x": 6,
                   "y": 316
                },
-               "id": 128,
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10452,7 +10632,7 @@
                   "x": 12,
                   "y": 316
                },
-               "id": 129,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10542,7 +10722,7 @@
                   "x": 18,
                   "y": 316
                },
-               "id": 130,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10632,7 +10812,7 @@
                   "x": 0,
                   "y": 324
                },
-               "id": 131,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10722,7 +10902,7 @@
                   "x": 6,
                   "y": 324
                },
-               "id": 132,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10812,7 +10992,7 @@
                   "x": 12,
                   "y": 324
                },
-               "id": 133,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10902,7 +11082,7 @@
                   "x": 18,
                   "y": 324
                },
-               "id": 134,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10992,7 +11172,7 @@
                   "x": 0,
                   "y": 332
                },
-               "id": 135,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11082,7 +11262,7 @@
                   "x": 6,
                   "y": 332
                },
-               "id": 136,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11172,7 +11352,7 @@
                   "x": 12,
                   "y": 332
                },
-               "id": 137,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11262,7 +11442,7 @@
                   "x": 18,
                   "y": 332
                },
-               "id": 138,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11352,7 +11532,7 @@
                   "x": 0,
                   "y": 340
                },
-               "id": 139,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11442,7 +11622,7 @@
                   "x": 6,
                   "y": 340
                },
-               "id": 140,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11532,7 +11712,7 @@
                   "x": 12,
                   "y": 340
                },
-               "id": 141,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11622,7 +11802,7 @@
                   "x": 18,
                   "y": 340
                },
-               "id": 142,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11712,7 +11892,7 @@
                   "x": 0,
                   "y": 348
                },
-               "id": 143,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11802,7 +11982,7 @@
                   "x": 6,
                   "y": 348
                },
-               "id": 144,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11892,7 +12072,7 @@
                   "x": 12,
                   "y": 348
                },
-               "id": 145,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11982,7 +12162,7 @@
                   "x": 18,
                   "y": 348
                },
-               "id": 146,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12072,7 +12252,7 @@
                   "x": 0,
                   "y": 356
                },
-               "id": 147,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12162,7 +12342,7 @@
                   "x": 6,
                   "y": 356
                },
-               "id": 148,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12252,7 +12432,7 @@
                   "x": 12,
                   "y": 356
                },
-               "id": 149,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12342,7 +12522,7 @@
                   "x": 18,
                   "y": 356
                },
-               "id": 150,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12432,7 +12612,7 @@
                   "x": 0,
                   "y": 364
                },
-               "id": 151,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12522,7 +12702,7 @@
                   "x": 6,
                   "y": 364
                },
-               "id": 152,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12612,7 +12792,7 @@
                   "x": 12,
                   "y": 364
                },
-               "id": 153,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12702,7 +12882,7 @@
                   "x": 18,
                   "y": 364
                },
-               "id": 154,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12792,7 +12972,7 @@
                   "x": 0,
                   "y": 372
                },
-               "id": 155,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12882,7 +13062,7 @@
                   "x": 6,
                   "y": 372
                },
-               "id": 156,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12972,7 +13152,7 @@
                   "x": 12,
                   "y": 372
                },
-               "id": 157,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13062,7 +13242,7 @@
                   "x": 18,
                   "y": 372
                },
-               "id": 158,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13152,7 +13332,7 @@
                   "x": 0,
                   "y": 380
                },
-               "id": 159,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13242,7 +13422,7 @@
                   "x": 6,
                   "y": 380
                },
-               "id": 160,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13332,7 +13512,7 @@
                   "x": 12,
                   "y": 380
                },
-               "id": 161,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13422,7 +13602,7 @@
                   "x": 18,
                   "y": 380
                },
-               "id": 162,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13512,7 +13692,7 @@
                   "x": 0,
                   "y": 388
                },
-               "id": 163,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13602,7 +13782,7 @@
                   "x": 6,
                   "y": 388
                },
-               "id": 164,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13692,7 +13872,7 @@
                   "x": 12,
                   "y": 388
                },
-               "id": 165,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13782,7 +13962,7 @@
                   "x": 18,
                   "y": 388
                },
-               "id": 166,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13872,7 +14052,7 @@
                   "x": 0,
                   "y": 396
                },
-               "id": 167,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13962,7 +14142,7 @@
                   "x": 6,
                   "y": 396
                },
-               "id": 168,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14052,7 +14232,7 @@
                   "x": 12,
                   "y": 396
                },
-               "id": 169,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14142,7 +14322,7 @@
                   "x": 18,
                   "y": 396
                },
-               "id": 170,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14232,7 +14412,7 @@
                   "x": 0,
                   "y": 404
                },
-               "id": 171,
+               "id": 173,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14322,7 +14502,7 @@
                   "x": 6,
                   "y": 404
                },
-               "id": 172,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14412,7 +14592,7 @@
                   "x": 12,
                   "y": 404
                },
-               "id": 173,
+               "id": 175,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14502,7 +14682,7 @@
                   "x": 18,
                   "y": 404
                },
-               "id": 174,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14595,7 +14775,7 @@
             "x": 0,
             "y": 412
          },
-         "id": 175,
+         "id": 177,
          "panels": [
             {
                "aliasColors": { },
@@ -14612,7 +14792,7 @@
                   "x": 0,
                   "y": 413
                },
-               "id": 176,
+               "id": 178,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14702,7 +14882,7 @@
                   "x": 12,
                   "y": 413
                },
-               "id": 177,
+               "id": 179,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14792,7 +14972,7 @@
                   "x": 0,
                   "y": 421
                },
-               "id": 178,
+               "id": 180,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14882,7 +15062,7 @@
                   "x": 12,
                   "y": 421
                },
-               "id": 179,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_static_compiled.json
+++ b/tests/Prometheus/dashboard_static_compiled.json
@@ -4134,7 +4134,7 @@
                "dashes": false,
                "datasource": "Prometheus",
                "decimals": 3,
-               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n",
+               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,

--- a/tests/Prometheus/dashboard_tdg_compiled.json
+++ b/tests/Prometheus/dashboard_tdg_compiled.json
@@ -3590,15 +3590,105 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 3,
-               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "description": "Amount of memory in bytes currently used to store tuples (data).\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 118
                },
                "id": 48,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_vinyl_memory_tuple_cache{job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Tuples cache memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 3,
+               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 118
+               },
+               "id": 49,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3684,11 +3774,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 118
                },
-               "id": 49,
+               "id": 50,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3778,7 +3868,7 @@
                   "x": 0,
                   "y": 126
                },
-               "id": 50,
+               "id": 51,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3868,7 +3958,7 @@
                   "x": 8,
                   "y": 126
                },
-               "id": 51,
+               "id": 52,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3958,7 +4048,7 @@
                   "x": 16,
                   "y": 126
                },
-               "id": 52,
+               "id": 53,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4040,15 +4130,105 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 3,
+               "description": "«Level 0» (L0) memory area in bytes. L0 is the area that\nvinyl can use for in-memory storage of an LSM tree.\nBy monitoring this metric, you can see when L0 is getting\nclose to its maximum (tnt_vinyl_regulator_dump_watermark),\nat which time a dump will occur. You can expect L0 = 0\nimmediately after the dump operation is completed.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 134
+               },
+               "id": 54,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_vinyl_memory_level0{job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Level 0 memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 3,
                "description": "The maximum amount of memory used for in-memory storing of a vinyl LSM tree.\nWhen accessing this maximum, the dumping must occur.\nFor details, see https://www.tarantool.io/en/doc/latest/book/box/engines/#engines-algorithm-filling-lsm.\nThe value is slightly smaller than the amount of memory allocated for vinyl trees,\nwhich is the `vinyl_memory` parameter.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 0,
+                  "w": 8,
+                  "x": 8,
                   "y": 134
                },
-               "id": 53,
+               "id": 55,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4134,11 +4314,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 134
                },
-               "id": 54,
+               "id": 56,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4228,7 +4408,7 @@
                   "x": 0,
                   "y": 142
                },
-               "id": 55,
+               "id": 57,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4318,7 +4498,7 @@
                   "x": 6,
                   "y": 142
                },
-               "id": 56,
+               "id": 58,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4408,7 +4588,7 @@
                   "x": 12,
                   "y": 142
                },
-               "id": 57,
+               "id": 59,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4498,7 +4678,7 @@
                   "x": 18,
                   "y": 142
                },
-               "id": 58,
+               "id": 60,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4588,7 +4768,7 @@
                   "x": 0,
                   "y": 150
                },
-               "id": 59,
+               "id": 61,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4678,7 +4858,7 @@
                   "x": 6,
                   "y": 150
                },
-               "id": 60,
+               "id": 62,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4768,7 +4948,7 @@
                   "x": 12,
                   "y": 150
                },
-               "id": 61,
+               "id": 63,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4858,7 +5038,7 @@
                   "x": 18,
                   "y": 150
                },
-               "id": 62,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4951,7 +5131,7 @@
             "x": 0,
             "y": 158
          },
-         "id": 63,
+         "id": 65,
          "panels": [
             {
                "aliasColors": { },
@@ -4968,7 +5148,7 @@
                   "x": 0,
                   "y": 159
                },
-               "id": 64,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5058,7 +5238,7 @@
                   "x": 12,
                   "y": 159
                },
-               "id": 65,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5148,7 +5328,7 @@
                   "x": 0,
                   "y": 167
                },
-               "id": 66,
+               "id": 68,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5238,7 +5418,7 @@
                   "x": 12,
                   "y": 167
                },
-               "id": 67,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5331,7 +5511,7 @@
             "x": 0,
             "y": 175
          },
-         "id": 68,
+         "id": 70,
          "panels": [
             {
                "aliasColors": { },
@@ -5348,7 +5528,7 @@
                   "x": 0,
                   "y": 176
                },
-               "id": 69,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5438,7 +5618,7 @@
                   "x": 8,
                   "y": 176
                },
-               "id": 70,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5528,7 +5708,7 @@
                   "x": 16,
                   "y": 176
                },
-               "id": 71,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5618,7 +5798,7 @@
                   "x": 0,
                   "y": 184
                },
-               "id": 72,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5708,7 +5888,7 @@
                   "x": 12,
                   "y": 184
                },
-               "id": 73,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5798,7 +5978,7 @@
                   "x": 0,
                   "y": 192
                },
-               "id": 74,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5888,7 +6068,7 @@
                   "x": 8,
                   "y": 192
                },
-               "id": 75,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5978,7 +6158,7 @@
                   "x": 16,
                   "y": 192
                },
-               "id": 76,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6071,7 +6251,7 @@
             "x": 0,
             "y": 200
          },
-         "id": 77,
+         "id": 79,
          "panels": [
             {
                "aliasColors": { },
@@ -6088,7 +6268,7 @@
                   "x": 0,
                   "y": 201
                },
-               "id": 78,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6178,7 +6358,7 @@
                   "x": 6,
                   "y": 201
                },
-               "id": 79,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6268,7 +6448,7 @@
                   "x": 12,
                   "y": 201
                },
-               "id": 80,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6358,7 +6538,7 @@
                   "x": 18,
                   "y": 201
                },
-               "id": 81,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6448,7 +6628,7 @@
                   "x": 0,
                   "y": 209
                },
-               "id": 82,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6538,7 +6718,7 @@
                   "x": 12,
                   "y": 209
                },
-               "id": 83,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6628,7 +6808,7 @@
                   "x": 0,
                   "y": 217
                },
-               "id": 84,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6718,7 +6898,7 @@
                   "x": 8,
                   "y": 217
                },
-               "id": 85,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6808,7 +6988,7 @@
                   "x": 16,
                   "y": 217
                },
-               "id": 86,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6898,7 +7078,7 @@
                   "x": 0,
                   "y": 225
                },
-               "id": 87,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6988,7 +7168,7 @@
                   "x": 8,
                   "y": 225
                },
-               "id": 88,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7078,7 +7258,7 @@
                   "x": 16,
                   "y": 225
                },
-               "id": 89,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7168,7 +7348,7 @@
                   "x": 0,
                   "y": 233
                },
-               "id": 90,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7258,7 +7438,7 @@
                   "x": 6,
                   "y": 233
                },
-               "id": 91,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7348,7 +7528,7 @@
                   "x": 12,
                   "y": 233
                },
-               "id": 92,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7438,7 +7618,7 @@
                   "x": 18,
                   "y": 233
                },
-               "id": 93,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7528,7 +7708,7 @@
                   "x": 0,
                   "y": 241
                },
-               "id": 94,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7618,7 +7798,7 @@
                   "x": 8,
                   "y": 241
                },
-               "id": 95,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7708,7 +7888,7 @@
                   "x": 16,
                   "y": 241
                },
-               "id": 96,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7801,7 +7981,7 @@
             "x": 0,
             "y": 249
          },
-         "id": 97,
+         "id": 99,
          "panels": [
             {
                "aliasColors": { },
@@ -7818,7 +7998,7 @@
                   "x": 0,
                   "y": 250
                },
-               "id": 98,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7908,7 +8088,7 @@
                   "x": 8,
                   "y": 250
                },
-               "id": 99,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7998,7 +8178,7 @@
                   "x": 16,
                   "y": 250
                },
-               "id": 100,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8088,7 +8268,7 @@
                   "x": 0,
                   "y": 258
                },
-               "id": 101,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8178,7 +8358,7 @@
                   "x": 8,
                   "y": 258
                },
-               "id": 102,
+               "id": 104,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8268,7 +8448,7 @@
                   "x": 16,
                   "y": 258
                },
-               "id": 103,
+               "id": 105,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8358,7 +8538,7 @@
                   "x": 0,
                   "y": 266
                },
-               "id": 104,
+               "id": 106,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8448,7 +8628,7 @@
                   "x": 8,
                   "y": 266
                },
-               "id": 105,
+               "id": 107,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8538,7 +8718,7 @@
                   "x": 16,
                   "y": 266
                },
-               "id": 106,
+               "id": 108,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8628,7 +8808,7 @@
                   "x": 0,
                   "y": 274
                },
-               "id": 107,
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8718,7 +8898,7 @@
                   "x": 8,
                   "y": 274
                },
-               "id": 108,
+               "id": 110,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8808,7 +8988,7 @@
                   "x": 16,
                   "y": 274
                },
-               "id": 109,
+               "id": 111,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8901,7 +9081,7 @@
             "x": 0,
             "y": 282
          },
-         "id": 110,
+         "id": 112,
          "panels": [
             {
                "aliasColors": { },
@@ -8918,7 +9098,7 @@
                   "x": 0,
                   "y": 283
                },
-               "id": 111,
+               "id": 113,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9008,7 +9188,7 @@
                   "x": 8,
                   "y": 283
                },
-               "id": 112,
+               "id": 114,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9098,7 +9278,7 @@
                   "x": 16,
                   "y": 283
                },
-               "id": 113,
+               "id": 115,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9188,7 +9368,7 @@
                   "x": 0,
                   "y": 291
                },
-               "id": 114,
+               "id": 116,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9278,7 +9458,7 @@
                   "x": 6,
                   "y": 291
                },
-               "id": 115,
+               "id": 117,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9368,7 +9548,7 @@
                   "x": 12,
                   "y": 291
                },
-               "id": 116,
+               "id": 118,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9458,7 +9638,7 @@
                   "x": 18,
                   "y": 291
                },
-               "id": 117,
+               "id": 119,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9548,7 +9728,7 @@
                   "x": 0,
                   "y": 299
                },
-               "id": 118,
+               "id": 120,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9638,7 +9818,7 @@
                   "x": 6,
                   "y": 299
                },
-               "id": 119,
+               "id": 121,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9728,7 +9908,7 @@
                   "x": 12,
                   "y": 299
                },
-               "id": 120,
+               "id": 122,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9818,7 +9998,7 @@
                   "x": 18,
                   "y": 299
                },
-               "id": 121,
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9911,7 +10091,7 @@
             "x": 0,
             "y": 307
          },
-         "id": 122,
+         "id": 124,
          "panels": [
             {
                "aliasColors": { },
@@ -9928,7 +10108,7 @@
                   "x": 0,
                   "y": 308
                },
-               "id": 123,
+               "id": 125,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -10018,7 +10198,7 @@
                   "x": 6,
                   "y": 308
                },
-               "id": 124,
+               "id": 126,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10108,7 +10288,7 @@
                   "x": 12,
                   "y": 308
                },
-               "id": 125,
+               "id": 127,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10198,7 +10378,7 @@
                   "x": 18,
                   "y": 308
                },
-               "id": 126,
+               "id": 128,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10288,7 +10468,7 @@
                   "x": 0,
                   "y": 316
                },
-               "id": 127,
+               "id": 129,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10378,7 +10558,7 @@
                   "x": 6,
                   "y": 316
                },
-               "id": 128,
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10468,7 +10648,7 @@
                   "x": 12,
                   "y": 316
                },
-               "id": 129,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10558,7 +10738,7 @@
                   "x": 18,
                   "y": 316
                },
-               "id": 130,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10648,7 +10828,7 @@
                   "x": 0,
                   "y": 324
                },
-               "id": 131,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10738,7 +10918,7 @@
                   "x": 8,
                   "y": 324
                },
-               "id": 132,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10828,7 +11008,7 @@
                   "x": 16,
                   "y": 324
                },
-               "id": 133,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10918,7 +11098,7 @@
                   "x": 0,
                   "y": 332
                },
-               "id": 134,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11008,7 +11188,7 @@
                   "x": 8,
                   "y": 332
                },
-               "id": 135,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -11098,7 +11278,7 @@
                   "x": 16,
                   "y": 332
                },
-               "id": 136,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11188,7 +11368,7 @@
                   "x": 0,
                   "y": 340
                },
-               "id": 137,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11278,7 +11458,7 @@
                   "x": 8,
                   "y": 340
                },
-               "id": 138,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11368,7 +11548,7 @@
                   "x": 16,
                   "y": 340
                },
-               "id": 139,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11458,7 +11638,7 @@
                   "x": 0,
                   "y": 348
                },
-               "id": 140,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11548,7 +11728,7 @@
                   "x": 8,
                   "y": 348
                },
-               "id": 141,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -11638,7 +11818,7 @@
                   "x": 16,
                   "y": 348
                },
-               "id": 142,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11728,7 +11908,7 @@
                   "x": 0,
                   "y": 356
                },
-               "id": 143,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11818,7 +11998,7 @@
                   "x": 0,
                   "y": 366
                },
-               "id": 144,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11908,7 +12088,7 @@
                   "x": 6,
                   "y": 366
                },
-               "id": 145,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11998,7 +12178,7 @@
                   "x": 12,
                   "y": 366
                },
-               "id": 146,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12088,7 +12268,7 @@
                   "x": 18,
                   "y": 366
                },
-               "id": 147,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12181,7 +12361,7 @@
             "x": 0,
             "y": 374
          },
-         "id": 148,
+         "id": 150,
          "panels": [
             {
                "aliasColors": { },
@@ -12198,7 +12378,7 @@
                   "x": 0,
                   "y": 375
                },
-               "id": 149,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12288,7 +12468,7 @@
                   "x": 12,
                   "y": 375
                },
-               "id": 150,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12378,7 +12558,7 @@
                   "x": 0,
                   "y": 383
                },
-               "id": 151,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12468,7 +12648,7 @@
                   "x": 12,
                   "y": 383
                },
-               "id": 152,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12558,7 +12738,7 @@
                   "x": 0,
                   "y": 391
                },
-               "id": 153,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12648,7 +12828,7 @@
                   "x": 8,
                   "y": 391
                },
-               "id": 154,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12738,7 +12918,7 @@
                   "x": 16,
                   "y": 391
                },
-               "id": 155,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12828,7 +13008,7 @@
                   "x": 0,
                   "y": 399
                },
-               "id": 156,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12918,7 +13098,7 @@
                   "x": 8,
                   "y": 399
                },
-               "id": 157,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13008,7 +13188,7 @@
                   "x": 16,
                   "y": 399
                },
-               "id": 158,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13098,7 +13278,7 @@
                   "x": 0,
                   "y": 407
                },
-               "id": 159,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13188,7 +13368,7 @@
                   "x": 6,
                   "y": 407
                },
-               "id": 160,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13278,7 +13458,7 @@
                   "x": 12,
                   "y": 407
                },
-               "id": 161,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13368,7 +13548,7 @@
                   "x": 18,
                   "y": 407
                },
-               "id": 162,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13458,7 +13638,7 @@
                   "x": 0,
                   "y": 415
                },
-               "id": 163,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13548,7 +13728,7 @@
                   "x": 12,
                   "y": 415
                },
-               "id": 164,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13641,7 +13821,7 @@
             "x": 0,
             "y": 423
          },
-         "id": 165,
+         "id": 167,
          "panels": [
             {
                "aliasColors": { },
@@ -13658,7 +13838,7 @@
                   "x": 0,
                   "y": 424
                },
-               "id": 166,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -13748,7 +13928,7 @@
                   "x": 12,
                   "y": 424
                },
-               "id": 167,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13838,7 +14018,7 @@
                   "x": 0,
                   "y": 432
                },
-               "id": 168,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13928,7 +14108,7 @@
                   "x": 12,
                   "y": 432
                },
-               "id": 169,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14021,7 +14201,7 @@
             "x": 0,
             "y": 440
          },
-         "id": 170,
+         "id": 172,
          "panels": [
             {
                "aliasColors": { },
@@ -14038,7 +14218,7 @@
                   "x": 0,
                   "y": 441
                },
-               "id": 171,
+               "id": 173,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -14128,7 +14308,7 @@
                   "x": 12,
                   "y": 441
                },
-               "id": 172,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -14221,7 +14401,7 @@
             "x": 0,
             "y": 449
          },
-         "id": 173,
+         "id": 175,
          "panels": [
             {
                "aliasColors": { },
@@ -14238,7 +14418,7 @@
                   "x": 0,
                   "y": 450
                },
-               "id": 174,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14328,7 +14508,7 @@
                   "x": 12,
                   "y": 450
                },
-               "id": 175,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14418,7 +14598,7 @@
                   "x": 0,
                   "y": 458
                },
-               "id": 176,
+               "id": 178,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14508,7 +14688,7 @@
                   "x": 12,
                   "y": 458
                },
-               "id": 177,
+               "id": 179,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14601,7 +14781,7 @@
             "x": 0,
             "y": 466
          },
-         "id": 178,
+         "id": 180,
          "panels": [
             {
                "aliasColors": { },
@@ -14618,7 +14798,7 @@
                   "x": 0,
                   "y": 467
                },
-               "id": 179,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14708,7 +14888,7 @@
                   "x": 12,
                   "y": 467
                },
-               "id": 180,
+               "id": 182,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14798,7 +14978,7 @@
                   "x": 0,
                   "y": 475
                },
-               "id": 181,
+               "id": 183,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14888,7 +15068,7 @@
                   "x": 12,
                   "y": 475
                },
-               "id": 182,
+               "id": 184,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14981,7 +15161,7 @@
             "x": 0,
             "y": 483
          },
-         "id": 183,
+         "id": 185,
          "panels": [
             {
                "aliasColors": { },
@@ -14998,7 +15178,7 @@
                   "x": 0,
                   "y": 484
                },
-               "id": 184,
+               "id": 186,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15088,7 +15268,7 @@
                   "x": 8,
                   "y": 484
                },
-               "id": 185,
+               "id": 187,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15178,7 +15358,7 @@
                   "x": 16,
                   "y": 484
                },
-               "id": 186,
+               "id": 188,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15268,7 +15448,7 @@
                   "x": 0,
                   "y": 492
                },
-               "id": 187,
+               "id": 189,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15358,7 +15538,7 @@
                   "x": 8,
                   "y": 492
                },
-               "id": 188,
+               "id": 190,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15448,7 +15628,7 @@
                   "x": 16,
                   "y": 492
                },
-               "id": 189,
+               "id": 191,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15541,7 +15721,7 @@
             "x": 0,
             "y": 500
          },
-         "id": 190,
+         "id": 192,
          "panels": [
             {
                "aliasColors": { },
@@ -15558,7 +15738,7 @@
                   "x": 0,
                   "y": 501
                },
-               "id": 191,
+               "id": 193,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15648,7 +15828,7 @@
                   "x": 8,
                   "y": 501
                },
-               "id": 192,
+               "id": 194,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15738,7 +15918,7 @@
                   "x": 16,
                   "y": 501
                },
-               "id": 193,
+               "id": 195,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15828,7 +16008,7 @@
                   "x": 0,
                   "y": 509
                },
-               "id": 194,
+               "id": 196,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15918,7 +16098,7 @@
                   "x": 8,
                   "y": 509
                },
-               "id": 195,
+               "id": 197,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16008,7 +16188,7 @@
                   "x": 16,
                   "y": 509
                },
-               "id": 196,
+               "id": 198,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16101,7 +16281,7 @@
             "x": 0,
             "y": 517
          },
-         "id": 197,
+         "id": 199,
          "panels": [
             {
                "aliasColors": { },
@@ -16118,7 +16298,7 @@
                   "x": 0,
                   "y": 518
                },
-               "id": 198,
+               "id": 200,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16208,7 +16388,7 @@
                   "x": 6,
                   "y": 518
                },
-               "id": 199,
+               "id": 201,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16298,7 +16478,7 @@
                   "x": 12,
                   "y": 518
                },
-               "id": 200,
+               "id": 202,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16388,7 +16568,7 @@
                   "x": 18,
                   "y": 518
                },
-               "id": 201,
+               "id": 203,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16478,7 +16658,7 @@
                   "x": 0,
                   "y": 526
                },
-               "id": 202,
+               "id": 204,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16568,7 +16748,7 @@
                   "x": 12,
                   "y": 526
                },
-               "id": 203,
+               "id": 205,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16658,7 +16838,7 @@
                   "x": 0,
                   "y": 534
                },
-               "id": 204,
+               "id": 206,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16748,7 +16928,7 @@
                   "x": 6,
                   "y": 534
                },
-               "id": 205,
+               "id": 207,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16838,7 +17018,7 @@
                   "x": 12,
                   "y": 534
                },
-               "id": 206,
+               "id": 208,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16928,7 +17108,7 @@
                   "x": 18,
                   "y": 534
                },
-               "id": 207,
+               "id": 209,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17018,7 +17198,7 @@
                   "x": 0,
                   "y": 542
                },
-               "id": 208,
+               "id": 210,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17108,7 +17288,7 @@
                   "x": 6,
                   "y": 542
                },
-               "id": 209,
+               "id": 211,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17198,7 +17378,7 @@
                   "x": 12,
                   "y": 542
                },
-               "id": 210,
+               "id": 212,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17288,7 +17468,7 @@
                   "x": 18,
                   "y": 542
                },
-               "id": 211,
+               "id": 213,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17378,7 +17558,7 @@
                   "x": 0,
                   "y": 550
                },
-               "id": 212,
+               "id": 214,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17468,7 +17648,7 @@
                   "x": 6,
                   "y": 550
                },
-               "id": 213,
+               "id": 215,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17558,7 +17738,7 @@
                   "x": 12,
                   "y": 550
                },
-               "id": 214,
+               "id": 216,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17648,7 +17828,7 @@
                   "x": 18,
                   "y": 550
                },
-               "id": 215,
+               "id": 217,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17741,7 +17921,7 @@
             "x": 0,
             "y": 558
          },
-         "id": 216,
+         "id": 218,
          "panels": [
             {
                "aliasColors": { },
@@ -17758,7 +17938,7 @@
                   "x": 0,
                   "y": 559
                },
-               "id": 217,
+               "id": 219,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17848,7 +18028,7 @@
                   "x": 8,
                   "y": 559
                },
-               "id": 218,
+               "id": 220,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17938,7 +18118,7 @@
                   "x": 16,
                   "y": 559
                },
-               "id": 219,
+               "id": 221,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18028,7 +18208,7 @@
                   "x": 0,
                   "y": 567
                },
-               "id": 220,
+               "id": 222,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18118,7 +18298,7 @@
                   "x": 8,
                   "y": 567
                },
-               "id": 221,
+               "id": 223,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18208,7 +18388,7 @@
                   "x": 16,
                   "y": 567
                },
-               "id": 222,
+               "id": 224,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18298,7 +18478,7 @@
                   "x": 0,
                   "y": 575
                },
-               "id": 223,
+               "id": 225,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18388,7 +18568,7 @@
                   "x": 8,
                   "y": 575
                },
-               "id": 224,
+               "id": 226,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18478,7 +18658,7 @@
                   "x": 16,
                   "y": 575
                },
-               "id": 225,
+               "id": 227,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18568,7 +18748,7 @@
                   "x": 0,
                   "y": 583
                },
-               "id": 226,
+               "id": 228,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18658,7 +18838,7 @@
                   "x": 8,
                   "y": 583
                },
-               "id": 227,
+               "id": 229,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18748,7 +18928,7 @@
                   "x": 16,
                   "y": 583
                },
-               "id": 228,
+               "id": 230,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18841,7 +19021,7 @@
             "x": 0,
             "y": 591
          },
-         "id": 229,
+         "id": 231,
          "panels": [
             {
                "aliasColors": { },
@@ -18858,7 +19038,7 @@
                   "x": 0,
                   "y": 592
                },
-               "id": 230,
+               "id": 232,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18948,7 +19128,7 @@
                   "x": 8,
                   "y": 592
                },
-               "id": 231,
+               "id": 233,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19038,7 +19218,7 @@
                   "x": 16,
                   "y": 592
                },
-               "id": 232,
+               "id": 234,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19128,7 +19308,7 @@
                   "x": 0,
                   "y": 600
                },
-               "id": 233,
+               "id": 235,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -19218,7 +19398,7 @@
                   "x": 12,
                   "y": 600
                },
-               "id": 234,
+               "id": 236,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19308,7 +19488,7 @@
                   "x": 0,
                   "y": 608
                },
-               "id": 235,
+               "id": 237,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19398,7 +19578,7 @@
                   "x": 6,
                   "y": 608
                },
-               "id": 236,
+               "id": 238,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19488,7 +19668,7 @@
                   "x": 12,
                   "y": 608
                },
-               "id": 237,
+               "id": 239,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19578,7 +19758,7 @@
                   "x": 18,
                   "y": 608
                },
-               "id": 238,
+               "id": 240,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19668,7 +19848,7 @@
                   "x": 0,
                   "y": 616
                },
-               "id": 239,
+               "id": 241,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -19758,7 +19938,7 @@
                   "x": 12,
                   "y": 616
                },
-               "id": 240,
+               "id": 242,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19848,7 +20028,7 @@
                   "x": 0,
                   "y": 624
                },
-               "id": 241,
+               "id": 243,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19938,7 +20118,7 @@
                   "x": 8,
                   "y": 624
                },
-               "id": 242,
+               "id": 244,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20028,7 +20208,7 @@
                   "x": 16,
                   "y": 624
                },
-               "id": 243,
+               "id": 245,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20118,7 +20298,7 @@
                   "x": 0,
                   "y": 632
                },
-               "id": 244,
+               "id": 246,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -20208,7 +20388,7 @@
                   "x": 12,
                   "y": 632
                },
-               "id": 245,
+               "id": 247,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_tdg_compiled.json
+++ b/tests/Prometheus/dashboard_tdg_compiled.json
@@ -3590,7 +3590,7 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 3,
-               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n",
+               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,

--- a/tests/Prometheus/dashboard_tdg_static_compiled.json
+++ b/tests/Prometheus/dashboard_tdg_static_compiled.json
@@ -3574,7 +3574,7 @@
                "dashes": false,
                "datasource": "Prometheus",
                "decimals": 3,
-               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n",
+               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,

--- a/tests/Prometheus/dashboard_tdg_static_compiled.json
+++ b/tests/Prometheus/dashboard_tdg_static_compiled.json
@@ -3574,15 +3574,105 @@
                "dashes": false,
                "datasource": "Prometheus",
                "decimals": 3,
-               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "description": "Amount of memory in bytes currently used to store tuples (data).\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 118
                },
                "id": 48,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_vinyl_memory_tuple_cache{job=~\"tarantool\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Tuples cache memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 118
+               },
+               "id": 49,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3668,11 +3758,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 118
                },
-               "id": 49,
+               "id": 50,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3762,7 +3852,7 @@
                   "x": 0,
                   "y": 126
                },
-               "id": 50,
+               "id": 51,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3852,7 +3942,7 @@
                   "x": 8,
                   "y": 126
                },
-               "id": 51,
+               "id": 52,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3942,7 +4032,7 @@
                   "x": 16,
                   "y": 126
                },
-               "id": 52,
+               "id": 53,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4024,15 +4114,105 @@
                "dashes": false,
                "datasource": "Prometheus",
                "decimals": 3,
+               "description": "«Level 0» (L0) memory area in bytes. L0 is the area that\nvinyl can use for in-memory storage of an LSM tree.\nBy monitoring this metric, you can see when L0 is getting\nclose to its maximum (tnt_vinyl_regulator_dump_watermark),\nat which time a dump will occur. You can expect L0 = 0\nimmediately after the dump operation is completed.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 134
+               },
+               "id": 54,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_vinyl_memory_level0{job=~\"tarantool\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Level 0 memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
                "description": "The maximum amount of memory used for in-memory storing of a vinyl LSM tree.\nWhen accessing this maximum, the dumping must occur.\nFor details, see https://www.tarantool.io/en/doc/latest/book/box/engines/#engines-algorithm-filling-lsm.\nThe value is slightly smaller than the amount of memory allocated for vinyl trees,\nwhich is the `vinyl_memory` parameter.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 0,
+                  "w": 8,
+                  "x": 8,
                   "y": 134
                },
-               "id": 53,
+               "id": 55,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4118,11 +4298,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 134
                },
-               "id": 54,
+               "id": 56,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4212,7 +4392,7 @@
                   "x": 0,
                   "y": 142
                },
-               "id": 55,
+               "id": 57,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4302,7 +4482,7 @@
                   "x": 6,
                   "y": 142
                },
-               "id": 56,
+               "id": 58,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4392,7 +4572,7 @@
                   "x": 12,
                   "y": 142
                },
-               "id": 57,
+               "id": 59,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4482,7 +4662,7 @@
                   "x": 18,
                   "y": 142
                },
-               "id": 58,
+               "id": 60,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4572,7 +4752,7 @@
                   "x": 0,
                   "y": 150
                },
-               "id": 59,
+               "id": 61,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4662,7 +4842,7 @@
                   "x": 6,
                   "y": 150
                },
-               "id": 60,
+               "id": 62,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4752,7 +4932,7 @@
                   "x": 12,
                   "y": 150
                },
-               "id": 61,
+               "id": 63,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4842,7 +5022,7 @@
                   "x": 18,
                   "y": 150
                },
-               "id": 62,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4935,7 +5115,7 @@
             "x": 0,
             "y": 158
          },
-         "id": 63,
+         "id": 65,
          "panels": [
             {
                "aliasColors": { },
@@ -4952,7 +5132,7 @@
                   "x": 0,
                   "y": 159
                },
-               "id": 64,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5042,7 +5222,7 @@
                   "x": 12,
                   "y": 159
                },
-               "id": 65,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5132,7 +5312,7 @@
                   "x": 0,
                   "y": 167
                },
-               "id": 66,
+               "id": 68,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5222,7 +5402,7 @@
                   "x": 12,
                   "y": 167
                },
-               "id": 67,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5315,7 +5495,7 @@
             "x": 0,
             "y": 175
          },
-         "id": 68,
+         "id": 70,
          "panels": [
             {
                "aliasColors": { },
@@ -5332,7 +5512,7 @@
                   "x": 0,
                   "y": 176
                },
-               "id": 69,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5422,7 +5602,7 @@
                   "x": 8,
                   "y": 176
                },
-               "id": 70,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5512,7 +5692,7 @@
                   "x": 16,
                   "y": 176
                },
-               "id": 71,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5602,7 +5782,7 @@
                   "x": 0,
                   "y": 184
                },
-               "id": 72,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5692,7 +5872,7 @@
                   "x": 12,
                   "y": 184
                },
-               "id": 73,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5782,7 +5962,7 @@
                   "x": 0,
                   "y": 192
                },
-               "id": 74,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5872,7 +6052,7 @@
                   "x": 8,
                   "y": 192
                },
-               "id": 75,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5962,7 +6142,7 @@
                   "x": 16,
                   "y": 192
                },
-               "id": 76,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6055,7 +6235,7 @@
             "x": 0,
             "y": 200
          },
-         "id": 77,
+         "id": 79,
          "panels": [
             {
                "aliasColors": { },
@@ -6072,7 +6252,7 @@
                   "x": 0,
                   "y": 201
                },
-               "id": 78,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6162,7 +6342,7 @@
                   "x": 6,
                   "y": 201
                },
-               "id": 79,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6252,7 +6432,7 @@
                   "x": 12,
                   "y": 201
                },
-               "id": 80,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6342,7 +6522,7 @@
                   "x": 18,
                   "y": 201
                },
-               "id": 81,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6432,7 +6612,7 @@
                   "x": 0,
                   "y": 209
                },
-               "id": 82,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6522,7 +6702,7 @@
                   "x": 12,
                   "y": 209
                },
-               "id": 83,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6612,7 +6792,7 @@
                   "x": 0,
                   "y": 217
                },
-               "id": 84,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6702,7 +6882,7 @@
                   "x": 8,
                   "y": 217
                },
-               "id": 85,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6792,7 +6972,7 @@
                   "x": 16,
                   "y": 217
                },
-               "id": 86,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6882,7 +7062,7 @@
                   "x": 0,
                   "y": 225
                },
-               "id": 87,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6972,7 +7152,7 @@
                   "x": 8,
                   "y": 225
                },
-               "id": 88,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7062,7 +7242,7 @@
                   "x": 16,
                   "y": 225
                },
-               "id": 89,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7152,7 +7332,7 @@
                   "x": 0,
                   "y": 233
                },
-               "id": 90,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7242,7 +7422,7 @@
                   "x": 6,
                   "y": 233
                },
-               "id": 91,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7332,7 +7512,7 @@
                   "x": 12,
                   "y": 233
                },
-               "id": 92,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7422,7 +7602,7 @@
                   "x": 18,
                   "y": 233
                },
-               "id": 93,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7512,7 +7692,7 @@
                   "x": 0,
                   "y": 241
                },
-               "id": 94,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7602,7 +7782,7 @@
                   "x": 8,
                   "y": 241
                },
-               "id": 95,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7692,7 +7872,7 @@
                   "x": 16,
                   "y": 241
                },
-               "id": 96,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7785,7 +7965,7 @@
             "x": 0,
             "y": 249
          },
-         "id": 97,
+         "id": 99,
          "panels": [
             {
                "aliasColors": { },
@@ -7802,7 +7982,7 @@
                   "x": 0,
                   "y": 250
                },
-               "id": 98,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7892,7 +8072,7 @@
                   "x": 8,
                   "y": 250
                },
-               "id": 99,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7982,7 +8162,7 @@
                   "x": 16,
                   "y": 250
                },
-               "id": 100,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8072,7 +8252,7 @@
                   "x": 0,
                   "y": 258
                },
-               "id": 101,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8162,7 +8342,7 @@
                   "x": 8,
                   "y": 258
                },
-               "id": 102,
+               "id": 104,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8252,7 +8432,7 @@
                   "x": 16,
                   "y": 258
                },
-               "id": 103,
+               "id": 105,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8342,7 +8522,7 @@
                   "x": 0,
                   "y": 266
                },
-               "id": 104,
+               "id": 106,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8432,7 +8612,7 @@
                   "x": 8,
                   "y": 266
                },
-               "id": 105,
+               "id": 107,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8522,7 +8702,7 @@
                   "x": 16,
                   "y": 266
                },
-               "id": 106,
+               "id": 108,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8612,7 +8792,7 @@
                   "x": 0,
                   "y": 274
                },
-               "id": 107,
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8702,7 +8882,7 @@
                   "x": 8,
                   "y": 274
                },
-               "id": 108,
+               "id": 110,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8792,7 +8972,7 @@
                   "x": 16,
                   "y": 274
                },
-               "id": 109,
+               "id": 111,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8885,7 +9065,7 @@
             "x": 0,
             "y": 282
          },
-         "id": 110,
+         "id": 112,
          "panels": [
             {
                "aliasColors": { },
@@ -8902,7 +9082,7 @@
                   "x": 0,
                   "y": 283
                },
-               "id": 111,
+               "id": 113,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8992,7 +9172,7 @@
                   "x": 8,
                   "y": 283
                },
-               "id": 112,
+               "id": 114,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9082,7 +9262,7 @@
                   "x": 16,
                   "y": 283
                },
-               "id": 113,
+               "id": 115,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9172,7 +9352,7 @@
                   "x": 0,
                   "y": 291
                },
-               "id": 114,
+               "id": 116,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9262,7 +9442,7 @@
                   "x": 6,
                   "y": 291
                },
-               "id": 115,
+               "id": 117,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9352,7 +9532,7 @@
                   "x": 12,
                   "y": 291
                },
-               "id": 116,
+               "id": 118,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9442,7 +9622,7 @@
                   "x": 18,
                   "y": 291
                },
-               "id": 117,
+               "id": 119,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9532,7 +9712,7 @@
                   "x": 0,
                   "y": 299
                },
-               "id": 118,
+               "id": 120,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9622,7 +9802,7 @@
                   "x": 6,
                   "y": 299
                },
-               "id": 119,
+               "id": 121,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9712,7 +9892,7 @@
                   "x": 12,
                   "y": 299
                },
-               "id": 120,
+               "id": 122,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9802,7 +9982,7 @@
                   "x": 18,
                   "y": 299
                },
-               "id": 121,
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9895,7 +10075,7 @@
             "x": 0,
             "y": 307
          },
-         "id": 122,
+         "id": 124,
          "panels": [
             {
                "aliasColors": { },
@@ -9912,7 +10092,7 @@
                   "x": 0,
                   "y": 308
                },
-               "id": 123,
+               "id": 125,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -10002,7 +10182,7 @@
                   "x": 6,
                   "y": 308
                },
-               "id": 124,
+               "id": 126,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10092,7 +10272,7 @@
                   "x": 12,
                   "y": 308
                },
-               "id": 125,
+               "id": 127,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10182,7 +10362,7 @@
                   "x": 18,
                   "y": 308
                },
-               "id": 126,
+               "id": 128,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10272,7 +10452,7 @@
                   "x": 0,
                   "y": 316
                },
-               "id": 127,
+               "id": 129,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10362,7 +10542,7 @@
                   "x": 6,
                   "y": 316
                },
-               "id": 128,
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10452,7 +10632,7 @@
                   "x": 12,
                   "y": 316
                },
-               "id": 129,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10542,7 +10722,7 @@
                   "x": 18,
                   "y": 316
                },
-               "id": 130,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10632,7 +10812,7 @@
                   "x": 0,
                   "y": 324
                },
-               "id": 131,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10722,7 +10902,7 @@
                   "x": 8,
                   "y": 324
                },
-               "id": 132,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10812,7 +10992,7 @@
                   "x": 16,
                   "y": 324
                },
-               "id": 133,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10902,7 +11082,7 @@
                   "x": 0,
                   "y": 332
                },
-               "id": 134,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10992,7 +11172,7 @@
                   "x": 8,
                   "y": 332
                },
-               "id": 135,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -11082,7 +11262,7 @@
                   "x": 16,
                   "y": 332
                },
-               "id": 136,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11172,7 +11352,7 @@
                   "x": 0,
                   "y": 340
                },
-               "id": 137,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11262,7 +11442,7 @@
                   "x": 8,
                   "y": 340
                },
-               "id": 138,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11352,7 +11532,7 @@
                   "x": 16,
                   "y": 340
                },
-               "id": 139,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11442,7 +11622,7 @@
                   "x": 0,
                   "y": 348
                },
-               "id": 140,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11532,7 +11712,7 @@
                   "x": 8,
                   "y": 348
                },
-               "id": 141,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -11622,7 +11802,7 @@
                   "x": 16,
                   "y": 348
                },
-               "id": 142,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11712,7 +11892,7 @@
                   "x": 0,
                   "y": 356
                },
-               "id": 143,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11802,7 +11982,7 @@
                   "x": 0,
                   "y": 366
                },
-               "id": 144,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11892,7 +12072,7 @@
                   "x": 6,
                   "y": 366
                },
-               "id": 145,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11982,7 +12162,7 @@
                   "x": 12,
                   "y": 366
                },
-               "id": 146,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12072,7 +12252,7 @@
                   "x": 18,
                   "y": 366
                },
-               "id": 147,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12165,7 +12345,7 @@
             "x": 0,
             "y": 374
          },
-         "id": 148,
+         "id": 150,
          "panels": [
             {
                "aliasColors": { },
@@ -12182,7 +12362,7 @@
                   "x": 0,
                   "y": 375
                },
-               "id": 149,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12272,7 +12452,7 @@
                   "x": 12,
                   "y": 375
                },
-               "id": 150,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12362,7 +12542,7 @@
                   "x": 0,
                   "y": 383
                },
-               "id": 151,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12452,7 +12632,7 @@
                   "x": 12,
                   "y": 383
                },
-               "id": 152,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12542,7 +12722,7 @@
                   "x": 0,
                   "y": 391
                },
-               "id": 153,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12632,7 +12812,7 @@
                   "x": 8,
                   "y": 391
                },
-               "id": 154,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12722,7 +12902,7 @@
                   "x": 16,
                   "y": 391
                },
-               "id": 155,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12812,7 +12992,7 @@
                   "x": 0,
                   "y": 399
                },
-               "id": 156,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12902,7 +13082,7 @@
                   "x": 8,
                   "y": 399
                },
-               "id": 157,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12992,7 +13172,7 @@
                   "x": 16,
                   "y": 399
                },
-               "id": 158,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13082,7 +13262,7 @@
                   "x": 0,
                   "y": 407
                },
-               "id": 159,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13172,7 +13352,7 @@
                   "x": 6,
                   "y": 407
                },
-               "id": 160,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13262,7 +13442,7 @@
                   "x": 12,
                   "y": 407
                },
-               "id": 161,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13352,7 +13532,7 @@
                   "x": 18,
                   "y": 407
                },
-               "id": 162,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13442,7 +13622,7 @@
                   "x": 0,
                   "y": 415
                },
-               "id": 163,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13532,7 +13712,7 @@
                   "x": 12,
                   "y": 415
                },
-               "id": 164,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13625,7 +13805,7 @@
             "x": 0,
             "y": 423
          },
-         "id": 165,
+         "id": 167,
          "panels": [
             {
                "aliasColors": { },
@@ -13642,7 +13822,7 @@
                   "x": 0,
                   "y": 424
                },
-               "id": 166,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -13732,7 +13912,7 @@
                   "x": 12,
                   "y": 424
                },
-               "id": 167,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13822,7 +14002,7 @@
                   "x": 0,
                   "y": 432
                },
-               "id": 168,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13912,7 +14092,7 @@
                   "x": 12,
                   "y": 432
                },
-               "id": 169,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14005,7 +14185,7 @@
             "x": 0,
             "y": 440
          },
-         "id": 170,
+         "id": 172,
          "panels": [
             {
                "aliasColors": { },
@@ -14022,7 +14202,7 @@
                   "x": 0,
                   "y": 441
                },
-               "id": 171,
+               "id": 173,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -14112,7 +14292,7 @@
                   "x": 12,
                   "y": 441
                },
-               "id": 172,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -14205,7 +14385,7 @@
             "x": 0,
             "y": 449
          },
-         "id": 173,
+         "id": 175,
          "panels": [
             {
                "aliasColors": { },
@@ -14222,7 +14402,7 @@
                   "x": 0,
                   "y": 450
                },
-               "id": 174,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14312,7 +14492,7 @@
                   "x": 12,
                   "y": 450
                },
-               "id": 175,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14402,7 +14582,7 @@
                   "x": 0,
                   "y": 458
                },
-               "id": 176,
+               "id": 178,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14492,7 +14672,7 @@
                   "x": 12,
                   "y": 458
                },
-               "id": 177,
+               "id": 179,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14585,7 +14765,7 @@
             "x": 0,
             "y": 466
          },
-         "id": 178,
+         "id": 180,
          "panels": [
             {
                "aliasColors": { },
@@ -14602,7 +14782,7 @@
                   "x": 0,
                   "y": 467
                },
-               "id": 179,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14692,7 +14872,7 @@
                   "x": 12,
                   "y": 467
                },
-               "id": 180,
+               "id": 182,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14782,7 +14962,7 @@
                   "x": 0,
                   "y": 475
                },
-               "id": 181,
+               "id": 183,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14872,7 +15052,7 @@
                   "x": 12,
                   "y": 475
                },
-               "id": 182,
+               "id": 184,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14965,7 +15145,7 @@
             "x": 0,
             "y": 483
          },
-         "id": 183,
+         "id": 185,
          "panels": [
             {
                "aliasColors": { },
@@ -14982,7 +15162,7 @@
                   "x": 0,
                   "y": 484
                },
-               "id": 184,
+               "id": 186,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15072,7 +15252,7 @@
                   "x": 8,
                   "y": 484
                },
-               "id": 185,
+               "id": 187,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15162,7 +15342,7 @@
                   "x": 16,
                   "y": 484
                },
-               "id": 186,
+               "id": 188,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15252,7 +15432,7 @@
                   "x": 0,
                   "y": 492
                },
-               "id": 187,
+               "id": 189,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15342,7 +15522,7 @@
                   "x": 8,
                   "y": 492
                },
-               "id": 188,
+               "id": 190,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15432,7 +15612,7 @@
                   "x": 16,
                   "y": 492
                },
-               "id": 189,
+               "id": 191,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15525,7 +15705,7 @@
             "x": 0,
             "y": 500
          },
-         "id": 190,
+         "id": 192,
          "panels": [
             {
                "aliasColors": { },
@@ -15542,7 +15722,7 @@
                   "x": 0,
                   "y": 501
                },
-               "id": 191,
+               "id": 193,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15632,7 +15812,7 @@
                   "x": 8,
                   "y": 501
                },
-               "id": 192,
+               "id": 194,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15722,7 +15902,7 @@
                   "x": 16,
                   "y": 501
                },
-               "id": 193,
+               "id": 195,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15812,7 +15992,7 @@
                   "x": 0,
                   "y": 509
                },
-               "id": 194,
+               "id": 196,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15902,7 +16082,7 @@
                   "x": 8,
                   "y": 509
                },
-               "id": 195,
+               "id": 197,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15992,7 +16172,7 @@
                   "x": 16,
                   "y": 509
                },
-               "id": 196,
+               "id": 198,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16085,7 +16265,7 @@
             "x": 0,
             "y": 517
          },
-         "id": 197,
+         "id": 199,
          "panels": [
             {
                "aliasColors": { },
@@ -16102,7 +16282,7 @@
                   "x": 0,
                   "y": 518
                },
-               "id": 198,
+               "id": 200,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16192,7 +16372,7 @@
                   "x": 6,
                   "y": 518
                },
-               "id": 199,
+               "id": 201,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16282,7 +16462,7 @@
                   "x": 12,
                   "y": 518
                },
-               "id": 200,
+               "id": 202,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16372,7 +16552,7 @@
                   "x": 18,
                   "y": 518
                },
-               "id": 201,
+               "id": 203,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16462,7 +16642,7 @@
                   "x": 0,
                   "y": 526
                },
-               "id": 202,
+               "id": 204,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16552,7 +16732,7 @@
                   "x": 12,
                   "y": 526
                },
-               "id": 203,
+               "id": 205,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16642,7 +16822,7 @@
                   "x": 0,
                   "y": 534
                },
-               "id": 204,
+               "id": 206,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16732,7 +16912,7 @@
                   "x": 6,
                   "y": 534
                },
-               "id": 205,
+               "id": 207,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16822,7 +17002,7 @@
                   "x": 12,
                   "y": 534
                },
-               "id": 206,
+               "id": 208,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16912,7 +17092,7 @@
                   "x": 18,
                   "y": 534
                },
-               "id": 207,
+               "id": 209,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17002,7 +17182,7 @@
                   "x": 0,
                   "y": 542
                },
-               "id": 208,
+               "id": 210,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17092,7 +17272,7 @@
                   "x": 6,
                   "y": 542
                },
-               "id": 209,
+               "id": 211,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17182,7 +17362,7 @@
                   "x": 12,
                   "y": 542
                },
-               "id": 210,
+               "id": 212,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17272,7 +17452,7 @@
                   "x": 18,
                   "y": 542
                },
-               "id": 211,
+               "id": 213,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17362,7 +17542,7 @@
                   "x": 0,
                   "y": 550
                },
-               "id": 212,
+               "id": 214,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17452,7 +17632,7 @@
                   "x": 6,
                   "y": 550
                },
-               "id": 213,
+               "id": 215,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17542,7 +17722,7 @@
                   "x": 12,
                   "y": 550
                },
-               "id": 214,
+               "id": 216,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17632,7 +17812,7 @@
                   "x": 18,
                   "y": 550
                },
-               "id": 215,
+               "id": 217,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17725,7 +17905,7 @@
             "x": 0,
             "y": 558
          },
-         "id": 216,
+         "id": 218,
          "panels": [
             {
                "aliasColors": { },
@@ -17742,7 +17922,7 @@
                   "x": 0,
                   "y": 559
                },
-               "id": 217,
+               "id": 219,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17832,7 +18012,7 @@
                   "x": 8,
                   "y": 559
                },
-               "id": 218,
+               "id": 220,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17922,7 +18102,7 @@
                   "x": 16,
                   "y": 559
                },
-               "id": 219,
+               "id": 221,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18012,7 +18192,7 @@
                   "x": 0,
                   "y": 567
                },
-               "id": 220,
+               "id": 222,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18102,7 +18282,7 @@
                   "x": 8,
                   "y": 567
                },
-               "id": 221,
+               "id": 223,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18192,7 +18372,7 @@
                   "x": 16,
                   "y": 567
                },
-               "id": 222,
+               "id": 224,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18282,7 +18462,7 @@
                   "x": 0,
                   "y": 575
                },
-               "id": 223,
+               "id": 225,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18372,7 +18552,7 @@
                   "x": 8,
                   "y": 575
                },
-               "id": 224,
+               "id": 226,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18462,7 +18642,7 @@
                   "x": 16,
                   "y": 575
                },
-               "id": 225,
+               "id": 227,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18552,7 +18732,7 @@
                   "x": 0,
                   "y": 583
                },
-               "id": 226,
+               "id": 228,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18642,7 +18822,7 @@
                   "x": 8,
                   "y": 583
                },
-               "id": 227,
+               "id": 229,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18732,7 +18912,7 @@
                   "x": 16,
                   "y": 583
                },
-               "id": 228,
+               "id": 230,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18825,7 +19005,7 @@
             "x": 0,
             "y": 591
          },
-         "id": 229,
+         "id": 231,
          "panels": [
             {
                "aliasColors": { },
@@ -18842,7 +19022,7 @@
                   "x": 0,
                   "y": 592
                },
-               "id": 230,
+               "id": 232,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18932,7 +19112,7 @@
                   "x": 8,
                   "y": 592
                },
-               "id": 231,
+               "id": 233,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19022,7 +19202,7 @@
                   "x": 16,
                   "y": 592
                },
-               "id": 232,
+               "id": 234,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19112,7 +19292,7 @@
                   "x": 0,
                   "y": 600
                },
-               "id": 233,
+               "id": 235,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -19202,7 +19382,7 @@
                   "x": 12,
                   "y": 600
                },
-               "id": 234,
+               "id": 236,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19292,7 +19472,7 @@
                   "x": 0,
                   "y": 608
                },
-               "id": 235,
+               "id": 237,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19382,7 +19562,7 @@
                   "x": 6,
                   "y": 608
                },
-               "id": 236,
+               "id": 238,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19472,7 +19652,7 @@
                   "x": 12,
                   "y": 608
                },
-               "id": 237,
+               "id": 239,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19562,7 +19742,7 @@
                   "x": 18,
                   "y": 608
                },
-               "id": 238,
+               "id": 240,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19652,7 +19832,7 @@
                   "x": 0,
                   "y": 616
                },
-               "id": 239,
+               "id": 241,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -19742,7 +19922,7 @@
                   "x": 12,
                   "y": 616
                },
-               "id": 240,
+               "id": 242,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19832,7 +20012,7 @@
                   "x": 0,
                   "y": 624
                },
-               "id": 241,
+               "id": 243,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19922,7 +20102,7 @@
                   "x": 8,
                   "y": 624
                },
-               "id": 242,
+               "id": 244,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20012,7 +20192,7 @@
                   "x": 16,
                   "y": 624
                },
-               "id": 243,
+               "id": 245,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20102,7 +20282,7 @@
                   "x": 0,
                   "y": 632
                },
-               "id": 244,
+               "id": 246,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -20192,7 +20372,7 @@
                   "x": 12,
                   "y": 632
                },
-               "id": 245,
+               "id": 247,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_with_custom_panels_compiled.json
+++ b/tests/Prometheus/dashboard_with_custom_panels_compiled.json
@@ -4150,15 +4150,105 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 3,
-               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "description": "Amount of memory in bytes currently used to store tuples (data).\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 135
                },
                "id": 55,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_vinyl_memory_tuple_cache{job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Tuples cache memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 3,
+               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 135
+               },
+               "id": 56,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4244,11 +4334,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 135
                },
-               "id": 56,
+               "id": 57,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4338,7 +4428,7 @@
                   "x": 0,
                   "y": 143
                },
-               "id": 57,
+               "id": 58,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4428,7 +4518,7 @@
                   "x": 8,
                   "y": 143
                },
-               "id": 58,
+               "id": 59,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4518,7 +4608,7 @@
                   "x": 16,
                   "y": 143
                },
-               "id": 59,
+               "id": 60,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4600,15 +4690,105 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 3,
+               "description": "«Level 0» (L0) memory area in bytes. L0 is the area that\nvinyl can use for in-memory storage of an LSM tree.\nBy monitoring this metric, you can see when L0 is getting\nclose to its maximum (tnt_vinyl_regulator_dump_watermark),\nat which time a dump will occur. You can expect L0 = 0\nimmediately after the dump operation is completed.\n\nPanel works with `metrics >= 0.8.0`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 151
+               },
+               "id": 61,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_vinyl_memory_level0{job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Level 0 memory",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "${DS_PROMETHEUS}",
+               "decimals": 3,
                "description": "The maximum amount of memory used for in-memory storing of a vinyl LSM tree.\nWhen accessing this maximum, the dumping must occur.\nFor details, see https://www.tarantool.io/en/doc/latest/book/box/engines/#engines-algorithm-filling-lsm.\nThe value is slightly smaller than the amount of memory allocated for vinyl trees,\nwhich is the `vinyl_memory` parameter.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 0,
+                  "w": 8,
+                  "x": 8,
                   "y": 151
                },
-               "id": 60,
+               "id": 62,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4694,11 +4874,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 151
                },
-               "id": 61,
+               "id": 63,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4788,7 +4968,7 @@
                   "x": 0,
                   "y": 159
                },
-               "id": 62,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4878,7 +5058,7 @@
                   "x": 6,
                   "y": 159
                },
-               "id": 63,
+               "id": 65,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4968,7 +5148,7 @@
                   "x": 12,
                   "y": 159
                },
-               "id": 64,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5058,7 +5238,7 @@
                   "x": 18,
                   "y": 159
                },
-               "id": 65,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5148,7 +5328,7 @@
                   "x": 0,
                   "y": 167
                },
-               "id": 66,
+               "id": 68,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5238,7 +5418,7 @@
                   "x": 6,
                   "y": 167
                },
-               "id": 67,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5328,7 +5508,7 @@
                   "x": 12,
                   "y": 167
                },
-               "id": 68,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5418,7 +5598,7 @@
                   "x": 18,
                   "y": 167
                },
-               "id": 69,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5511,7 +5691,7 @@
             "x": 0,
             "y": 175
          },
-         "id": 70,
+         "id": 72,
          "panels": [
             {
                "aliasColors": { },
@@ -5528,7 +5708,7 @@
                   "x": 0,
                   "y": 176
                },
-               "id": 71,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5618,7 +5798,7 @@
                   "x": 12,
                   "y": 176
                },
-               "id": 72,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5711,7 +5891,7 @@
             "x": 0,
             "y": 184
          },
-         "id": 73,
+         "id": 75,
          "panels": [
             {
                "aliasColors": { },
@@ -5728,7 +5908,7 @@
                   "x": 0,
                   "y": 185
                },
-               "id": 74,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5818,7 +5998,7 @@
                   "x": 8,
                   "y": 185
                },
-               "id": 75,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5908,7 +6088,7 @@
                   "x": 16,
                   "y": 185
                },
-               "id": 76,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5998,7 +6178,7 @@
                   "x": 0,
                   "y": 193
                },
-               "id": 77,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6088,7 +6268,7 @@
                   "x": 12,
                   "y": 193
                },
-               "id": 78,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6178,7 +6358,7 @@
                   "x": 0,
                   "y": 201
                },
-               "id": 79,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6268,7 +6448,7 @@
                   "x": 8,
                   "y": 201
                },
-               "id": 80,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6358,7 +6538,7 @@
                   "x": 16,
                   "y": 201
                },
-               "id": 81,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6451,7 +6631,7 @@
             "x": 0,
             "y": 209
          },
-         "id": 82,
+         "id": 84,
          "panels": [
             {
                "aliasColors": { },
@@ -6468,7 +6648,7 @@
                   "x": 0,
                   "y": 210
                },
-               "id": 83,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6558,7 +6738,7 @@
                   "x": 6,
                   "y": 210
                },
-               "id": 84,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6648,7 +6828,7 @@
                   "x": 12,
                   "y": 210
                },
-               "id": 85,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6738,7 +6918,7 @@
                   "x": 18,
                   "y": 210
                },
-               "id": 86,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6828,7 +7008,7 @@
                   "x": 0,
                   "y": 218
                },
-               "id": 87,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6918,7 +7098,7 @@
                   "x": 12,
                   "y": 218
                },
-               "id": 88,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7008,7 +7188,7 @@
                   "x": 0,
                   "y": 226
                },
-               "id": 89,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7098,7 +7278,7 @@
                   "x": 8,
                   "y": 226
                },
-               "id": 90,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7188,7 +7368,7 @@
                   "x": 16,
                   "y": 226
                },
-               "id": 91,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7278,7 +7458,7 @@
                   "x": 0,
                   "y": 234
                },
-               "id": 92,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7368,7 +7548,7 @@
                   "x": 8,
                   "y": 234
                },
-               "id": 93,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7458,7 +7638,7 @@
                   "x": 16,
                   "y": 234
                },
-               "id": 94,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7548,7 +7728,7 @@
                   "x": 0,
                   "y": 242
                },
-               "id": 95,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7638,7 +7818,7 @@
                   "x": 6,
                   "y": 242
                },
-               "id": 96,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7728,7 +7908,7 @@
                   "x": 12,
                   "y": 242
                },
-               "id": 97,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7818,7 +7998,7 @@
                   "x": 18,
                   "y": 242
                },
-               "id": 98,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7908,7 +8088,7 @@
                   "x": 0,
                   "y": 250
                },
-               "id": 99,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7998,7 +8178,7 @@
                   "x": 8,
                   "y": 250
                },
-               "id": 100,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8088,7 +8268,7 @@
                   "x": 16,
                   "y": 250
                },
-               "id": 101,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8181,7 +8361,7 @@
             "x": 0,
             "y": 258
          },
-         "id": 102,
+         "id": 104,
          "panels": [
             {
                "aliasColors": { },
@@ -8198,7 +8378,7 @@
                   "x": 0,
                   "y": 259
                },
-               "id": 103,
+               "id": 105,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8288,7 +8468,7 @@
                   "x": 8,
                   "y": 259
                },
-               "id": 104,
+               "id": 106,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8378,7 +8558,7 @@
                   "x": 16,
                   "y": 259
                },
-               "id": 105,
+               "id": 107,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8468,7 +8648,7 @@
                   "x": 0,
                   "y": 267
                },
-               "id": 106,
+               "id": 108,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8558,7 +8738,7 @@
                   "x": 8,
                   "y": 267
                },
-               "id": 107,
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8648,7 +8828,7 @@
                   "x": 16,
                   "y": 267
                },
-               "id": 108,
+               "id": 110,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8738,7 +8918,7 @@
                   "x": 0,
                   "y": 275
                },
-               "id": 109,
+               "id": 111,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8828,7 +9008,7 @@
                   "x": 8,
                   "y": 275
                },
-               "id": 110,
+               "id": 112,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8918,7 +9098,7 @@
                   "x": 16,
                   "y": 275
                },
-               "id": 111,
+               "id": 113,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9008,7 +9188,7 @@
                   "x": 0,
                   "y": 283
                },
-               "id": 112,
+               "id": 114,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9098,7 +9278,7 @@
                   "x": 8,
                   "y": 283
                },
-               "id": 113,
+               "id": 115,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9188,7 +9368,7 @@
                   "x": 16,
                   "y": 283
                },
-               "id": 114,
+               "id": 116,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9281,7 +9461,7 @@
             "x": 0,
             "y": 291
          },
-         "id": 115,
+         "id": 117,
          "panels": [
             {
                "aliasColors": { },
@@ -9298,7 +9478,7 @@
                   "x": 0,
                   "y": 292
                },
-               "id": 116,
+               "id": 118,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9388,7 +9568,7 @@
                   "x": 6,
                   "y": 292
                },
-               "id": 117,
+               "id": 119,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9478,7 +9658,7 @@
                   "x": 12,
                   "y": 292
                },
-               "id": 118,
+               "id": 120,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9568,7 +9748,7 @@
                   "x": 18,
                   "y": 292
                },
-               "id": 119,
+               "id": 121,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9658,7 +9838,7 @@
                   "x": 0,
                   "y": 300
                },
-               "id": 120,
+               "id": 122,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9748,7 +9928,7 @@
                   "x": 8,
                   "y": 300
                },
-               "id": 121,
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9838,7 +10018,7 @@
                   "x": 16,
                   "y": 300
                },
-               "id": 122,
+               "id": 124,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9928,7 +10108,7 @@
                   "x": 0,
                   "y": 308
                },
-               "id": 123,
+               "id": 125,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10018,7 +10198,7 @@
                   "x": 6,
                   "y": 308
                },
-               "id": 124,
+               "id": 126,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10108,7 +10288,7 @@
                   "x": 12,
                   "y": 308
                },
-               "id": 125,
+               "id": 127,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10198,7 +10378,7 @@
                   "x": 18,
                   "y": 308
                },
-               "id": 126,
+               "id": 128,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10288,7 +10468,7 @@
                   "x": 0,
                   "y": 316
                },
-               "id": 127,
+               "id": 129,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10378,7 +10558,7 @@
                   "x": 6,
                   "y": 316
                },
-               "id": 128,
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10468,7 +10648,7 @@
                   "x": 12,
                   "y": 316
                },
-               "id": 129,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10558,7 +10738,7 @@
                   "x": 18,
                   "y": 316
                },
-               "id": 130,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10648,7 +10828,7 @@
                   "x": 0,
                   "y": 324
                },
-               "id": 131,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10738,7 +10918,7 @@
                   "x": 6,
                   "y": 324
                },
-               "id": 132,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10828,7 +11008,7 @@
                   "x": 12,
                   "y": 324
                },
-               "id": 133,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10918,7 +11098,7 @@
                   "x": 18,
                   "y": 324
                },
-               "id": 134,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11008,7 +11188,7 @@
                   "x": 0,
                   "y": 332
                },
-               "id": 135,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11098,7 +11278,7 @@
                   "x": 6,
                   "y": 332
                },
-               "id": 136,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11188,7 +11368,7 @@
                   "x": 12,
                   "y": 332
                },
-               "id": 137,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11278,7 +11458,7 @@
                   "x": 18,
                   "y": 332
                },
-               "id": 138,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11368,7 +11548,7 @@
                   "x": 0,
                   "y": 340
                },
-               "id": 139,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11458,7 +11638,7 @@
                   "x": 6,
                   "y": 340
                },
-               "id": 140,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11548,7 +11728,7 @@
                   "x": 12,
                   "y": 340
                },
-               "id": 141,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11638,7 +11818,7 @@
                   "x": 18,
                   "y": 340
                },
-               "id": 142,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11728,7 +11908,7 @@
                   "x": 0,
                   "y": 348
                },
-               "id": 143,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11818,7 +11998,7 @@
                   "x": 6,
                   "y": 348
                },
-               "id": 144,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11908,7 +12088,7 @@
                   "x": 12,
                   "y": 348
                },
-               "id": 145,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11998,7 +12178,7 @@
                   "x": 18,
                   "y": 348
                },
-               "id": 146,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12088,7 +12268,7 @@
                   "x": 0,
                   "y": 356
                },
-               "id": 147,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12178,7 +12358,7 @@
                   "x": 6,
                   "y": 356
                },
-               "id": 148,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12268,7 +12448,7 @@
                   "x": 12,
                   "y": 356
                },
-               "id": 149,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12358,7 +12538,7 @@
                   "x": 18,
                   "y": 356
                },
-               "id": 150,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12448,7 +12628,7 @@
                   "x": 0,
                   "y": 364
                },
-               "id": 151,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12538,7 +12718,7 @@
                   "x": 6,
                   "y": 364
                },
-               "id": 152,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12628,7 +12808,7 @@
                   "x": 12,
                   "y": 364
                },
-               "id": 153,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12718,7 +12898,7 @@
                   "x": 18,
                   "y": 364
                },
-               "id": 154,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12808,7 +12988,7 @@
                   "x": 0,
                   "y": 372
                },
-               "id": 155,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12898,7 +13078,7 @@
                   "x": 6,
                   "y": 372
                },
-               "id": 156,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12988,7 +13168,7 @@
                   "x": 12,
                   "y": 372
                },
-               "id": 157,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13078,7 +13258,7 @@
                   "x": 18,
                   "y": 372
                },
-               "id": 158,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13168,7 +13348,7 @@
                   "x": 0,
                   "y": 380
                },
-               "id": 159,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13258,7 +13438,7 @@
                   "x": 6,
                   "y": 380
                },
-               "id": 160,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13348,7 +13528,7 @@
                   "x": 12,
                   "y": 380
                },
-               "id": 161,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13438,7 +13618,7 @@
                   "x": 18,
                   "y": 380
                },
-               "id": 162,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13528,7 +13708,7 @@
                   "x": 0,
                   "y": 388
                },
-               "id": 163,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13618,7 +13798,7 @@
                   "x": 6,
                   "y": 388
                },
-               "id": 164,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13708,7 +13888,7 @@
                   "x": 12,
                   "y": 388
                },
-               "id": 165,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13798,7 +13978,7 @@
                   "x": 18,
                   "y": 388
                },
-               "id": 166,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13888,7 +14068,7 @@
                   "x": 0,
                   "y": 396
                },
-               "id": 167,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13978,7 +14158,7 @@
                   "x": 6,
                   "y": 396
                },
-               "id": 168,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14068,7 +14248,7 @@
                   "x": 12,
                   "y": 396
                },
-               "id": 169,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14158,7 +14338,7 @@
                   "x": 18,
                   "y": 396
                },
-               "id": 170,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14248,7 +14428,7 @@
                   "x": 0,
                   "y": 404
                },
-               "id": 171,
+               "id": 173,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14338,7 +14518,7 @@
                   "x": 6,
                   "y": 404
                },
-               "id": 172,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14428,7 +14608,7 @@
                   "x": 12,
                   "y": 404
                },
-               "id": 173,
+               "id": 175,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14518,7 +14698,7 @@
                   "x": 18,
                   "y": 404
                },
-               "id": 174,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14611,7 +14791,7 @@
             "x": 0,
             "y": 412
          },
-         "id": 175,
+         "id": 177,
          "panels": [
             {
                "aliasColors": { },
@@ -14628,7 +14808,7 @@
                   "x": 0,
                   "y": 413
                },
-               "id": 176,
+               "id": 178,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14718,7 +14898,7 @@
                   "x": 12,
                   "y": 413
                },
-               "id": 177,
+               "id": 179,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14808,7 +14988,7 @@
                   "x": 0,
                   "y": 421
                },
-               "id": 178,
+               "id": 180,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14898,7 +15078,7 @@
                   "x": 12,
                   "y": 421
                },
-               "id": 179,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14991,7 +15171,7 @@
             "x": 0,
             "y": 429
          },
-         "id": 180,
+         "id": 182,
          "panels": [
             {
                "aliasColors": { },
@@ -15008,7 +15188,7 @@
                   "x": 0,
                   "y": 430
                },
-               "id": 181,
+               "id": 183,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15098,7 +15278,7 @@
                   "x": 0,
                   "y": 436
                },
-               "id": 182,
+               "id": 184,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15188,7 +15368,7 @@
                   "x": 12,
                   "y": 436
                },
-               "id": 183,
+               "id": 185,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_with_custom_panels_compiled.json
+++ b/tests/Prometheus/dashboard_with_custom_panels_compiled.json
@@ -4150,7 +4150,7 @@
                "dashes": false,
                "datasource": "${DS_PROMETHEUS}",
                "decimals": 3,
-               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n",
+               "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,


### PR DESCRIPTION
Merge after #170

Before this patch, the code had `tnt_vinyl_memory_tuple_cache` and `tnt_vinyl_memory_level0` panels, but they weren't added to any dashboard. This patch fixes this behavior and adds "Tuples cache memory" and "Level 0 memory" panels to vinyl section.

![image](https://user-images.githubusercontent.com/20455996/182124012-cb142dcf-0f41-4ec9-9231-28c4c33f5aff.png)
![image](https://user-images.githubusercontent.com/20455996/182124029-ddbb3b14-43b2-4488-8225-615dcc034534.png)


Closes #154