### PR TITLE
dashboard: use fill(null) in InfluxQL requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set default Prometheus job to `tarantool`
 - Set default InfluxDB measurement to `tarantool_http`
 - Use in-built `$__rate_interval` instead of user-defined `$rate_time_range`
+- Use `fill(null)` in InfluxQL requests
 
 
 ## [1.3.0] - 2022-06-29

--- a/dashboard/panels/cluster.libsonnet
+++ b/dashboard/panels/cluster.libsonnet
@@ -342,6 +342,7 @@ local prometheus = grafana.prometheus;
         measurement=measurement,
         group_tags=['label_pairs_alias'],
         alias='$tag_label_pairs_alias',
+        fill='null',
       ).where('metric_name', '=', 'tnt_cartridge_issues').where('label_pairs_level', '=', level)
       .selectField('value').addConverter('last')
   ),
@@ -437,6 +438,7 @@ local prometheus = grafana.prometheus;
         measurement=measurement,
         group_tags=['label_pairs_alias', 'label_pairs_stream', 'label_pairs_id'],
         alias='$tag_label_pairs_alias $tag_label_pairs_stream ($tag_label_pairs_id)',
+        fill='null',
       ).where('metric_name', '=', 'tnt_replication_status')
       .selectField('value').addConverter('last')
   ),
@@ -513,6 +515,7 @@ local prometheus = grafana.prometheus;
         measurement=measurement,
         group_tags=['label_pairs_alias', 'label_pairs_id'],
         alias='$tag_label_pairs_alias ($tag_label_pairs_id)',
+        fill='null',
       ).where('metric_name', '=', 'tnt_replication_lag')
       .selectField('value').addConverter('mean')
   ),
@@ -554,6 +557,7 @@ local prometheus = grafana.prometheus;
         measurement=measurement,
         group_tags=['label_pairs_alias', 'label_pairs_delta'],
         alias='$tag_label_pairs_alias ($tag_label_pairs_delta)',
+        fill='null',
       ).where('metric_name', '=', 'tnt_clock_delta')
       .selectField('value').addConverter('last')
   ),

--- a/dashboard/panels/common.libsonnet
+++ b/dashboard/panels/common.libsonnet
@@ -66,6 +66,7 @@ local prometheus = grafana.prometheus;
         measurement=measurement,
         group_tags=['label_pairs_alias'],
         alias='$tag_label_pairs_alias',
+        fill='null',
       ).where('metric_name', '=', metric_name)
       .selectField('value').addConverter(converter),
 
@@ -88,6 +89,7 @@ local prometheus = grafana.prometheus;
         measurement=measurement,
         group_tags=['label_pairs_alias'],
         alias='$tag_label_pairs_alias',
+        fill='null',
       ).where('metric_name', '=', metric_name)
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s']),
 

--- a/dashboard/panels/crud.libsonnet
+++ b/dashboard/panels/crud.libsonnet
@@ -68,6 +68,7 @@ local operation_rps_template(
       measurement=measurement,
       group_tags=['label_pairs_alias', 'label_pairs_name'],
       alias='$tag_label_pairs_alias — $tag_label_pairs_name',
+      fill='null',
     ).where('metric_name', '=', 'tnt_crud_stats_count')
     .where('label_pairs_operation', '=', operation)
     .where('label_pairs_status', '=', status)
@@ -115,6 +116,7 @@ local operation_latency_template(
       measurement=measurement,
       group_tags=['label_pairs_alias', 'label_pairs_name'],
       alias='$tag_label_pairs_alias — $tag_label_pairs_name',
+      fill='null',
     ).where('metric_name', '=', 'tnt_crud_stats')
     .where('label_pairs_operation', '=', operation)
     .where('label_pairs_status', '=', status)
@@ -634,6 +636,7 @@ local module = {
         measurement=measurement,
         group_tags=['label_pairs_alias', 'label_pairs_name'],
         alias='$tag_label_pairs_alias — $tag_label_pairs_name',
+        fill='null',
       ).where('metric_name', '=', 'tnt_crud_map_reduces')
       .where('label_pairs_operation', '=', 'select')
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s'])

--- a/dashboard/panels/expirationd.libsonnet
+++ b/dashboard/panels/expirationd.libsonnet
@@ -30,6 +30,7 @@ local prometheus = grafana.prometheus;
           'label_pairs_name',
         ],
         alias='$tag_label_pairs_name — $tag_label_pairs_alias',
+        fill='null',
       ).where('metric_name', '=', metric_name)
       .selectField('value').addConverter('mean'),
 
@@ -55,6 +56,7 @@ local prometheus = grafana.prometheus;
           'label_pairs_name',
         ],
         alias='$tag_label_pairs_name — $tag_label_pairs_alias',
+        fill='null',
       ).where('metric_name', '=', metric_name)
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s']),
 

--- a/dashboard/panels/http.libsonnet
+++ b/dashboard/panels/http.libsonnet
@@ -37,6 +37,7 @@ local prometheus = grafana.prometheus;
         measurement=measurement,
         group_tags=['label_pairs_alias', 'label_pairs_path', 'label_pairs_method', 'label_pairs_status'],
         alias='$tag_label_pairs_alias — $tag_label_pairs_method $tag_label_pairs_path (code $tag_label_pairs_status)',
+        fill='null',
       ).where('metric_name', '=', metric_name).where('label_pairs_status', '=~', std.format('/%s/', status_regex))
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s'])
   ),
@@ -144,6 +145,7 @@ local prometheus = grafana.prometheus;
         measurement=measurement,
         group_tags=['label_pairs_alias', 'label_pairs_path', 'label_pairs_method', 'label_pairs_status'],
         alias='$tag_label_pairs_alias — $tag_label_pairs_method $tag_label_pairs_path (code $tag_label_pairs_status)',
+        fill='null',
       ).where('metric_name', '=', metric_name).where('label_pairs_quantile', '=', quantile)
       .where('label_pairs_status', '=~', std.format('/%s/', status_regex)).selectField('value').addConverter('mean')
   ),

--- a/dashboard/panels/operations.libsonnet
+++ b/dashboard/panels/operations.libsonnet
@@ -37,6 +37,7 @@ local prometheus = grafana.prometheus;
         measurement=measurement,
         group_tags=['label_pairs_alias'],
         alias='$tag_label_pairs_alias',
+        fill='null',
       ).where('metric_name', '=', 'tnt_stats_op_total').where('label_pairs_operation', '=', operation)
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s'])
   ),

--- a/dashboard/panels/space.libsonnet
+++ b/dashboard/panels/space.libsonnet
@@ -40,6 +40,7 @@ local prometheus = grafana.prometheus;
         measurement=measurement,
         group_tags=['label_pairs_alias', 'label_pairs_name'],
         alias='$tag_label_pairs_alias — $tag_label_pairs_name',
+        fill='null',
       ).where('metric_name', '=', metric_name).where('label_pairs_engine', '=', engine)
       .selectField('value').addConverter('last')
   ),
@@ -125,6 +126,7 @@ local prometheus = grafana.prometheus;
         measurement=measurement,
         group_tags=['label_pairs_alias', 'label_pairs_name'],
         alias='$tag_label_pairs_alias — $tag_label_pairs_name',
+        fill='null',
       ).where('metric_name', '=', metric_name).where('label_pairs_engine', '=', 'memtx')
       .selectField('value').addConverter('mean')
   ),
@@ -194,6 +196,7 @@ local prometheus = grafana.prometheus;
         measurement=measurement,
         group_tags=['label_pairs_alias', 'label_pairs_name', 'label_pairs_index_name'],
         alias='$tag_label_pairs_alias — $tag_label_pairs_name ($tag_label_pairs_index_name)',
+        fill='null',
       ).where('metric_name', '=', 'tnt_space_index_bsize')
       .selectField('value').addConverter('mean')
   ),

--- a/dashboard/panels/tdg/expirationd.libsonnet
+++ b/dashboard/panels/tdg/expirationd.libsonnet
@@ -30,6 +30,7 @@ local prometheus = grafana.prometheus;
           'label_pairs_name',
         ],
         alias='$tag_label_pairs_name — $tag_label_pairs_alias',
+        fill='null',
       ).where('metric_name', '=', metric_name)
       .selectField('value').addConverter('mean'),
 
@@ -55,6 +56,7 @@ local prometheus = grafana.prometheus;
           'label_pairs_name',
         ],
         alias='$tag_label_pairs_name — $tag_label_pairs_alias',
+        fill='null',
       ).where('metric_name', '=', metric_name)
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s']),
 

--- a/dashboard/panels/tdg/file_connectors.libsonnet
+++ b/dashboard/panels/tdg/file_connectors.libsonnet
@@ -30,6 +30,7 @@ local prometheus = grafana.prometheus;
           'label_pairs_connector_name',
         ],
         alias='$tag_label_pairs_connector_name — $tag_label_pairs_alias',
+        fill='null',
       ).where('metric_name', '=', metric_name)
       .selectField('value').addConverter('mean'),
 

--- a/dashboard/panels/tdg/graphql.libsonnet
+++ b/dashboard/panels/tdg/graphql.libsonnet
@@ -33,6 +33,7 @@ local prometheus = grafana.prometheus;
           'label_pairs_entity',
         ],
         alias='$tag_label_pairs_operation_name ($tag_label_pairs_schema, $tag_label_pairs_entity) — $tag_label_pairs_alias',
+        fill='null',
       ).where('metric_name', '=', metric_name)
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s']),
 
@@ -69,7 +70,7 @@ local prometheus = grafana.prometheus;
           (SELECT "value" as "%(metric_name_count)s" FROM %(policy_prefix)s"%(measurement)s"
           WHERE ("metric_name" = '%(metric_name_count)s') AND $timeFilter)
           GROUP BY time($__interval), "label_pairs_alias", "label_pairs_operation_name",
-          "label_pairs_schema", "label_pairs_entity" fill(none)
+          "label_pairs_schema", "label_pairs_entity" fill(null)
         |||, {
           metric_name_sum: std.join('_', [metric_name, 'sum']),
           metric_name_count: std.join('_', [metric_name, 'count']),

--- a/dashboard/panels/tdg/iproto.libsonnet
+++ b/dashboard/panels/tdg/iproto.libsonnet
@@ -53,6 +53,7 @@ local prometheus = grafana.prometheus;
           'label_pairs_type',
         ],
         alias='$tag_label_pairs_type — $tag_label_pairs_alias',
+        fill='null',
       ).where('metric_name', '=', metric_name)
       .where('label_pairs_method', '=', std.format('repository.%s', method_tail))
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s']),
@@ -102,6 +103,7 @@ local prometheus = grafana.prometheus;
           'label_pairs_type',
         ],
         alias='$tag_label_pairs_type — $tag_label_pairs_alias',
+        fill='null',
       ).where('metric_name', '=', metric_name)
       .where('label_pairs_method', '=', std.format('repository.%s', method_tail))
       .where('label_pairs_quantile', '=', '0.99')

--- a/dashboard/panels/tdg/kafka/brokers.libsonnet
+++ b/dashboard/panels/tdg/kafka/brokers.libsonnet
@@ -33,6 +33,7 @@ local prometheus = grafana.prometheus;
           'label_pairs_broker_name',
         ],
         alias='$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)',
+        fill='null',
       ).where('metric_name', '=', metric_name)
       .selectField('value').addConverter('mean'),
 
@@ -61,6 +62,7 @@ local prometheus = grafana.prometheus;
           'label_pairs_broker_name',
         ],
         alias='$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)',
+        fill='null',
       ).where('metric_name', '=', metric_name)
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s']),
 
@@ -89,6 +91,7 @@ local prometheus = grafana.prometheus;
           'label_pairs_broker_name',
         ],
         alias='$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)',
+        fill='null',
       ).where('metric_name', '=', metric_name).where('label_pairs_quantile', '=', '0.99')
       .selectField('value').addConverter('last'),
 
@@ -620,6 +623,7 @@ local prometheus = grafana.prometheus;
           'label_pairs_request',
         ],
         alias='$tag_label_pairs_request — $tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)',
+        fill='null',
       ).where('metric_name', '=', 'tdg_kafka_broker_req')
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s']),
   ),

--- a/dashboard/panels/tdg/kafka/topics.libsonnet
+++ b/dashboard/panels/tdg/kafka/topics.libsonnet
@@ -33,6 +33,7 @@ local prometheus = grafana.prometheus;
           'label_pairs_topic',
         ],
         alias='$tag_label_pairs_name ($tag_label_pairs_topic) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)',
+        fill='null',
       ).where('metric_name', '=', metric_name)
       .selectField('value').addConverter('mean'),
 
@@ -61,6 +62,7 @@ local prometheus = grafana.prometheus;
           'label_pairs_partition',
         ],
         alias='$tag_label_pairs_name ($tag_label_pairs_topic, $tag_label_pairs_partition) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)',
+        fill='null',
       ).where('metric_name', '=', metric_name)
       .selectField('value').addConverter('mean'),
 
@@ -90,6 +92,7 @@ local prometheus = grafana.prometheus;
           'label_pairs_partition',
         ],
         alias='$tag_label_pairs_name ($tag_label_pairs_topic, $tag_label_pairs_partition) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)',
+        fill='null',
       ).where('metric_name', '=', metric_name)
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s']),
 
@@ -118,6 +121,7 @@ local prometheus = grafana.prometheus;
           'label_pairs_topic',
         ],
         alias='$tag_label_pairs_name ($tag_label_pairs_topic) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)',
+        fill='null',
       ).where('metric_name', '=', metric_name).where('label_pairs_quantile', '=', '0.99')
       .selectField('value').addConverter('last'),
 

--- a/dashboard/panels/tdg/kafka/utils.libsonnet
+++ b/dashboard/panels/tdg/kafka/utils.libsonnet
@@ -24,6 +24,7 @@ local prometheus = grafana.prometheus;
         measurement=measurement,
         group_tags=['label_pairs_alias', 'label_pairs_name', 'label_pairs_type', 'label_pairs_connector_name'],
         alias='$tag_label_pairs_name — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)',
+        fill='null',
       ).where('metric_name', '=', metric_name)
       .selectField('value').addConverter('mean'),
 
@@ -46,6 +47,7 @@ local prometheus = grafana.prometheus;
         measurement=measurement,
         group_tags=['label_pairs_alias', 'label_pairs_name', 'label_pairs_type', 'label_pairs_connector_name'],
         alias='$tag_label_pairs_name — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)',
+        fill='null',
       ).where('metric_name', '=', metric_name)
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s']),
 }

--- a/dashboard/panels/tdg/rest_api.libsonnet
+++ b/dashboard/panels/tdg/rest_api.libsonnet
@@ -47,6 +47,7 @@ local prometheus = grafana.prometheus;
           'label_pairs_method',
         ],
         alias='$tag_label_pairs_method $tag_label_pairs_type (code $tag_label_pairs_status_code) — $tag_label_pairs_alias',
+        fill='null',
       ).where('metric_name', '=', metric_name)
       .where('label_pairs_method', get_condition, 'GET')
       .where('label_pairs_status_code', '=~', std.format('/%s/', status_regex))
@@ -92,6 +93,7 @@ local prometheus = grafana.prometheus;
           'label_pairs_method',
         ],
         alias='$tag_label_pairs_method $tag_label_pairs_type (code $tag_label_pairs_status_code) — $tag_label_pairs_alias',
+        fill='null',
       ).where('metric_name', '=', metric_name)
       .where('label_pairs_method', get_condition, 'GET')
       .where('label_pairs_status_code', '=~', std.format('/%s/', status_regex))

--- a/dashboard/panels/tdg/tasks.libsonnet
+++ b/dashboard/panels/tdg/tasks.libsonnet
@@ -41,6 +41,7 @@ local prometheus = grafana.prometheus;
           'label_pairs_kind',
         ],
         alias='$tag_label_pairs_name — $tag_label_pairs_alias',
+        fill='null',
       ).where('metric_name', '=', metric_name)
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s']),
   ),
@@ -78,6 +79,7 @@ local prometheus = grafana.prometheus;
           'label_pairs_kind',
         ],
         alias='$tag_label_pairs_name — $tag_label_pairs_alias',
+        fill='null',
       ).where('metric_name', '=', metric_name)
       .selectField('value').addConverter('mean'),
   ),
@@ -124,7 +126,7 @@ local prometheus = grafana.prometheus;
           WHERE ("metric_name" = '%(metric_name_sum)s') AND $timeFilter),
           (SELECT "value" as "%(metric_name_count)s" FROM %(policy_prefix)s"%(measurement)s"
           WHERE ("metric_name" = '%(metric_name_count)s') AND $timeFilter)
-          GROUP BY time($__interval), "label_pairs_alias", "label_pairs_name" fill(none)
+          GROUP BY time($__interval), "label_pairs_alias", "label_pairs_name" fill(null)
         |||, {
           metric_name_sum: std.join('_', [metric_name, 'sum']),
           metric_name_count: std.join('_', [metric_name, 'count']),
@@ -167,6 +169,7 @@ local prometheus = grafana.prometheus;
           'label_pairs_kind',
         ],
         alias='$tag_label_pairs_name ($tag_label_pairs_kind) — $tag_label_pairs_alias',
+        fill='null',
       ).where('metric_name', '=', metric_name)
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s']),
   ),
@@ -204,6 +207,7 @@ local prometheus = grafana.prometheus;
           'label_pairs_kind',
         ],
         alias='$tag_label_pairs_name ($tag_label_pairs_kind) — $tag_label_pairs_alias',
+        fill='null',
       ).where('metric_name', '=', metric_name)
       .selectField('value').addConverter('mean'),
   ),
@@ -251,7 +255,7 @@ local prometheus = grafana.prometheus;
           (SELECT "value" as "%(metric_name_count)s" FROM %(policy_prefix)s"%(measurement)s"
           WHERE ("metric_name" = '%(metric_name_count)s') AND $timeFilter)
           GROUP BY time($__interval), "label_pairs_alias", "label_pairs_name",
-          "label_pairs_kind" fill(none)
+          "label_pairs_kind" fill(null)
         |||, {
           metric_name_sum: std.join('_', [metric_name, 'sum']),
           metric_name_count: std.join('_', [metric_name, 'count']),

--- a/dashboard/panels/tdg/tuples.libsonnet
+++ b/dashboard/panels/tdg/tuples.libsonnet
@@ -41,7 +41,7 @@ local prometheus = grafana.prometheus;
           WHERE ("metric_name" = '%(metric_name_sum)s') AND $timeFilter),
           (SELECT "value" as "%(metric_name_count)s" FROM %(policy_prefix)s"%(measurement)s"
           WHERE ("metric_name" = '%(metric_name_count)s') AND $timeFilter)
-          GROUP BY time($__interval), "label_pairs_alias", "label_pairs_type_name" fill(none)
+          GROUP BY time($__interval), "label_pairs_alias", "label_pairs_type_name" fill(null)
         |||, {
           metric_name_sum: std.join('_', [metric_name, 'sum']),
           metric_name_count: std.join('_', [metric_name, 'count']),

--- a/dashboard/panels/vinyl.libsonnet
+++ b/dashboard/panels/vinyl.libsonnet
@@ -590,6 +590,7 @@ local prometheus = grafana.prometheus;
         measurement=measurement,
         group_tags=['label_pairs_alias'],
         alias='$tag_label_pairs_alias',
+        fill='null',
       ).where('metric_name', '=', 'tnt_vinyl_scheduler_tasks').where('label_pairs_status', '=', 'inprogress')
       .selectField('value').addConverter('last')
   ),
@@ -627,6 +628,7 @@ local prometheus = grafana.prometheus;
         measurement=measurement,
         group_tags=['label_pairs_alias'],
         alias='$tag_label_pairs_alias',
+        fill='null',
       ).where('metric_name', '=', 'tnt_vinyl_scheduler_tasks').where('label_pairs_status', '=', 'failed')
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s'])
   ),

--- a/tests/InfluxDB/dashboard_compiled.json
+++ b/tests/InfluxDB/dashboard_compiled.json
@@ -138,7 +138,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -275,7 +275,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -478,7 +478,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -628,7 +628,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -729,7 +729,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -863,7 +863,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1030,7 +1030,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1191,7 +1191,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1352,7 +1352,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1513,7 +1513,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1674,7 +1674,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1835,7 +1835,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1998,7 +1998,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2129,7 +2129,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2266,7 +2266,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2403,7 +2403,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2540,7 +2540,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2671,7 +2671,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2808,7 +2808,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2939,7 +2939,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3076,7 +3076,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3207,7 +3207,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3344,7 +3344,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3509,7 +3509,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3640,7 +3640,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3771,7 +3771,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3902,7 +3902,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4033,7 +4033,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4164,7 +4164,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4295,7 +4295,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4426,7 +4426,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4557,7 +4557,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4714,7 +4714,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4857,7 +4857,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5000,7 +5000,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5149,7 +5149,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5286,7 +5286,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5443,7 +5443,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5574,7 +5574,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5705,7 +5705,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5836,7 +5836,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5967,7 +5967,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6098,7 +6098,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6229,7 +6229,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6360,7 +6360,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6491,7 +6491,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6622,7 +6622,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6753,7 +6753,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6884,7 +6884,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7021,7 +7021,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7158,7 +7158,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7295,7 +7295,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7426,7 +7426,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7563,7 +7563,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7706,7 +7706,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7843,7 +7843,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8000,7 +8000,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8137,7 +8137,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8294,7 +8294,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8425,7 +8425,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8556,7 +8556,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8687,7 +8687,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8818,7 +8818,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8949,7 +8949,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9080,7 +9080,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9211,7 +9211,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9362,7 +9362,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9499,7 +9499,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9636,7 +9636,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9773,7 +9773,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9904,7 +9904,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10041,7 +10041,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10178,7 +10178,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10315,7 +10315,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10452,7 +10452,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10589,7 +10589,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10726,7 +10726,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10863,7 +10863,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11000,7 +11000,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11131,7 +11131,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11262,7 +11262,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11393,7 +11393,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11524,7 +11524,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11655,7 +11655,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11792,7 +11792,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11949,7 +11949,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12092,7 +12092,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12235,7 +12235,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12378,7 +12378,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12521,7 +12521,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12664,7 +12664,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12807,7 +12807,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12950,7 +12950,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13093,7 +13093,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13236,7 +13236,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13379,7 +13379,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13522,7 +13522,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13691,7 +13691,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13846,7 +13846,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14001,7 +14001,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14156,7 +14156,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14525,7 +14525,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14674,7 +14674,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14829,7 +14829,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14984,7 +14984,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15139,7 +15139,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15294,7 +15294,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15449,7 +15449,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15604,7 +15604,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15759,7 +15759,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15914,7 +15914,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16069,7 +16069,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16224,7 +16224,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16379,7 +16379,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16534,7 +16534,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16689,7 +16689,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16844,7 +16844,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16999,7 +16999,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17154,7 +17154,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17309,7 +17309,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17464,7 +17464,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17619,7 +17619,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17774,7 +17774,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17929,7 +17929,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18084,7 +18084,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18239,7 +18239,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18394,7 +18394,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18549,7 +18549,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18704,7 +18704,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18859,7 +18859,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19014,7 +19014,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19169,7 +19169,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19324,7 +19324,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19479,7 +19479,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19634,7 +19634,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19789,7 +19789,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19944,7 +19944,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20099,7 +20099,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20254,7 +20254,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20409,7 +20409,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20564,7 +20564,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20719,7 +20719,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20874,7 +20874,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21029,7 +21029,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21184,7 +21184,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21339,7 +21339,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21494,7 +21494,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21649,7 +21649,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21804,7 +21804,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21959,7 +21959,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22114,7 +22114,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22269,7 +22269,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22424,7 +22424,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22579,7 +22579,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22754,7 +22754,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22897,7 +22897,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -23040,7 +23040,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -23177,7 +23177,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }

--- a/tests/InfluxDB/dashboard_static_compiled.json
+++ b/tests/InfluxDB/dashboard_static_compiled.json
@@ -115,7 +115,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -252,7 +252,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -455,7 +455,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -605,7 +605,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -706,7 +706,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -840,7 +840,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1007,7 +1007,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1168,7 +1168,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1329,7 +1329,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1490,7 +1490,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1651,7 +1651,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1812,7 +1812,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1975,7 +1975,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2106,7 +2106,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2243,7 +2243,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2380,7 +2380,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2517,7 +2517,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2648,7 +2648,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2785,7 +2785,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2916,7 +2916,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3053,7 +3053,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3184,7 +3184,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3321,7 +3321,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3486,7 +3486,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3617,7 +3617,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3748,7 +3748,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3879,7 +3879,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4010,7 +4010,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4141,7 +4141,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4272,7 +4272,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4403,7 +4403,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4534,7 +4534,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4691,7 +4691,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4834,7 +4834,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4977,7 +4977,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5126,7 +5126,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5263,7 +5263,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5420,7 +5420,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5551,7 +5551,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5682,7 +5682,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5813,7 +5813,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5944,7 +5944,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6075,7 +6075,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6206,7 +6206,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6337,7 +6337,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6468,7 +6468,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6599,7 +6599,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6730,7 +6730,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6861,7 +6861,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6998,7 +6998,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7135,7 +7135,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7272,7 +7272,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7403,7 +7403,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7540,7 +7540,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7683,7 +7683,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7820,7 +7820,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7977,7 +7977,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8114,7 +8114,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8271,7 +8271,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8402,7 +8402,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8533,7 +8533,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8664,7 +8664,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8795,7 +8795,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8926,7 +8926,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9057,7 +9057,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9188,7 +9188,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9339,7 +9339,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9476,7 +9476,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9613,7 +9613,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9750,7 +9750,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9881,7 +9881,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10018,7 +10018,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10155,7 +10155,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10292,7 +10292,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10429,7 +10429,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10566,7 +10566,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10703,7 +10703,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10840,7 +10840,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10977,7 +10977,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11108,7 +11108,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11239,7 +11239,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11370,7 +11370,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11501,7 +11501,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11632,7 +11632,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11769,7 +11769,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11926,7 +11926,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12069,7 +12069,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12212,7 +12212,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12355,7 +12355,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12498,7 +12498,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12641,7 +12641,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12784,7 +12784,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12927,7 +12927,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13070,7 +13070,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13213,7 +13213,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13356,7 +13356,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13499,7 +13499,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13668,7 +13668,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13823,7 +13823,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13978,7 +13978,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14133,7 +14133,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14502,7 +14502,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14651,7 +14651,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14806,7 +14806,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14961,7 +14961,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15116,7 +15116,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15271,7 +15271,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15426,7 +15426,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15581,7 +15581,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15736,7 +15736,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15891,7 +15891,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16046,7 +16046,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16201,7 +16201,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16356,7 +16356,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16511,7 +16511,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16666,7 +16666,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16821,7 +16821,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16976,7 +16976,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17131,7 +17131,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17286,7 +17286,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17441,7 +17441,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17596,7 +17596,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17751,7 +17751,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17906,7 +17906,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18061,7 +18061,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18216,7 +18216,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18371,7 +18371,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18526,7 +18526,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18681,7 +18681,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18836,7 +18836,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18991,7 +18991,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19146,7 +19146,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19301,7 +19301,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19456,7 +19456,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19611,7 +19611,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19766,7 +19766,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19921,7 +19921,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20076,7 +20076,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20231,7 +20231,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20386,7 +20386,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20541,7 +20541,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20696,7 +20696,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20851,7 +20851,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21006,7 +21006,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21161,7 +21161,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21316,7 +21316,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21471,7 +21471,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21626,7 +21626,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21781,7 +21781,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21936,7 +21936,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22091,7 +22091,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22246,7 +22246,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22401,7 +22401,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22556,7 +22556,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22731,7 +22731,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22874,7 +22874,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -23017,7 +23017,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -23154,7 +23154,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }

--- a/tests/InfluxDB/dashboard_tdg_compiled.json
+++ b/tests/InfluxDB/dashboard_tdg_compiled.json
@@ -138,7 +138,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -275,7 +275,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -478,7 +478,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -628,7 +628,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -729,7 +729,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -863,7 +863,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1012,7 +1012,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1143,7 +1143,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1280,7 +1280,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1417,7 +1417,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1554,7 +1554,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1685,7 +1685,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1822,7 +1822,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1953,7 +1953,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2090,7 +2090,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2221,7 +2221,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2358,7 +2358,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2523,7 +2523,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2654,7 +2654,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2785,7 +2785,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2916,7 +2916,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3047,7 +3047,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3178,7 +3178,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3309,7 +3309,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3440,7 +3440,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3571,7 +3571,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3728,7 +3728,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3871,7 +3871,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4014,7 +4014,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4163,7 +4163,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4300,7 +4300,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4457,7 +4457,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4588,7 +4588,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4719,7 +4719,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4850,7 +4850,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4981,7 +4981,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5112,7 +5112,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5243,7 +5243,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5374,7 +5374,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5505,7 +5505,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5636,7 +5636,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5767,7 +5767,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5898,7 +5898,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6035,7 +6035,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6172,7 +6172,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6309,7 +6309,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6440,7 +6440,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6577,7 +6577,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6720,7 +6720,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6857,7 +6857,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7014,7 +7014,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7151,7 +7151,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7606,7 +7606,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7737,7 +7737,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7868,7 +7868,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7999,7 +7999,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8130,7 +8130,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8261,7 +8261,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8392,7 +8392,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8523,7 +8523,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8674,7 +8674,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8811,7 +8811,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8948,7 +8948,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9085,7 +9085,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9216,7 +9216,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9353,7 +9353,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9490,7 +9490,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9627,7 +9627,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9764,7 +9764,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9901,7 +9901,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10038,7 +10038,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10175,7 +10175,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10312,7 +10312,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10443,7 +10443,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10574,7 +10574,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10705,7 +10705,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10836,7 +10836,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10967,7 +10967,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11104,7 +11104,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11261,7 +11261,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11404,7 +11404,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11547,7 +11547,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11690,7 +11690,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11833,7 +11833,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11976,7 +11976,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12119,7 +12119,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12262,7 +12262,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12405,7 +12405,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12548,7 +12548,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12691,7 +12691,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12834,7 +12834,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13015,7 +13015,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13164,7 +13164,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13313,7 +13313,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13462,7 +13462,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13617,7 +13617,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13772,7 +13772,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13927,7 +13927,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14082,7 +14082,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14237,7 +14237,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14392,7 +14392,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14547,7 +14547,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14728,7 +14728,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14883,7 +14883,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15044,7 +15044,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15205,7 +15205,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15366,7 +15366,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15521,7 +15521,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15676,7 +15676,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15831,7 +15831,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15986,7 +15986,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16147,7 +16147,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16308,7 +16308,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16469,7 +16469,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16630,7 +16630,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16785,7 +16785,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16946,7 +16946,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17107,7 +17107,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17268,7 +17268,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17429,7 +17429,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17590,7 +17590,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17745,7 +17745,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17912,7 +17912,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18073,7 +18073,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18234,7 +18234,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18395,7 +18395,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18556,7 +18556,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18737,7 +18737,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18892,7 +18892,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19047,7 +19047,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19208,7 +19208,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19375,7 +19375,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19536,7 +19536,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19697,7 +19697,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19858,7 +19858,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20019,7 +20019,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20180,7 +20180,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20341,7 +20341,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20508,7 +20508,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20675,7 +20675,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20842,7 +20842,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21009,7 +21009,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21176,7 +21176,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21345,7 +21345,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21494,7 +21494,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21643,7 +21643,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21798,7 +21798,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21967,7 +21967,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22116,7 +22116,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22273,7 +22273,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22416,7 +22416,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22559,7 +22559,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22696,7 +22696,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22847,7 +22847,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_scanned_tuples_sum\") / mean(\"tdg_scanned_tuples_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_scanned_tuples_sum\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_scanned_tuples_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_scanned_tuples_count\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_scanned_tuples_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_type_name\" fill(none)\n",
+                     "query": "SELECT mean(\"tdg_scanned_tuples_sum\") / mean(\"tdg_scanned_tuples_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_scanned_tuples_sum\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_scanned_tuples_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_scanned_tuples_count\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_scanned_tuples_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_type_name\" fill(null)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -22954,7 +22954,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_returned_tuples_sum\") / mean(\"tdg_returned_tuples_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_returned_tuples_sum\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_returned_tuples_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_returned_tuples_count\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_returned_tuples_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_type_name\" fill(none)\n",
+                     "query": "SELECT mean(\"tdg_returned_tuples_sum\") / mean(\"tdg_returned_tuples_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_returned_tuples_sum\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_returned_tuples_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_returned_tuples_count\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_returned_tuples_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_type_name\" fill(null)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -23061,7 +23061,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -23192,7 +23192,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -23349,7 +23349,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -23486,7 +23486,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -23623,7 +23623,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -23760,7 +23760,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -23897,7 +23897,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -24034,7 +24034,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -24203,7 +24203,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -24340,7 +24340,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_graphql_query_time_sum\") / mean(\"tdg_graphql_query_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_graphql_query_time_sum\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_graphql_query_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_graphql_query_time_count\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_graphql_query_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_operation_name\",\n\"label_pairs_schema\", \"label_pairs_entity\" fill(none)\n",
+                     "query": "SELECT mean(\"tdg_graphql_query_time_sum\") / mean(\"tdg_graphql_query_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_graphql_query_time_sum\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_graphql_query_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_graphql_query_time_count\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_graphql_query_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_operation_name\",\n\"label_pairs_schema\", \"label_pairs_entity\" fill(null)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -24465,7 +24465,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -24620,7 +24620,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -24757,7 +24757,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_graphql_mutation_time_sum\") / mean(\"tdg_graphql_mutation_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_graphql_mutation_time_sum\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_graphql_mutation_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_graphql_mutation_time_count\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_graphql_mutation_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_operation_name\",\n\"label_pairs_schema\", \"label_pairs_entity\" fill(none)\n",
+                     "query": "SELECT mean(\"tdg_graphql_mutation_time_sum\") / mean(\"tdg_graphql_mutation_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_graphql_mutation_time_sum\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_graphql_mutation_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_graphql_mutation_time_count\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_graphql_mutation_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_operation_name\",\n\"label_pairs_schema\", \"label_pairs_entity\" fill(null)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -24882,7 +24882,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -25045,7 +25045,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -25194,7 +25194,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -25343,7 +25343,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -25492,7 +25492,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -25641,7 +25641,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -25790,7 +25790,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -25939,7 +25939,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -26088,7 +26088,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -26237,7 +26237,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -26386,7 +26386,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -26535,7 +26535,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -26684,7 +26684,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -26833,7 +26833,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -26982,7 +26982,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -27131,7 +27131,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -27280,7 +27280,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -27429,7 +27429,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -27578,7 +27578,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -27759,7 +27759,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -27926,7 +27926,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -28093,7 +28093,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -28260,7 +28260,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -28427,7 +28427,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -28594,7 +28594,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -28761,7 +28761,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -28928,7 +28928,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -29095,7 +29095,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -29262,7 +29262,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -29429,7 +29429,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -29596,7 +29596,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -29777,7 +29777,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -29926,7 +29926,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -30075,7 +30075,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -30224,7 +30224,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -30355,7 +30355,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_jobs_execution_time_sum\") / mean(\"tdg_jobs_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_jobs_execution_time_sum\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_jobs_execution_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_jobs_execution_time_count\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_jobs_execution_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\" fill(none)\n",
+                     "query": "SELECT mean(\"tdg_jobs_execution_time_sum\") / mean(\"tdg_jobs_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_jobs_execution_time_sum\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_jobs_execution_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_jobs_execution_time_count\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_jobs_execution_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\" fill(null)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -30474,7 +30474,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -30623,7 +30623,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -30772,7 +30772,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -30921,7 +30921,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -31070,7 +31070,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -31201,7 +31201,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_tasks_execution_time_sum\") / mean(\"tdg_tasks_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_tasks_execution_time_sum\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_tasks_execution_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_tasks_execution_time_count\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_tasks_execution_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\",\n\"label_pairs_kind\" fill(none)\n",
+                     "query": "SELECT mean(\"tdg_tasks_execution_time_sum\") / mean(\"tdg_tasks_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_tasks_execution_time_sum\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_tasks_execution_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_tasks_execution_time_count\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_tasks_execution_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\",\n\"label_pairs_kind\" fill(null)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -31320,7 +31320,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -31469,7 +31469,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -31618,7 +31618,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -31767,7 +31767,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -31898,7 +31898,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_system_tasks_execution_time_sum\") / mean(\"tdg_system_tasks_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_system_tasks_execution_time_sum\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_system_tasks_execution_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_system_tasks_execution_time_count\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_system_tasks_execution_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\",\n\"label_pairs_kind\" fill(none)\n",
+                     "query": "SELECT mean(\"tdg_system_tasks_execution_time_sum\") / mean(\"tdg_system_tasks_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_system_tasks_execution_time_sum\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_system_tasks_execution_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_system_tasks_execution_time_count\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_system_tasks_execution_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\",\n\"label_pairs_kind\" fill(null)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",

--- a/tests/InfluxDB/dashboard_tdg_static_compiled.json
+++ b/tests/InfluxDB/dashboard_tdg_static_compiled.json
@@ -115,7 +115,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -252,7 +252,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -455,7 +455,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -605,7 +605,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -706,7 +706,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -840,7 +840,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -989,7 +989,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1120,7 +1120,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1257,7 +1257,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1394,7 +1394,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1531,7 +1531,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1662,7 +1662,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1799,7 +1799,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1930,7 +1930,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2067,7 +2067,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2198,7 +2198,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2335,7 +2335,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2500,7 +2500,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2631,7 +2631,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2762,7 +2762,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2893,7 +2893,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3024,7 +3024,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3155,7 +3155,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3286,7 +3286,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3417,7 +3417,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3548,7 +3548,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3705,7 +3705,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3848,7 +3848,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3991,7 +3991,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4140,7 +4140,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4277,7 +4277,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4434,7 +4434,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4565,7 +4565,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4696,7 +4696,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4827,7 +4827,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4958,7 +4958,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5089,7 +5089,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5220,7 +5220,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5351,7 +5351,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5482,7 +5482,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5613,7 +5613,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5744,7 +5744,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5875,7 +5875,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6012,7 +6012,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6149,7 +6149,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6286,7 +6286,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6417,7 +6417,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6554,7 +6554,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6697,7 +6697,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6834,7 +6834,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6991,7 +6991,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7128,7 +7128,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7583,7 +7583,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7714,7 +7714,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7845,7 +7845,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7976,7 +7976,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8107,7 +8107,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8238,7 +8238,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8369,7 +8369,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8500,7 +8500,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8651,7 +8651,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8788,7 +8788,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8925,7 +8925,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9062,7 +9062,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9193,7 +9193,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9330,7 +9330,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9467,7 +9467,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9604,7 +9604,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9741,7 +9741,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9878,7 +9878,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10015,7 +10015,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10152,7 +10152,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10289,7 +10289,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10420,7 +10420,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10551,7 +10551,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10682,7 +10682,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10813,7 +10813,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10944,7 +10944,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11081,7 +11081,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11238,7 +11238,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11381,7 +11381,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11524,7 +11524,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11667,7 +11667,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11810,7 +11810,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11953,7 +11953,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12096,7 +12096,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12239,7 +12239,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12382,7 +12382,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12525,7 +12525,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12668,7 +12668,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12811,7 +12811,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12992,7 +12992,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13141,7 +13141,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13290,7 +13290,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13439,7 +13439,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13594,7 +13594,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13749,7 +13749,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13904,7 +13904,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14059,7 +14059,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14214,7 +14214,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14369,7 +14369,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14524,7 +14524,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14705,7 +14705,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14860,7 +14860,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15021,7 +15021,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15182,7 +15182,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15343,7 +15343,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15498,7 +15498,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15653,7 +15653,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15808,7 +15808,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15963,7 +15963,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16124,7 +16124,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16285,7 +16285,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16446,7 +16446,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16607,7 +16607,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16762,7 +16762,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16923,7 +16923,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17084,7 +17084,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17245,7 +17245,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17406,7 +17406,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17567,7 +17567,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17722,7 +17722,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17889,7 +17889,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18050,7 +18050,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18211,7 +18211,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18372,7 +18372,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18533,7 +18533,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18714,7 +18714,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18869,7 +18869,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19024,7 +19024,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19185,7 +19185,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19352,7 +19352,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19513,7 +19513,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19674,7 +19674,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19835,7 +19835,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19996,7 +19996,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20157,7 +20157,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20318,7 +20318,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20485,7 +20485,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20652,7 +20652,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20819,7 +20819,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20986,7 +20986,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21153,7 +21153,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21322,7 +21322,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21471,7 +21471,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21620,7 +21620,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21775,7 +21775,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21944,7 +21944,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22093,7 +22093,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22250,7 +22250,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22393,7 +22393,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22536,7 +22536,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22673,7 +22673,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22824,7 +22824,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_scanned_tuples_sum\") / mean(\"tdg_scanned_tuples_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_scanned_tuples_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_scanned_tuples_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_scanned_tuples_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_scanned_tuples_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_type_name\" fill(none)\n",
+                     "query": "SELECT mean(\"tdg_scanned_tuples_sum\") / mean(\"tdg_scanned_tuples_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_scanned_tuples_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_scanned_tuples_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_scanned_tuples_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_scanned_tuples_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_type_name\" fill(null)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -22931,7 +22931,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_returned_tuples_sum\") / mean(\"tdg_returned_tuples_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_returned_tuples_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_returned_tuples_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_returned_tuples_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_returned_tuples_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_type_name\" fill(none)\n",
+                     "query": "SELECT mean(\"tdg_returned_tuples_sum\") / mean(\"tdg_returned_tuples_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_returned_tuples_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_returned_tuples_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_returned_tuples_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_returned_tuples_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_type_name\" fill(null)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -23038,7 +23038,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -23169,7 +23169,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -23326,7 +23326,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -23463,7 +23463,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -23600,7 +23600,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -23737,7 +23737,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -23874,7 +23874,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -24011,7 +24011,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -24180,7 +24180,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -24317,7 +24317,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_graphql_query_time_sum\") / mean(\"tdg_graphql_query_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_graphql_query_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_query_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_graphql_query_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_query_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_operation_name\",\n\"label_pairs_schema\", \"label_pairs_entity\" fill(none)\n",
+                     "query": "SELECT mean(\"tdg_graphql_query_time_sum\") / mean(\"tdg_graphql_query_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_graphql_query_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_query_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_graphql_query_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_query_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_operation_name\",\n\"label_pairs_schema\", \"label_pairs_entity\" fill(null)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -24442,7 +24442,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -24597,7 +24597,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -24734,7 +24734,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_graphql_mutation_time_sum\") / mean(\"tdg_graphql_mutation_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_graphql_mutation_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_mutation_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_graphql_mutation_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_mutation_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_operation_name\",\n\"label_pairs_schema\", \"label_pairs_entity\" fill(none)\n",
+                     "query": "SELECT mean(\"tdg_graphql_mutation_time_sum\") / mean(\"tdg_graphql_mutation_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_graphql_mutation_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_mutation_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_graphql_mutation_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_mutation_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_operation_name\",\n\"label_pairs_schema\", \"label_pairs_entity\" fill(null)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -24859,7 +24859,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -25022,7 +25022,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -25171,7 +25171,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -25320,7 +25320,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -25469,7 +25469,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -25618,7 +25618,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -25767,7 +25767,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -25916,7 +25916,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -26065,7 +26065,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -26214,7 +26214,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -26363,7 +26363,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -26512,7 +26512,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -26661,7 +26661,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -26810,7 +26810,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -26959,7 +26959,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -27108,7 +27108,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -27257,7 +27257,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -27406,7 +27406,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -27555,7 +27555,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -27736,7 +27736,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -27903,7 +27903,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -28070,7 +28070,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -28237,7 +28237,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -28404,7 +28404,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -28571,7 +28571,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -28738,7 +28738,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -28905,7 +28905,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -29072,7 +29072,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -29239,7 +29239,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -29406,7 +29406,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -29573,7 +29573,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -29754,7 +29754,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -29903,7 +29903,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -30052,7 +30052,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -30201,7 +30201,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -30332,7 +30332,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_jobs_execution_time_sum\") / mean(\"tdg_jobs_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_jobs_execution_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_jobs_execution_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_jobs_execution_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_jobs_execution_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\" fill(none)\n",
+                     "query": "SELECT mean(\"tdg_jobs_execution_time_sum\") / mean(\"tdg_jobs_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_jobs_execution_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_jobs_execution_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_jobs_execution_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_jobs_execution_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\" fill(null)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -30451,7 +30451,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -30600,7 +30600,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -30749,7 +30749,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -30898,7 +30898,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -31047,7 +31047,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -31178,7 +31178,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_tasks_execution_time_sum\") / mean(\"tdg_tasks_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_tasks_execution_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_tasks_execution_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_tasks_execution_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_tasks_execution_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\",\n\"label_pairs_kind\" fill(none)\n",
+                     "query": "SELECT mean(\"tdg_tasks_execution_time_sum\") / mean(\"tdg_tasks_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_tasks_execution_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_tasks_execution_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_tasks_execution_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_tasks_execution_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\",\n\"label_pairs_kind\" fill(null)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -31297,7 +31297,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -31446,7 +31446,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -31595,7 +31595,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -31744,7 +31744,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -31875,7 +31875,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_system_tasks_execution_time_sum\") / mean(\"tdg_system_tasks_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_system_tasks_execution_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_system_tasks_execution_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_system_tasks_execution_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_system_tasks_execution_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\",\n\"label_pairs_kind\" fill(none)\n",
+                     "query": "SELECT mean(\"tdg_system_tasks_execution_time_sum\") / mean(\"tdg_system_tasks_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_system_tasks_execution_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_system_tasks_execution_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_system_tasks_execution_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_system_tasks_execution_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\",\n\"label_pairs_kind\" fill(null)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",

--- a/tests/InfluxDB/dashboard_with_custom_panels.jsonnet
+++ b/tests/InfluxDB/dashboard_with_custom_panels.jsonnet
@@ -59,6 +59,7 @@ dashboard.addPanels([
       measurement=variable.influxdb.measurement,
       group_tags=['label_pairs_alias'],
       alias='$tag_label_pairs_alias',
+      fill='null',
     ).where('metric_name', '=', 'my_component_load_metric').where('label_pairs_quantile', '=', '0.99')
     .selectField('value').addConverter('mean')
   ),

--- a/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
+++ b/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
@@ -138,7 +138,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -275,7 +275,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -478,7 +478,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -628,7 +628,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -729,7 +729,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -863,7 +863,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1030,7 +1030,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1191,7 +1191,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1352,7 +1352,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1513,7 +1513,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1674,7 +1674,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1835,7 +1835,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -1998,7 +1998,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2129,7 +2129,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2266,7 +2266,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2403,7 +2403,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2540,7 +2540,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2671,7 +2671,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2808,7 +2808,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -2939,7 +2939,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3076,7 +3076,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3207,7 +3207,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3344,7 +3344,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3509,7 +3509,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3640,7 +3640,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3771,7 +3771,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -3902,7 +3902,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4033,7 +4033,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4164,7 +4164,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4295,7 +4295,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4426,7 +4426,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4557,7 +4557,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4714,7 +4714,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -4857,7 +4857,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5000,7 +5000,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5149,7 +5149,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5286,7 +5286,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5443,7 +5443,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5574,7 +5574,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5705,7 +5705,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5836,7 +5836,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -5967,7 +5967,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6098,7 +6098,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6229,7 +6229,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6360,7 +6360,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6491,7 +6491,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6622,7 +6622,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6753,7 +6753,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -6884,7 +6884,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7021,7 +7021,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7158,7 +7158,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7295,7 +7295,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7426,7 +7426,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7563,7 +7563,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7706,7 +7706,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -7843,7 +7843,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8000,7 +8000,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8137,7 +8137,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8294,7 +8294,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8425,7 +8425,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8556,7 +8556,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8687,7 +8687,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8818,7 +8818,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -8949,7 +8949,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9080,7 +9080,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9211,7 +9211,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9362,7 +9362,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9499,7 +9499,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9636,7 +9636,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9773,7 +9773,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -9904,7 +9904,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10041,7 +10041,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10178,7 +10178,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10315,7 +10315,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10452,7 +10452,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10589,7 +10589,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10726,7 +10726,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -10863,7 +10863,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11000,7 +11000,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11131,7 +11131,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11262,7 +11262,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11393,7 +11393,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11524,7 +11524,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11655,7 +11655,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11792,7 +11792,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -11949,7 +11949,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12092,7 +12092,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12235,7 +12235,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12378,7 +12378,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12521,7 +12521,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12664,7 +12664,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12807,7 +12807,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -12950,7 +12950,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13093,7 +13093,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13236,7 +13236,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13379,7 +13379,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13522,7 +13522,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13691,7 +13691,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -13846,7 +13846,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14001,7 +14001,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14156,7 +14156,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14525,7 +14525,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14674,7 +14674,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14829,7 +14829,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -14984,7 +14984,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15139,7 +15139,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15294,7 +15294,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15449,7 +15449,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15604,7 +15604,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15759,7 +15759,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -15914,7 +15914,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16069,7 +16069,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16224,7 +16224,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16379,7 +16379,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16534,7 +16534,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16689,7 +16689,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16844,7 +16844,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -16999,7 +16999,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17154,7 +17154,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17309,7 +17309,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17464,7 +17464,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17619,7 +17619,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17774,7 +17774,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -17929,7 +17929,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18084,7 +18084,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18239,7 +18239,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18394,7 +18394,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18549,7 +18549,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18704,7 +18704,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -18859,7 +18859,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19014,7 +19014,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19169,7 +19169,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19324,7 +19324,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19479,7 +19479,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19634,7 +19634,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19789,7 +19789,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -19944,7 +19944,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20099,7 +20099,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20254,7 +20254,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20409,7 +20409,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20564,7 +20564,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20719,7 +20719,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -20874,7 +20874,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21029,7 +21029,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21184,7 +21184,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21339,7 +21339,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21494,7 +21494,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21649,7 +21649,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21804,7 +21804,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -21959,7 +21959,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22114,7 +22114,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22269,7 +22269,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22424,7 +22424,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22579,7 +22579,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22754,7 +22754,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -22897,7 +22897,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -23040,7 +23040,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -23177,7 +23177,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -23328,7 +23328,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -23459,7 +23459,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }
@@ -23596,7 +23596,7 @@
                         },
                         {
                            "params": [
-                              "none"
+                              "null"
                            ],
                            "type": "fill"
                         }


### PR DESCRIPTION
This patch replaces fill(none) with fill(null) in dashboards InfluxQL requests. After this patch, all panels with non-derivative requests will show the gap in metrics for an interval if there were no metrics for this interval. Before this patch, they had displayed a straight line connecting border values in the area. Derivative requests will still display a straight line [1]. There is a workaround to make derivative requests result consistent with non-derivative one, but it makes query more complicated both in terms of readability and performance, so it's not worth it.

1. https://github.com/influxdata/influxdb/issues/7185

Closes #23