### PR TITLE
Dashboard defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Added
 - Options to build static dashboards
 
+## Changed
+- Set default Prometheus job to `tarantool`
+
 
 ## [1.3.0] - 2022-06-29
 Grafana revisions: [InfluxDB revision 13](https://grafana.com/api/dashboards/12567/revisions/13/download), [Prometheus revision 13](https://grafana.com/api/dashboards/13054/revisions/13/download), [InfluxDB TDG revision 2](https://grafana.com/api/dashboards/16405/revisions/2/download), [Prometheus TDG revision 2](https://grafana.com/api/dashboards/16406/revisions/2/download).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 - Set default Prometheus job to `tarantool`
+- Set default InfluxDB measurement to `tarantool_http`
 
 
 ## [1.3.0] - 2022-06-29

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+JOB ?= tarantool
 RATE_TIME_RANGE ?= 2m
 POLICY ?= autogen
 OUTPUT_STATIC_DASHBOARD ?= dashboard.json
@@ -14,10 +15,7 @@ ifndef DATASOURCE
 	@echo 1>&2 "DATASOURCE must be set"
 		false
 endif
-ifndef JOB
-	@echo 1>&2 "JOB must be set"
-		false
-endif
+	# JOB is optional, default is "tarantool"
 	# RATE_TIME_RANGE is optional, default is "2m"
 	jsonnet -J ./vendor -J . \
 		--ext-str DATASOURCE=${DATASOURCE} \

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 JOB ?= tarantool
 RATE_TIME_RANGE ?= 2m
 POLICY ?= autogen
+MEASUREMENT ?= tarantool_http
 OUTPUT_STATIC_DASHBOARD ?= dashboard.json
 
 .PHONY: build-deps
@@ -38,10 +39,7 @@ ifndef DATASOURCE
 		false
 endif
 	# POLICY is optional, default is "autogen"
-ifndef MEASUREMENT
-	@echo 1>&2 "MEASUREMENT must be set"
-		false
-endif
+	# MEASUREMENT is optional, default is "tarantool_http"
 	jsonnet -J ./vendor -J . \
 		--ext-str DATASOURCE=${DATASOURCE} \
 		--ext-str POLICY=${POLICY} \

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ To set up an InfluxDB dashboard for monitoring example app, use the following va
 
 To set up an Prometheus dashboard for monitoring example app, use the following variables:
 
-- `Job`: `tarantool_app`;
+- `Job`: `tarantool`;
 - `Rate time range`: `2m`.
 
 ### Monitoring local app
@@ -116,7 +116,7 @@ to install build dependencies and dependencies that are required to run tests lo
 
 To build a static dashboard with no input and dynamic variables, run `make` commands.
 ```bash
-make DATASOURCE=MyPrometheus JOB=MyApp \
+make DATASOURCE=Prometheus JOB=tarantool \
      OUTPUT_STATIC_DASHBOARD=mydashboard.json build-static-prometheus
 ```
 Following targets are available:
@@ -127,7 +127,7 @@ Following targets are available:
 
 Variables for Prometheus targets:
 - `DATASOURCE`: name of a Prometheus data source;
-- `JOB`: name of a Prometheus job collecting your application metrics;
+- `JOB` (optional, default `tarantool`): name of a Prometheus job collecting your application metrics;
 - `RATE_TIME_RANGE` (optional, default `2m`): rps computation rate time range;
 - `OUTPUT_STATIC_DASHBOARD` (optional, default `dashboard.json`): compiled dashboard file.
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can also interact with Prometheus at [localhost:9090](http://localhost:9090/
 
 To set up an InfluxDB dashboard for monitoring example app, use the following variables:
 
-- `Measurement`: `tarantool_app_http`;
+- `Measurement`: `tarantool_http`;
 - `Policy`: `default`.
 
 To set up an Prometheus dashboard for monitoring example app, use the following variables:
@@ -134,7 +134,7 @@ Variables for Prometheus targets:
 Variables for InfluxDB targets:
 - `DATASOURCE`: name of a InfluxDB data source;
 - `POLICY` (optional, default `autogen`): InfluxDB metrics retention policy;
-- `MEASUREMENT`: name of a InfluxDB measurement with your application metrics;
+- `MEASUREMENT` (optional, default `tarantool_http`): name of a InfluxDB measurement with your application metrics;
 - `OUTPUT_STATIC_DASHBOARD` (optional, default `dashboard.json`): compiled dashboard file.
 
 You can also compile configurable Prometheus dashboard template (the same we publish to

--- a/dashboard/build/influxdb/dashboard.libsonnet
+++ b/dashboard/build/influxdb/dashboard.libsonnet
@@ -18,6 +18,7 @@ dashboard_raw(
   name='INFLUXDB_MEASUREMENT',
   label='Measurement',
   type='constant',
+  value='tarantool_http',
   description='InfluxDB Tarantool metrics measurement'
 ).addInput(
   name='INFLUXDB_POLICY',

--- a/dashboard/build/influxdb/tdg_dashboard.libsonnet
+++ b/dashboard/build/influxdb/tdg_dashboard.libsonnet
@@ -18,6 +18,7 @@ tdg_dashboard_raw(
   name='INFLUXDB_MEASUREMENT',
   label='Measurement',
   type='constant',
+  value='tarantool_http',
   description='InfluxDB Tarantool metrics measurement'
 ).addInput(
   name='INFLUXDB_POLICY',

--- a/dashboard/build/prometheus/dashboard.libsonnet
+++ b/dashboard/build/prometheus/dashboard.libsonnet
@@ -18,8 +18,7 @@ dashboard_raw(
   name='PROMETHEUS_JOB',
   label='Job',
   type='constant',
-  pluginId=null,
-  pluginName=null,
+  value='tarantool',
   description='Prometheus Tarantool metrics job'
 ).addInput(
   name='PROMETHEUS_RATE_TIME_RANGE',

--- a/dashboard/build/prometheus/tdg_dashboard.libsonnet
+++ b/dashboard/build/prometheus/tdg_dashboard.libsonnet
@@ -18,8 +18,7 @@ tdg_dashboard_raw(
   name='PROMETHEUS_JOB',
   label='Job',
   type='constant',
-  pluginId=null,
-  pluginName=null,
+  value='tarantool',
   description='Prometheus Tarantool metrics job'
 ).addInput(
   name='PROMETHEUS_RATE_TIME_RANGE',

--- a/doc/monitoring/grafana_dashboard.rst
+++ b/doc/monitoring/grafana_dashboard.rst
@@ -123,7 +123,7 @@ to Telegraf configuration including each Tarantool instance metrics URL:
         insecure_skip_verify = true
         interval = "10s"
         data_format = "json"
-        name_prefix = "example_project_"
+        name_prefix = "tarantool_"
         fieldpass = ["value"]
 
 Be sure to include each label key as ``label_pairs_<key>`` so it will be
@@ -172,11 +172,11 @@ For TDG dashboard, please use
         insecure_skip_verify = true
         interval = "10s"
         data_format = "json"
-        name_prefix = "example_project_"
+        name_prefix = "tarantool_"
         fieldpass = ["value"]
 
 If you connect Telegraf instance to InfluxDB storage, metrics will be stored
-with ``"<name_prefix>http"`` measurement (``"example_project_http"`` in our example).
+with ``"<name_prefix>http"`` measurement (``"tarantool_http"`` in our example).
 
 .. _monitoring-grafana_dashboard-import:
 

--- a/doc/monitoring/grafana_dashboard.rst
+++ b/doc/monitoring/grafana_dashboard.rst
@@ -79,7 +79,7 @@ metrics path as it was configured on Tarantool instances:
 ..  code-block:: yaml
 
     scrape_configs:
-      - job_name: "example_project"
+      - job_name: tarantool
         static_configs:
           - targets: 
             - "example_project:8081"

--- a/example_cluster/prometheus/alerts.yml
+++ b/example_cluster/prometheus/alerts.yml
@@ -179,7 +179,7 @@ groups:
   rules:
   # Alert for CRUD module request errors.
   - alert: CRUDHighErrorRate
-    expr: rate(tnt_crud_stats_count{ job="tarantool_app", status="error" }[5m]) > 0.1
+    expr: rate(tnt_crud_stats_count{ job="tarantool", status="error" }[5m]) > 0.1
     for: 1m
     labels:
       severity: critical
@@ -190,7 +190,7 @@ groups:
 
   # Warning for CRUD module requests too long responses.
   - alert: CRUDHighLatency
-    expr: tnt_crud_stats{ job="tarantool_app", quantile="0.99" } > 0.1
+    expr: tnt_crud_stats{ job="tarantool", quantile="0.99" } > 0.1
     for: 1m
     labels:
       severity: warning
@@ -201,7 +201,7 @@ groups:
 
   # Warning for too many map reduce CRUD module requests.
   - alert: CRUDHighMapReduceRate
-    expr: rate(tnt_crud_map_reduces{ job="tarantool_app" }[5m]) > 0.1
+    expr: rate(tnt_crud_map_reduces{ job="tarantool" }[5m]) > 0.1
     for: 1m
     labels:
       severity: warning
@@ -214,12 +214,12 @@ groups:
 
 - name: tarantool-business
   rules:
-  # Warning for any endpoint of an instance in tarantool_app job that responds too long.
+  # Warning for any endpoint of an instance in tarantool job that responds too long.
   # Beware that metric name depends on name of the collector you use in HTTP metrics middleware
   # and request depends on type of this collector.
   # This example based on summary collector with default name.
   - alert: HTTPHighLatency
-    expr: http_server_request_latency{ job="tarantool_app", quantile="0.99" } > 0.1
+    expr: http_server_request_latency{ job="tarantool", quantile="0.99" } > 0.1
     for: 5m
     labels:
       severity: warning
@@ -228,12 +228,12 @@ groups:
       description: "Some {{ $labels.method }} requests to {{ $labels.path }} path with {{ $labels.status }} response status
         on '{{ $labels.alias }}' instance of job '{{ $labels.job }}' are processed too long."
 
-  # Warning for any endpoint of an instance in tarantool_app job that sends too much 4xx responses.
+  # Warning for any endpoint of an instance in tarantool job that sends too much 4xx responses.
   # Beware that metric name depends on name of the collector you use in HTTP metrics middleware
   # and request depends on type of this collector.
   # This example based on summary collector with default name.
   - alert: HTTPHighClientErrorRateInstance
-    expr: sum by (job, instance, method, path, alias) (rate(http_server_request_latency_count{ job="tarantool_app", status=~"^4\\d{2}$" }[5m])) > 10
+    expr: sum by (job, instance, method, path, alias) (rate(http_server_request_latency_count{ job="tarantool", status=~"^4\\d{2}$" }[5m])) > 10
     for: 1m
     labels:
       severity: warning
@@ -242,12 +242,12 @@ groups:
       description: "Too many {{ $labels.method }} requests to {{ $labels.path }} path 
         on '{{ $labels.alias }}' instance of job '{{ $labels.job }}' get client error (4xx) responses."
 
-  # Warning for any endpoint in tarantool_app job that sends too much 4xx responses (cluster overall).
+  # Warning for any endpoint in tarantool job that sends too much 4xx responses (cluster overall).
   # Beware that metric name depends on name of the collector you use in HTTP metrics middleware
   # and request depends on type of this collector.
   # This example based on summary collector with default name.
   - alert: HTTPHighClientErrorRate
-    expr: sum by (job, method, path) (rate(http_server_request_latency_count{ job="tarantool_app", status=~"^4\\d{2}$" }[5m])) > 20
+    expr: sum by (job, method, path) (rate(http_server_request_latency_count{ job="tarantool", status=~"^4\\d{2}$" }[5m])) > 20
     for: 1m
     labels:
       severity: warning
@@ -256,12 +256,12 @@ groups:
       description: "Too many {{ $labels.method }} requests to {{ $labels.path }} path
         on instances of job '{{ $labels.job }}' get client error (4xx) responses."
 
-  # Warning for any endpoint of an instance in tarantool_app job that sends 5xx responses.
+  # Warning for any endpoint of an instance in tarantool job that sends 5xx responses.
   # Beware that metric name depends on name of the collector you use in HTTP metrics middleware
   # and request depends on type of this collector.
   # This example based on summary collector with default name.
   - alert: HTTPServerErrors
-    expr: sum by (job, instance, method, path, alias) (rate(http_server_request_latency_count{ job="tarantool_app", status=~"^5\\d{2}$" }[5m])) > 0
+    expr: sum by (job, instance, method, path, alias) (rate(http_server_request_latency_count{ job="tarantool", status=~"^5\\d{2}$" }[5m])) > 0
     for: 1m
     labels:
       severity: warning
@@ -270,12 +270,12 @@ groups:
       description: "Some {{ $labels.method }} requests to {{ $labels.path }} path 
         on '{{ $labels.alias }}' instance of job '{{ $labels.job }}' get server error (5xx) responses."
 
-  # Warning for any endpoint of a router instance (with "router" in alias) in tarantool_app job that gets too little requests.
+  # Warning for any endpoint of a router instance (with "router" in alias) in tarantool job that gets too little requests.
   # Beware that metric name depends on name of the collector you use in HTTP metrics middleware
   # and request depends on type of this collector.
   # This example based on summary collector with default name.
   - alert: HTTPLowRequestRateRouter
-    expr: sum by (job, instance, alias) (rate(http_server_request_latency_count{ job="tarantool_app", alias=~"^.*router.*$" }[5m])) < 10
+    expr: sum by (job, instance, alias) (rate(http_server_request_latency_count{ job="tarantool", alias=~"^.*router.*$" }[5m])) < 10
     for: 5m
     labels:
       severity: warning

--- a/example_cluster/prometheus/prometheus.localapp.yml
+++ b/example_cluster/prometheus/prometheus.localapp.yml
@@ -27,7 +27,7 @@ scrape_configs:
     static_configs:
       - targets: ["localhost:9090"]
 
-  - job_name: "tarantool_app"
+  - job_name: "tarantool"
     static_configs:
       - targets: 
         - "host.docker.internal:8081"

--- a/example_cluster/prometheus/prometheus.tdg.yml
+++ b/example_cluster/prometheus/prometheus.tdg.yml
@@ -27,7 +27,7 @@ scrape_configs:
     static_configs:
       - targets: ["localhost:9090"]
 
-  - job_name: "tarantool_app"
+  - job_name: "tarantool"
     static_configs:
       - targets: 
         - "tdg:8080"

--- a/example_cluster/prometheus/prometheus.yml
+++ b/example_cluster/prometheus/prometheus.yml
@@ -27,7 +27,7 @@ scrape_configs:
     static_configs:
       - targets: ["localhost:9090"]
 
-  - job_name: "tarantool_app"
+  - job_name: "tarantool"
     static_configs:
       - targets: 
         - "app:8081"

--- a/example_cluster/prometheus/test_alerts.yml
+++ b/example_cluster/prometheus/test_alerts.yml
@@ -9,9 +9,9 @@ evaluation_interval: 15s
 tests:
   - interval: 15s
     input_series:
-      - series: 'up{job="tarantool_app",instance="app:8081"}'
+      - series: 'up{job="tarantool",instance="app:8081"}'
         values: '1+0x12'
-      - series: 'up{job="tarantool_app",instance="app:8082"}'
+      - series: 'up{job="tarantool",instance="app:8082"}'
         values: '1 0+0x11'
     alert_rule_test:
       - eval_time: 2m
@@ -20,15 +20,15 @@ tests:
           - exp_labels:
               severity: page
               instance: app:8082
-              job: tarantool_app
+              job: tarantool
             exp_annotations:
-              summary: "Instance 'app:8082' ('tarantool_app') down"
-              description: "'app:8082' of job 'tarantool_app' has been down for more than a minute."
+              summary: "Instance 'app:8082' ('tarantool') down"
+              description: "'app:8082' of job 'tarantool' has been down for more than a minute."
 
 
   - interval: 15s
     input_series:
-      - series: 'tnt_info_memory_lua{job="tarantool_app",instance="app:8081",alias="tnt_router"}'
+      - series: 'tnt_info_memory_lua{job="tarantool",instance="app:8081",alias="tnt_router"}'
         values: '209715200+104857600x8' # 200 Mb + 100 Mb each interval
     alert_rule_test:
       - eval_time: 2m
@@ -38,10 +38,10 @@ tests:
               severity: warning
               instance: app:8081
               alias: tnt_router
-              job: tarantool_app
+              job: tarantool
             exp_annotations:
-              summary: "Instance 'tnt_router' ('tarantool_app') Lua runtime warning"
-              description: "'tnt_router' instance of job 'tarantool_app' uses too much Lua memory
+              summary: "Instance 'tnt_router' ('tarantool') Lua runtime warning"
+              description: "'tnt_router' instance of job 'tarantool' uses too much Lua memory
                 and may hit threshold soon."
       - eval_time: 2m
         alertname: LuaRuntimeAlert
@@ -50,7 +50,7 @@ tests:
 
   - interval: 15s
     input_series:
-      - series: 'tnt_info_memory_lua{job="tarantool_app",instance="app:8081",alias="tnt_router"}'
+      - series: 'tnt_info_memory_lua{job="tarantool",instance="app:8081",alias="tnt_router"}'
         values: '419430400+209715200x8' # 400 Mb + 200 Mb each interval
     alert_rule_test:
       - eval_time: 2m
@@ -60,10 +60,10 @@ tests:
               severity: warning
               instance: app:8081
               alias: tnt_router
-              job: tarantool_app
+              job: tarantool
             exp_annotations:
-              summary: "Instance 'tnt_router' ('tarantool_app') Lua runtime warning"
-              description: "'tnt_router' instance of job 'tarantool_app' uses too much Lua memory
+              summary: "Instance 'tnt_router' ('tarantool') Lua runtime warning"
+              description: "'tnt_router' instance of job 'tarantool' uses too much Lua memory
                 and may hit threshold soon."
       - eval_time: 2m
         alertname: LuaRuntimeAlert
@@ -72,18 +72,18 @@ tests:
               severity: page
               instance: app:8081
               alias: tnt_router
-              job: tarantool_app
+              job: tarantool
             exp_annotations:
-              summary: "Instance 'tnt_router' ('tarantool_app') Lua runtime alert"
-              description: "'tnt_router' instance of job 'tarantool_app' uses too much Lua memory
+              summary: "Instance 'tnt_router' ('tarantool') Lua runtime alert"
+              description: "'tnt_router' instance of job 'tarantool' uses too much Lua memory
                 and likely to hit threshold soon."
 
 
   - interval: 15s
     input_series:
-      - series: 'tnt_slab_quota_used_ratio{job="tarantool_app",instance="app:8081",alias="tnt_router"}'
+      - series: 'tnt_slab_quota_used_ratio{job="tarantool",instance="app:8081",alias="tnt_router"}'
         values: '75+0x2 92+0x8'
-      - series: 'tnt_slab_arena_used_ratio{job="tarantool_app",instance="app:8081",alias="tnt_router"}'
+      - series: 'tnt_slab_arena_used_ratio{job="tarantool",instance="app:8081",alias="tnt_router"}'
         values: '92+0x2 76+0x8'
     alert_rule_test:
       - eval_time: 2m
@@ -96,9 +96,9 @@ tests:
 
   - interval: 15s
     input_series:
-      - series: 'tnt_slab_quota_used_ratio{job="tarantool_app",instance="app:8081",alias="tnt_router"}'
+      - series: 'tnt_slab_quota_used_ratio{job="tarantool",instance="app:8081",alias="tnt_router"}'
         values: '75+0x2 92+0x8'
-      - series: 'tnt_slab_arena_used_ratio{job="tarantool_app",instance="app:8081",alias="tnt_router"}'
+      - series: 'tnt_slab_arena_used_ratio{job="tarantool",instance="app:8081",alias="tnt_router"}'
         values: '92+0x2 82+0x8'
     alert_rule_test:
       - eval_time: 2m
@@ -108,10 +108,10 @@ tests:
               severity: warning
               instance: app:8081
               alias: tnt_router
-              job: tarantool_app
+              job: tarantool
             exp_annotations:
-              summary: "Instance 'tnt_router' ('tarantool_app') low arena memory remaining"
-              description: "Low arena memory (tuples and indexes) remaining for 'tnt_router' instance of job 'tarantool_app'.
+              summary: "Instance 'tnt_router' ('tarantool') low arena memory remaining"
+              description: "Low arena memory (tuples and indexes) remaining for 'tnt_router' instance of job 'tarantool'.
                 Consider increasing memtx_memory or number of storages in case of sharded data."
       - eval_time: 2m
         alertname: MemtxArenaAlert
@@ -120,9 +120,9 @@ tests:
 
   - interval: 15s
     input_series:
-      - series: 'tnt_slab_quota_used_ratio{job="tarantool_app",instance="app:8081",alias="tnt_router"}'
+      - series: 'tnt_slab_quota_used_ratio{job="tarantool",instance="app:8081",alias="tnt_router"}'
         values: '85+0x2 92+0x8'
-      - series: 'tnt_slab_arena_used_ratio{job="tarantool_app",instance="app:8081",alias="tnt_router"}'
+      - series: 'tnt_slab_arena_used_ratio{job="tarantool",instance="app:8081",alias="tnt_router"}'
         values: '92+0x2 91+0x8'
     alert_rule_test:
       - eval_time: 2m
@@ -132,10 +132,10 @@ tests:
               severity: warning
               instance: app:8081
               alias: tnt_router
-              job: tarantool_app
+              job: tarantool
             exp_annotations:
-              summary: "Instance 'tnt_router' ('tarantool_app') low arena memory remaining"
-              description: "Low arena memory (tuples and indexes) remaining for 'tnt_router' instance of job 'tarantool_app'.
+              summary: "Instance 'tnt_router' ('tarantool') low arena memory remaining"
+              description: "Low arena memory (tuples and indexes) remaining for 'tnt_router' instance of job 'tarantool'.
                 Consider increasing memtx_memory or number of storages in case of sharded data."
       - eval_time: 2m
         alertname: MemtxArenaAlert
@@ -144,19 +144,19 @@ tests:
               severity: page
               instance: app:8081
               alias: tnt_router
-              job: tarantool_app
+              job: tarantool
             exp_annotations:
-              summary: "Instance 'tnt_router' ('tarantool_app') low arena memory remaining"
-              description: "Low arena memory (tuples and indexes) remaining for 'tnt_router' instance of job 'tarantool_app'.
+              summary: "Instance 'tnt_router' ('tarantool') low arena memory remaining"
+              description: "Low arena memory (tuples and indexes) remaining for 'tnt_router' instance of job 'tarantool'.
                 You are likely to hit limit soon.
                 It is strongly recommended to increase memtx_memory or number of storages in case of sharded data."
 
 
   - interval: 15s
     input_series:
-      - series: 'tnt_slab_quota_used_ratio{job="tarantool_app",instance="app:8081",alias="tnt_router"}'
+      - series: 'tnt_slab_quota_used_ratio{job="tarantool",instance="app:8081",alias="tnt_router"}'
         values: '75+0x2 92+0x8'
-      - series: 'tnt_slab_items_used_ratio{job="tarantool_app",instance="app:8081",alias="tnt_router"}'
+      - series: 'tnt_slab_items_used_ratio{job="tarantool",instance="app:8081",alias="tnt_router"}'
         values: '95+0x2 79+0x8'
     alert_rule_test:
       - eval_time: 2m
@@ -169,9 +169,9 @@ tests:
 
   - interval: 15s
     input_series:
-      - series: 'tnt_slab_quota_used_ratio{job="tarantool_app",instance="app:8081",alias="tnt_router"}'
+      - series: 'tnt_slab_quota_used_ratio{job="tarantool",instance="app:8081",alias="tnt_router"}'
         values: '75+0x2 92+0x8'
-      - series: 'tnt_slab_items_used_ratio{job="tarantool_app",instance="app:8081",alias="tnt_router"}'
+      - series: 'tnt_slab_items_used_ratio{job="tarantool",instance="app:8081",alias="tnt_router"}'
         values: '92+0x2 82+0x8'
     alert_rule_test:
       - eval_time: 2m
@@ -181,10 +181,10 @@ tests:
               severity: warning
               instance: app:8081
               alias: tnt_router
-              job: tarantool_app
+              job: tarantool
             exp_annotations:
-              summary: "Instance 'tnt_router' ('tarantool_app') low items memory remaining"
-              description: "Low items memory (tuples) remaining for 'tnt_router' instance of job 'tarantool_app'.
+              summary: "Instance 'tnt_router' ('tarantool') low items memory remaining"
+              description: "Low items memory (tuples) remaining for 'tnt_router' instance of job 'tarantool'.
                 Consider increasing memtx_memory or number of storages in case of sharded data."
       - eval_time: 2m
         alertname: MemtxItemsAlert
@@ -193,9 +193,9 @@ tests:
 
   - interval: 15s
     input_series:
-      - series: 'tnt_cartridge_issues{job="tarantool_app", instance="app:8081", alias="tnt_router", level="warning"}'
+      - series: 'tnt_cartridge_issues{job="tarantool", instance="app:8081", alias="tnt_router", level="warning"}'
         values: '0+0x2 1+0x8'
-      - series: 'tnt_cartridge_issues{job="tarantool_app", instance="app:8081", alias="tnt_router", level="critical"}'
+      - series: 'tnt_cartridge_issues{job="tarantool", instance="app:8081", alias="tnt_router", level="critical"}'
         values: '0+0x10'
     alert_rule_test:
       - eval_time: 2m
@@ -206,10 +206,10 @@ tests:
               level: warning
               instance: app:8081
               alias: tnt_router
-              job: tarantool_app
+              job: tarantool
             exp_annotations:
-              summary: "Instance 'tnt_router' ('tarantool_app') has 'warning'-level Cartridge issues"
-              description: "Instance 'tnt_router' of job 'tarantool_app' has 'warning'-level Cartridge issues.
+              summary: "Instance 'tnt_router' ('tarantool') has 'warning'-level Cartridge issues"
+              description: "Instance 'tnt_router' of job 'tarantool' has 'warning'-level Cartridge issues.
                 Possible reasons: high replication lag, replication long idle,
                 failover or switchover issues, clock issues, memory fragmentation,
                 configuration issues, alien members."
@@ -220,9 +220,9 @@ tests:
 
   - interval: 15s
     input_series:
-      - series: 'tnt_cartridge_issues{job="tarantool_app", instance="app:8081", alias="tnt_router", level="warning"}'
+      - series: 'tnt_cartridge_issues{job="tarantool", instance="app:8081", alias="tnt_router", level="warning"}'
         values: '0+0x2 2+0x8'
-      - series: 'tnt_cartridge_issues{job="tarantool_app", instance="app:8081", alias="tnt_router", level="critical"}'
+      - series: 'tnt_cartridge_issues{job="tarantool", instance="app:8081", alias="tnt_router", level="critical"}'
         values: '1+0x10'
     alert_rule_test:
       - eval_time: 2m
@@ -233,10 +233,10 @@ tests:
               level: warning
               instance: app:8081
               alias: tnt_router
-              job: tarantool_app
+              job: tarantool
             exp_annotations:
-              summary: "Instance 'tnt_router' ('tarantool_app') has 'warning'-level Cartridge issues"
-              description: "Instance 'tnt_router' of job 'tarantool_app' has 'warning'-level Cartridge issues.
+              summary: "Instance 'tnt_router' ('tarantool') has 'warning'-level Cartridge issues"
+              description: "Instance 'tnt_router' of job 'tarantool' has 'warning'-level Cartridge issues.
                 Possible reasons: high replication lag, replication long idle,
                 failover or switchover issues, clock issues, memory fragmentation,
                 configuration issues, alien members."
@@ -248,19 +248,19 @@ tests:
               level: critical
               instance: app:8081
               alias: tnt_router
-              job: tarantool_app
+              job: tarantool
             exp_annotations:
-              summary: "Instance 'tnt_router' ('tarantool_app') has 'critical'-level Cartridge issues"
-              description: "Instance 'tnt_router' of job 'tarantool_app' has 'critical'-level Cartridge issues.
+              summary: "Instance 'tnt_router' ('tarantool') has 'critical'-level Cartridge issues"
+              description: "Instance 'tnt_router' of job 'tarantool' has 'critical'-level Cartridge issues.
                 Possible reasons: replication process critical fail,
                 running out of available memory."
 
 
   - interval: 15s
     input_series:
-      - series: tnt_replication_1_lag{job="tarantool_app", instance="app:8081", alias="tnt_storage_master"}
+      - series: tnt_replication_1_lag{job="tarantool", instance="app:8081", alias="tnt_storage_master"}
         values: '0+0x10'
-      - series: tnt_replication_2_lag{job="tarantool_app", instance="app:8082", alias="tnt_storage_replica"}
+      - series: tnt_replication_2_lag{job="tarantool", instance="app:8082", alias="tnt_storage_replica"}
         values: '1+15x10'
     alert_rule_test:
       - eval_time: 2m
@@ -270,16 +270,16 @@ tests:
               severity: warning
               instance: app:8082
               alias: tnt_storage_replica
-              job: tarantool_app
+              job: tarantool
             exp_annotations:
-              summary: "Instance 'tnt_storage_replica' ('tarantool_app') have high replication lag"
-              description: "Instance 'tnt_storage_replica' of job 'tarantool_app' have high replication lag,
+              summary: "Instance 'tnt_storage_replica' ('tarantool') have high replication lag"
+              description: "Instance 'tnt_storage_replica' of job 'tarantool' have high replication lag,
                 check up your network and cluster state."
 
 
   - interval: 15s
     input_series:
-      - series: tnt_vinyl_regulator_rate_limit{job="tarantool_app", instance="app:8081", alias="tnt_storage_master"}
+      - series: tnt_vinyl_regulator_rate_limit{job="tarantool", instance="app:8081", alias="tnt_storage_master"}
         values: '10000000+0x2 10000+0x8'
     alert_rule_test:
       - eval_time: 2m
@@ -289,18 +289,18 @@ tests:
               severity: warning
               instance: app:8081
               alias: tnt_storage_master
-              job: tarantool_app
+              job: tarantool
             exp_annotations:
-              summary: "Instance 'tnt_storage_master' ('tarantool_app') have low vinyl regulator rate limit"
-              description: "Instance 'tnt_storage_master' of job 'tarantool_app' have low vinyl engine regulator rate limit.
+              summary: "Instance 'tnt_storage_master' ('tarantool') have low vinyl regulator rate limit"
+              description: "Instance 'tnt_storage_master' of job 'tarantool' have low vinyl engine regulator rate limit.
                 This indicates issues with the disk or the scheduler."
 
 
   - interval: 15s
     input_series:
-      - series: tnt_vinyl_tx_commit{job="tarantool_app", instance="app:8081", alias="tnt_storage_master"}
+      - series: tnt_vinyl_tx_commit{job="tarantool", instance="app:8081", alias="tnt_storage_master"}
         values: '100000+100x10'
-      - series: tnt_vinyl_tx_conflict{job="tarantool_app", instance="app:8081", alias="tnt_storage_master"}
+      - series: tnt_vinyl_tx_conflict{job="tarantool", instance="app:8081", alias="tnt_storage_master"}
         values: '0+0x3 2+0x6'
     alert_rule_test:
       - eval_time: 2m
@@ -310,9 +310,9 @@ tests:
 
   - interval: 15s
     input_series:
-      - series: tnt_vinyl_tx_commit{job="tarantool_app", instance="app:8081", alias="tnt_storage_master"}
+      - series: tnt_vinyl_tx_commit{job="tarantool", instance="app:8081", alias="tnt_storage_master"}
         values: '100000+100x10'
-      - series: tnt_vinyl_tx_conflict{job="tarantool_app", instance="app:8081", alias="tnt_storage_master"}
+      - series: tnt_vinyl_tx_conflict{job="tarantool", instance="app:8081", alias="tnt_storage_master"}
         values: '6+6x10'
     alert_rule_test:
       - eval_time: 2m
@@ -322,16 +322,16 @@ tests:
               severity: critical
               instance: app:8081
               alias: tnt_storage_master
-              job: tarantool_app
+              job: tarantool
             exp_annotations:
-              summary: "Instance 'tnt_storage_master' ('tarantool_app') have high vinyl tx conflict rate"
-              description: "Instance 'tnt_storage_master' of job 'tarantool_app' have
+              summary: "Instance 'tnt_storage_master' ('tarantool') have high vinyl tx conflict rate"
+              description: "Instance 'tnt_storage_master' of job 'tarantool' have
                 high vinyl transactions conflict rate. It indicates that vinyl is not healthy."
 
 
   - interval: 15s
     input_series:
-      - series: tnt_vinyl_scheduler_tasks{job="tarantool_app", instance="app:8081", alias="tnt_storage_master", status="failed"}
+      - series: tnt_vinyl_scheduler_tasks{job="tarantool", instance="app:8081", alias="tnt_storage_master", status="failed"}
         values: '2+3x10'
     alert_rule_test:
       - eval_time: 2m
@@ -341,17 +341,17 @@ tests:
               severity: critical
               instance: app:8081
               alias: tnt_storage_master
-              job: tarantool_app
+              job: tarantool
               status: failed
             exp_annotations:
-              summary: "Instance 'tnt_storage_master' ('tarantool_app') have high vinyl scheduler failed tasks rate"
-              description: "Instance 'tnt_storage_master' of job 'tarantool_app' have
+              summary: "Instance 'tnt_storage_master' ('tarantool') have high vinyl scheduler failed tasks rate"
+              description: "Instance 'tnt_storage_master' of job 'tarantool' have
                 high vinyl scheduler failed tasks rate."
 
 
   - interval: 15s
     input_series:
-      - series: tnt_ev_loop_time{job="tarantool_app", instance="app:8081", alias="tnt_router"}
+      - series: tnt_ev_loop_time{job="tarantool", instance="app:8081", alias="tnt_router"}
         values: '0.11+0x10'
     alert_rule_test:
       - eval_time: 2m
@@ -361,16 +361,16 @@ tests:
               severity: warning
               instance: app:8081
               alias: tnt_router
-              job: tarantool_app
+              job: tarantool
             exp_annotations:
-              summary: "Instance 'tnt_router' ('tarantool_app') event loop has high cycle duration"
-              description: "Instance 'tnt_router' of job 'tarantool_app' event loop has high cycle duration.
+              summary: "Instance 'tnt_router' ('tarantool') event loop has high cycle duration"
+              description: "Instance 'tnt_router' of job 'tarantool' event loop has high cycle duration.
                 Some high loaded fiber has too little yields. It may be the reason of 'Too long WAL write' warnings."
 
 
   - interval: 15s
     input_series:
-      - series: tnt_replication_status{job="tarantool_app", instance="app:8081", alias="tnt_storage_master", id="1", stream="upstream"}
+      - series: tnt_replication_status{job="tarantool", instance="app:8081", alias="tnt_storage_master", id="1", stream="upstream"}
         values: '1+0x3 0+0x10'
     alert_rule_test:
       - eval_time: 2m
@@ -380,18 +380,18 @@ tests:
               severity: critical
               instance: app:8081
               alias: tnt_storage_master
-              job: tarantool_app
+              job: tarantool
               id: "1"
               stream: upstream
             exp_annotations:
-              summary: "Instance 'tnt_storage_master' ('tarantool_app') upstream (id 1) replication is not running"
-              description: "Instance 'tnt_storage_master' ('tarantool_app') upstream (id 1) replication is
+              summary: "Instance 'tnt_storage_master' ('tarantool') upstream (id 1) replication is not running"
+              description: "Instance 'tnt_storage_master' ('tarantool') upstream (id 1) replication is
                  not running. Check Cartridge UI for details."
 
 
   - interval: 15s
     input_series:
-      - series: tnt_crud_stats_count{job="tarantool_app", instance="app:8081", alias="tnt_router", name="customers", operation="insert", status="error"}
+      - series: tnt_crud_stats_count{job="tarantool", instance="app:8081", alias="tnt_router", name="customers", operation="insert", status="error"}
         values: '0+100x100'
     alert_rule_test:
       - eval_time: 5m
@@ -401,19 +401,19 @@ tests:
               severity: critical
               instance: app:8081
               alias: tnt_router
-              job: tarantool_app
+              job: tarantool
               name: customers
               operation: insert
               status: error
             exp_annotations:
-              summary: "Instance 'tnt_router' ('tarantool_app') too many CRUD insert errors."
+              summary: "Instance 'tnt_router' ('tarantool') too many CRUD insert errors."
               description: "Too many insert CRUD requests for 'customers' space on
-                'tnt_router' instance of job 'tarantool_app' get module error responses."
+                'tnt_router' instance of job 'tarantool' get module error responses."
 
 
   - interval: 15s
     input_series:
-      - series: tnt_crud_stats{job="tarantool_app", instance="app:8081", alias="tnt_router", name="customers", operation="get", status="ok", quantile="0.99"}
+      - series: tnt_crud_stats{job="tarantool", instance="app:8081", alias="tnt_router", name="customers", operation="get", status="ok", quantile="0.99"}
         values: '0.11+0x0'
     alert_rule_test:
       - eval_time: 2m
@@ -423,20 +423,20 @@ tests:
               severity: warning
               instance: app:8081
               alias: tnt_router
-              job: tarantool_app
+              job: tarantool
               name: customers
               operation: get
               status: ok
               quantile: '0.99'
             exp_annotations:
-              summary: "Instance 'tnt_router' ('tarantool_app') too high CRUD get latency."
+              summary: "Instance 'tnt_router' ('tarantool') too high CRUD get latency."
               description: "Some get ok CRUD requests for 'customers' space on
-                'tnt_router' instance of job 'tarantool_app' are processed too long."
+                'tnt_router' instance of job 'tarantool' are processed too long."
 
 
   - interval: 15s
     input_series:
-      - series: tnt_crud_map_reduces{job="tarantool_app", instance="app:8081", alias="tnt_router", name="customers", operation="select"}
+      - series: tnt_crud_map_reduces{job="tarantool", instance="app:8081", alias="tnt_router", name="customers", operation="select"}
         values: '0+100x100'
     alert_rule_test:
       - eval_time: 5m
@@ -446,27 +446,27 @@ tests:
               severity: warning
               instance: app:8081
               alias: tnt_router
-              job: tarantool_app
+              job: tarantool
               name: customers
               operation: select
             exp_annotations:
-              summary: "Instance 'tnt_router' ('tarantool_app') too many CRUD select map reduces."
+              summary: "Instance 'tnt_router' ('tarantool') too many CRUD select map reduces."
               description: "There are too many select CRUD map reduce requests for 'customers' space on
-              'tnt_router' instance of job 'tarantool_app'.
+              'tnt_router' instance of job 'tarantool'.
               Check your request conditions or consider changing sharding schema."
 
 
   - interval: 15s
     input_series:
-        - series: http_server_request_latency_count{job="tarantool_app",instance="app:8081",path="/hello",method="GET",status="200",alias="tnt_router"}
+        - series: http_server_request_latency_count{job="tarantool",instance="app:8081",path="/hello",method="GET",status="200",alias="tnt_router"}
           values: '0+100x60'
-        - series: http_server_request_latency_sum{job="tarantool_app",instance="app:8081",path="/hello",method="GET",status="200",alias="tnt_router"}
+        - series: http_server_request_latency_sum{job="tarantool",instance="app:8081",path="/hello",method="GET",status="200",alias="tnt_router"}
           values: '0+2x60'
-        - series: http_server_request_latency{job="tarantool_app",instance="app:8081",path="/hello",method="GET",status="200",alias="tnt_router",quantile="0.5"}
+        - series: http_server_request_latency{job="tarantool",instance="app:8081",path="/hello",method="GET",status="200",alias="tnt_router",quantile="0.5"}
           values: '0.02+0x60'
-        - series: http_server_request_latency{job="tarantool_app",instance="app:8081",path="/hello",method="GET",status="200",alias="tnt_router",quantile="0.9"}
+        - series: http_server_request_latency{job="tarantool",instance="app:8081",path="/hello",method="GET",status="200",alias="tnt_router",quantile="0.9"}
           values: '0.05+0x60'
-        - series: http_server_request_latency{job="tarantool_app",instance="app:8081",path="/hello",method="GET",status="200",alias="tnt_router",quantile="0.99"}
+        - series: http_server_request_latency{job="tarantool",instance="app:8081",path="/hello",method="GET",status="200",alias="tnt_router",quantile="0.99"}
           values: '0.11+0x60'
     alert_rule_test:
       - eval_time: 10m
@@ -476,28 +476,28 @@ tests:
               severity: warning
               instance: app:8081
               alias: tnt_router
-              job: tarantool_app
+              job: tarantool
               path: /hello
               method: GET
               status: '200'
               quantile: '0.99'
             exp_annotations:
-              summary: "Instance 'tnt_router' ('tarantool_app') high HTTP latency"
+              summary: "Instance 'tnt_router' ('tarantool') high HTTP latency"
               description: "Some GET requests to /hello path with 200 response status
-                on 'tnt_router' instance of job 'tarantool_app' are processed too long."
+                on 'tnt_router' instance of job 'tarantool' are processed too long."
 
 
   - interval: 15s
     input_series:
-        - series: http_server_request_latency_count{job="tarantool_app",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router"}
+        - series: http_server_request_latency_count{job="tarantool",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router"}
           values: '0+200x100'
-        - series: http_server_request_latency_sum{job="tarantool_app",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router"}
+        - series: http_server_request_latency_sum{job="tarantool",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router"}
           values: '0+2x100'
-        - series: http_server_request_latency{job="tarantool_app",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router",quantile="0.5"}
+        - series: http_server_request_latency{job="tarantool",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router",quantile="0.5"}
           values: '0.02+0x100'
-        - series: http_server_request_latency{job="tarantool_app",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router",quantile="0.9"}
+        - series: http_server_request_latency{job="tarantool",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router",quantile="0.9"}
           values: '0.02+0x100'
-        - series: http_server_request_latency{job="tarantool_app",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router",quantile="0.99"}
+        - series: http_server_request_latency{job="tarantool",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router",quantile="0.99"}
           values: '0.02+0x100'
     alert_rule_test:
       - eval_time: 5m
@@ -507,46 +507,46 @@ tests:
               severity: warning
               instance: app:8081
               alias: tnt_router
-              job: tarantool_app
+              job: tarantool
               path: /hell0
               method: GET
             exp_annotations:
-              summary: "Instance 'tnt_router' ('tarantool_app') high rate of client error responses"
+              summary: "Instance 'tnt_router' ('tarantool') high rate of client error responses"
               description: "Too many GET requests to /hell0 path 
-                on 'tnt_router' instance of job 'tarantool_app' get client error (4xx) responses."
+                on 'tnt_router' instance of job 'tarantool' get client error (4xx) responses."
 
   # Total rate of 4xx is high, but distributed between different routers
   - interval: 15s
     input_series:
-        - series: http_server_request_latency_count{job="tarantool_app",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_1"}
+        - series: http_server_request_latency_count{job="tarantool",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_1"}
           values: '0+150x100'
-        - series: http_server_request_latency_sum{job="tarantool_app",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_1"}
+        - series: http_server_request_latency_sum{job="tarantool",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_1"}
           values: '0+2x100'
-        - series: http_server_request_latency{job="tarantool_app",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_1",quantile="0.5"}
+        - series: http_server_request_latency{job="tarantool",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_1",quantile="0.5"}
           values: '0.02+0x100'
-        - series: http_server_request_latency{job="tarantool_app",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_1",quantile="0.9"}
+        - series: http_server_request_latency{job="tarantool",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_1",quantile="0.9"}
           values: '0.02+0x100'
-        - series: http_server_request_latency{job="tarantool_app",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_1",quantile="0.99"}
+        - series: http_server_request_latency{job="tarantool",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_1",quantile="0.99"}
           values: '0.02+0x100'
-        - series: http_server_request_latency_count{job="tarantool_app",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_2"}
+        - series: http_server_request_latency_count{job="tarantool",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_2"}
           values: '0+150x100'
-        - series: http_server_request_latency_sum{job="tarantool_app",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_2"}
+        - series: http_server_request_latency_sum{job="tarantool",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_2"}
           values: '0+2x100'
-        - series: http_server_request_latency{job="tarantool_app",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_2",quantile="0.5"}
+        - series: http_server_request_latency{job="tarantool",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_2",quantile="0.5"}
           values: '0.02+0x100'
-        - series: http_server_request_latency{job="tarantool_app",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_2",quantile="0.9"}
+        - series: http_server_request_latency{job="tarantool",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_2",quantile="0.9"}
           values: '0.02+0x100'
-        - series: http_server_request_latency{job="tarantool_app",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_2",quantile="0.99"}
+        - series: http_server_request_latency{job="tarantool",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_2",quantile="0.99"}
           values: '0.02+0x100'
-        - series: http_server_request_latency_count{job="tarantool_app",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_3"}
+        - series: http_server_request_latency_count{job="tarantool",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_3"}
           values: '0+150x100'
-        - series: http_server_request_latency_sum{job="tarantool_app",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_3"}
+        - series: http_server_request_latency_sum{job="tarantool",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_3"}
           values: '0+2x100'
-        - series: http_server_request_latency{job="tarantool_app",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_3",quantile="0.5"}
+        - series: http_server_request_latency{job="tarantool",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_3",quantile="0.5"}
           values: '0.02+0x100'
-        - series: http_server_request_latency{job="tarantool_app",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_3",quantile="0.9"}
+        - series: http_server_request_latency{job="tarantool",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_3",quantile="0.9"}
           values: '0.02+0x100'
-        - series: http_server_request_latency{job="tarantool_app",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_3",quantile="0.99"}
+        - series: http_server_request_latency{job="tarantool",instance="app:8081",path="/hell0",method="GET",status="400",alias="tnt_router_3",quantile="0.99"}
           values: '0.02+0x100'
     alert_rule_test:
       - eval_time: 5m
@@ -557,25 +557,25 @@ tests:
         exp_alerts:
           - exp_labels:
               severity: warning
-              job: tarantool_app
+              job: tarantool
               path: /hell0
               method: GET
             exp_annotations:
-              summary: "Job 'tarantool_app' high rate of client error responses"
+              summary: "Job 'tarantool' high rate of client error responses"
               description: "Too many GET requests to /hell0 path
-                on instances of job 'tarantool_app' get client error (4xx) responses."
+                on instances of job 'tarantool' get client error (4xx) responses."
 
   - interval: 15s
     input_series:
-        - series: http_server_request_latency_count{job="tarantool_app",instance="app:8081",path="/goodbye",method="POST",status="500",alias="tnt_router"}
+        - series: http_server_request_latency_count{job="tarantool",instance="app:8081",path="/goodbye",method="POST",status="500",alias="tnt_router"}
           values: '0+0x10 1+0x10 2+0x10 3+0x10 4+0x10 5+0x10 6+0x10 7+0x10 8+0x10 9+0x10'
-        - series: http_server_request_latency_sum{job="tarantool_app",instance="app:8081",path="/goodbye",method="POST",status="500",alias="tnt_router"}
+        - series: http_server_request_latency_sum{job="tarantool",instance="app:8081",path="/goodbye",method="POST",status="500",alias="tnt_router"}
           values: '0+0x10 0.01+0x10 0.02+0x10 0.03+0x10 0.04+0x10 0.05+0x10 0.06+0x10 0.07+0x10 0.08+0x10 0.09+0x10'
-        - series: http_server_request_latency{job="tarantool_app",instance="app:8081",path="/goodbye",method="POST",status="500",alias="tnt_router",quantile="0.5"}
+        - series: http_server_request_latency{job="tarantool",instance="app:8081",path="/goodbye",method="POST",status="500",alias="tnt_router",quantile="0.5"}
           values: '0+0x10 0.01+0x100'
-        - series: http_server_request_latency{job="tarantool_app",instance="app:8081",path="/goodbye",method="POST",status="500",alias="tnt_router",quantile="0.9"}
+        - series: http_server_request_latency{job="tarantool",instance="app:8081",path="/goodbye",method="POST",status="500",alias="tnt_router",quantile="0.9"}
           values: '0+0x10 0.01+0x100'
-        - series: http_server_request_latency{job="tarantool_app",instance="app:8081",path="/goodbye",method="POST",status="500",alias="tnt_router",quantile="0.99"}
+        - series: http_server_request_latency{job="tarantool",instance="app:8081",path="/goodbye",method="POST",status="500",alias="tnt_router",quantile="0.99"}
           values: '0+0x10 0.01+0x100'
     alert_rule_test:
       - eval_time: 5m
@@ -585,25 +585,25 @@ tests:
               severity: warning
               instance: app:8081
               alias: tnt_router
-              job: tarantool_app
+              job: tarantool
               path: /goodbye
               method: POST
             exp_annotations:
-              summary: "Instance 'tnt_router' ('tarantool_app') server error responses"
+              summary: "Instance 'tnt_router' ('tarantool') server error responses"
               description: "Some POST requests to /goodbye path 
-                on 'tnt_router' instance of job 'tarantool_app' get server error (5xx) responses."
+                on 'tnt_router' instance of job 'tarantool' get server error (5xx) responses."
 
   - interval: 15s
     input_series:
-        - series: http_server_request_latency_count{job="tarantool_app",instance="app:8081",path="/hello",method="GET",status="200",alias="tnt_router"}
+        - series: http_server_request_latency_count{job="tarantool",instance="app:8081",path="/hello",method="GET",status="200",alias="tnt_router"}
           values: '0+0x10 1+0x10 2+0x10 3+0x10 4+0x10 5+0x10 6+0x10 7+0x10 8+0x10 9+0x10'
-        - series: http_server_request_latency_sum{job="tarantool_app",instance="app:8081",path="/hello",method="GET",status="200",alias="tnt_router"}
+        - series: http_server_request_latency_sum{job="tarantool",instance="app:8081",path="/hello",method="GET",status="200",alias="tnt_router"}
           values: '0+0x10 0.01+0x10 0.02+0x10 0.03+0x10 0.04+0x10 0.05+0x10 0.06+0x10 0.07+0x10 0.08+0x10 0.09+0x10'
-        - series: http_server_request_latency{job="tarantool_app",instance="app:8081",path="/hello",method="GET",status="200",alias="tnt_router",quantile="0.5"}
+        - series: http_server_request_latency{job="tarantool",instance="app:8081",path="/hello",method="GET",status="200",alias="tnt_router",quantile="0.5"}
           values: '0+0x10 0.01+0x100'
-        - series: http_server_request_latency{job="tarantool_app",instance="app:8081",path="/hello",method="GET",status="200",alias="tnt_router",quantile="0.9"}
+        - series: http_server_request_latency{job="tarantool",instance="app:8081",path="/hello",method="GET",status="200",alias="tnt_router",quantile="0.9"}
           values: '0+0x10 0.01+0x100'
-        - series: http_server_request_latency{job="tarantool_app",instance="app:8081",path="/hello",method="GET",status="200",alias="tnt_router",quantile="0.99"}
+        - series: http_server_request_latency{job="tarantool",instance="app:8081",path="/hello",method="GET",status="200",alias="tnt_router",quantile="0.99"}
           values: '0+0x10 0.01+0x100'
     alert_rule_test:
       - eval_time: 15m
@@ -613,8 +613,8 @@ tests:
               severity: warning
               instance: app:8081
               alias: tnt_router
-              job: tarantool_app
+              job: tarantool
             exp_annotations:
-              summary: "Router 'tnt_router' ('tarantool_app') low activity"
-              description: Router 'tnt_router' instance of job 'tarantool_app' gets too little requests.
+              summary: "Router 'tnt_router' ('tarantool') low activity"
+              description: Router 'tnt_router' instance of job 'tarantool' gets too little requests.
                 Please, check up your balancer middleware."

--- a/example_cluster/telegraf/telegraf.conf
+++ b/example_cluster/telegraf/telegraf.conf
@@ -26,7 +26,7 @@
     insecure_skip_verify = true
     interval = "10s"
     data_format = "json"
-    name_prefix = "tarantool_app_"
+    name_prefix = "tarantool_"
     fieldpass = ["value"]
 
 [[inputs.internal]]

--- a/example_cluster/telegraf/telegraf.localapp.conf
+++ b/example_cluster/telegraf/telegraf.localapp.conf
@@ -26,7 +26,7 @@
     insecure_skip_verify = true
     interval = "10s"
     data_format = "json"
-    name_prefix = "tarantool_app_"
+    name_prefix = "tarantool_"
     fieldpass = ["value"]
 
 [[inputs.internal]]

--- a/example_cluster/telegraf/telegraf.tdg.conf
+++ b/example_cluster/telegraf/telegraf.tdg.conf
@@ -34,7 +34,7 @@
     insecure_skip_verify = true
     interval = "10s"
     data_format = "json"
-    name_prefix = "tarantool_app_"
+    name_prefix = "tarantool_"
     fieldpass = ["value"]
 
 [[inputs.internal]]

--- a/tests/InfluxDB/dashboard_compiled.json
+++ b/tests/InfluxDB/dashboard_compiled.json
@@ -12,7 +12,8 @@
          "description": "InfluxDB Tarantool metrics measurement",
          "label": "Measurement",
          "name": "INFLUXDB_MEASUREMENT",
-         "type": "constant"
+         "type": "constant",
+         "value": "tarantool_http"
       },
       {
          "description": "InfluxDB Tarantool metrics policy",

--- a/tests/InfluxDB/dashboard_static.sh
+++ b/tests/InfluxDB/dashboard_static.sh
@@ -2,5 +2,5 @@
 
 make DATASOURCE=influxdb \
      POLICY=autogen \
-     MEASUREMENT=tarantool_app_http \
+     MEASUREMENT=tarantool_http \
      build-static-influxdb

--- a/tests/InfluxDB/dashboard_static_compiled.json
+++ b/tests/InfluxDB/dashboard_static_compiled.json
@@ -120,7 +120,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -257,7 +257,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -460,7 +460,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -610,7 +610,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -711,7 +711,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -845,7 +845,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -1012,7 +1012,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -1173,7 +1173,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -1334,7 +1334,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -1495,7 +1495,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -1656,7 +1656,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -1817,7 +1817,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -1980,7 +1980,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -2111,7 +2111,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -2248,7 +2248,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -2385,7 +2385,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -2522,7 +2522,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -2653,7 +2653,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -2790,7 +2790,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -2921,7 +2921,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -3058,7 +3058,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -3189,7 +3189,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -3326,7 +3326,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -3491,7 +3491,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -3622,7 +3622,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -3753,7 +3753,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -3884,7 +3884,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -4015,7 +4015,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -4146,7 +4146,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -4277,7 +4277,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -4408,7 +4408,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -4539,7 +4539,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -4696,7 +4696,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -4839,7 +4839,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -4982,7 +4982,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -5131,7 +5131,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -5268,7 +5268,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -5425,7 +5425,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -5556,7 +5556,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -5687,7 +5687,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -5818,7 +5818,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -5949,7 +5949,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -6080,7 +6080,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -6211,7 +6211,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -6342,7 +6342,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -6473,7 +6473,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -6604,7 +6604,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -6741,7 +6741,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -6878,7 +6878,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -7015,7 +7015,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -7146,7 +7146,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -7283,7 +7283,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -7426,7 +7426,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -7563,7 +7563,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -7720,7 +7720,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -7857,7 +7857,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -8014,7 +8014,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -8145,7 +8145,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -8276,7 +8276,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -8407,7 +8407,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -8538,7 +8538,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -8669,7 +8669,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -8800,7 +8800,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -8951,7 +8951,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -9088,7 +9088,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -9225,7 +9225,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -9362,7 +9362,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -9493,7 +9493,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -9630,7 +9630,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -9767,7 +9767,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -9904,7 +9904,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -10041,7 +10041,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -10178,7 +10178,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -10315,7 +10315,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -10452,7 +10452,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -10589,7 +10589,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -10720,7 +10720,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -10851,7 +10851,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -10982,7 +10982,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -11113,7 +11113,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -11244,7 +11244,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -11381,7 +11381,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -11538,7 +11538,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -11681,7 +11681,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -11824,7 +11824,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -11967,7 +11967,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -12110,7 +12110,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -12253,7 +12253,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -12396,7 +12396,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -12539,7 +12539,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -12682,7 +12682,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -12825,7 +12825,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -12968,7 +12968,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -13111,7 +13111,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -13280,7 +13280,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -13435,7 +13435,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -13590,7 +13590,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -13745,7 +13745,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -13889,7 +13889,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tnt_crud_tuples_fetched\") / (mean(\"tnt_crud_stats_count_ok\") + mean(\"tnt_crud_stats_count_error\"))\nas \"tnt_crud_tuples_per_request\" FROM\n(SELECT \"value\" as \"tnt_crud_tuples_fetched\" FROM \"autogen\".\"tarantool_app_http\"\nWHERE (\"metric_name\" = 'tnt_crud_tuples_fetched' AND \"label_pairs_operation\" = 'select') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_error\" FROM \"autogen\".\"tarantool_app_http\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_operation\" = 'select'\nAND \"label_pairs_status\" = 'error') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_ok\" FROM \"autogen\".\"tarantool_app_http\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_operation\" = 'select'\nAND \"label_pairs_status\" = 'ok') AND $timeFilter)\nGROUP BY time($__interval * 2), \"label_pairs_alias\", \"label_pairs_name\" fill(0)\n",
+                     "query": "SELECT mean(\"tnt_crud_tuples_fetched\") / (mean(\"tnt_crud_stats_count_ok\") + mean(\"tnt_crud_stats_count_error\"))\nas \"tnt_crud_tuples_per_request\" FROM\n(SELECT \"value\" as \"tnt_crud_tuples_fetched\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tnt_crud_tuples_fetched' AND \"label_pairs_operation\" = 'select') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_error\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_operation\" = 'select'\nAND \"label_pairs_status\" = 'error') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_ok\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_operation\" = 'select'\nAND \"label_pairs_status\" = 'ok') AND $timeFilter)\nGROUP BY time($__interval * 2), \"label_pairs_alias\", \"label_pairs_name\" fill(0)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -13996,7 +13996,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tnt_crud_tuples_lookup\") / (mean(\"tnt_crud_stats_count_ok\") + mean(\"tnt_crud_stats_count_error\"))\nas \"tnt_crud_tuples_per_request\" FROM\n(SELECT \"value\" as \"tnt_crud_tuples_lookup\" FROM \"autogen\".\"tarantool_app_http\"\nWHERE (\"metric_name\" = 'tnt_crud_tuples_lookup' AND \"label_pairs_operation\" = 'select') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_error\" FROM \"autogen\".\"tarantool_app_http\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_operation\" = 'select'\nAND \"label_pairs_status\" = 'error') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_ok\" FROM \"autogen\".\"tarantool_app_http\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_operation\" = 'select'\nAND \"label_pairs_status\" = 'ok') AND $timeFilter)\nGROUP BY time($__interval * 2), \"label_pairs_alias\", \"label_pairs_name\" fill(0)\n",
+                     "query": "SELECT mean(\"tnt_crud_tuples_lookup\") / (mean(\"tnt_crud_stats_count_ok\") + mean(\"tnt_crud_stats_count_error\"))\nas \"tnt_crud_tuples_per_request\" FROM\n(SELECT \"value\" as \"tnt_crud_tuples_lookup\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tnt_crud_tuples_lookup' AND \"label_pairs_operation\" = 'select') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_error\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_operation\" = 'select'\nAND \"label_pairs_status\" = 'error') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_ok\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_operation\" = 'select'\nAND \"label_pairs_status\" = 'ok') AND $timeFilter)\nGROUP BY time($__interval * 2), \"label_pairs_alias\", \"label_pairs_name\" fill(0)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -14114,7 +14114,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -14263,7 +14263,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -14418,7 +14418,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -14573,7 +14573,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -14728,7 +14728,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -14883,7 +14883,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -15038,7 +15038,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -15193,7 +15193,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -15348,7 +15348,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -15503,7 +15503,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -15658,7 +15658,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -15813,7 +15813,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -15968,7 +15968,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -16123,7 +16123,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -16278,7 +16278,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -16433,7 +16433,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -16588,7 +16588,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -16743,7 +16743,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -16898,7 +16898,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -17053,7 +17053,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -17208,7 +17208,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -17363,7 +17363,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -17518,7 +17518,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -17673,7 +17673,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -17828,7 +17828,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -17983,7 +17983,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -18138,7 +18138,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -18293,7 +18293,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -18448,7 +18448,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -18603,7 +18603,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -18758,7 +18758,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -18913,7 +18913,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -19068,7 +19068,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -19223,7 +19223,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -19378,7 +19378,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -19533,7 +19533,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -19688,7 +19688,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -19843,7 +19843,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -19998,7 +19998,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -20153,7 +20153,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -20308,7 +20308,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -20463,7 +20463,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -20618,7 +20618,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -20773,7 +20773,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -20928,7 +20928,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -21083,7 +21083,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -21238,7 +21238,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -21393,7 +21393,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -21548,7 +21548,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -21703,7 +21703,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -21858,7 +21858,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -22013,7 +22013,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -22168,7 +22168,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -22343,7 +22343,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -22486,7 +22486,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -22629,7 +22629,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -22766,7 +22766,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",

--- a/tests/InfluxDB/dashboard_tdg_compiled.json
+++ b/tests/InfluxDB/dashboard_tdg_compiled.json
@@ -12,7 +12,8 @@
          "description": "InfluxDB Tarantool metrics measurement",
          "label": "Measurement",
          "name": "INFLUXDB_MEASUREMENT",
-         "type": "constant"
+         "type": "constant",
+         "value": "tarantool_http"
       },
       {
          "description": "InfluxDB Tarantool metrics policy",

--- a/tests/InfluxDB/dashboard_tdg_static.sh
+++ b/tests/InfluxDB/dashboard_tdg_static.sh
@@ -2,5 +2,5 @@
 
 make DATASOURCE=influxdb \
      POLICY=autogen \
-     MEASUREMENT=tarantool_app_http \
+     MEASUREMENT=tarantool_http \
      build-static-tdg-influxdb

--- a/tests/InfluxDB/dashboard_tdg_static_compiled.json
+++ b/tests/InfluxDB/dashboard_tdg_static_compiled.json
@@ -120,7 +120,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -257,7 +257,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -460,7 +460,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -610,7 +610,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -711,7 +711,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -845,7 +845,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -994,7 +994,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -1125,7 +1125,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -1262,7 +1262,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -1399,7 +1399,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -1536,7 +1536,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -1667,7 +1667,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -1804,7 +1804,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -1935,7 +1935,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -2072,7 +2072,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -2203,7 +2203,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -2340,7 +2340,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -2505,7 +2505,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -2636,7 +2636,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -2767,7 +2767,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -2898,7 +2898,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -3029,7 +3029,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -3160,7 +3160,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -3291,7 +3291,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -3422,7 +3422,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -3553,7 +3553,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -3710,7 +3710,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -3853,7 +3853,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -3996,7 +3996,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -4145,7 +4145,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -4282,7 +4282,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -4439,7 +4439,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -4570,7 +4570,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -4701,7 +4701,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -4832,7 +4832,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -4963,7 +4963,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -5094,7 +5094,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -5225,7 +5225,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -5356,7 +5356,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -5487,7 +5487,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -5618,7 +5618,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -5755,7 +5755,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -5892,7 +5892,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -6029,7 +6029,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -6160,7 +6160,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -6297,7 +6297,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -6440,7 +6440,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -6577,7 +6577,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -6734,7 +6734,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -6871,7 +6871,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -7014,7 +7014,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -7163,7 +7163,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -7326,7 +7326,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -7457,7 +7457,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -7588,7 +7588,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -7719,7 +7719,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -7850,7 +7850,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -7981,7 +7981,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -8112,7 +8112,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -8263,7 +8263,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -8400,7 +8400,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -8537,7 +8537,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -8674,7 +8674,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -8805,7 +8805,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -8942,7 +8942,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -9079,7 +9079,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -9216,7 +9216,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -9353,7 +9353,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -9490,7 +9490,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -9627,7 +9627,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -9764,7 +9764,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -9901,7 +9901,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -10032,7 +10032,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -10163,7 +10163,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -10294,7 +10294,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -10425,7 +10425,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -10556,7 +10556,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -10693,7 +10693,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -10850,7 +10850,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -10993,7 +10993,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -11136,7 +11136,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -11279,7 +11279,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -11422,7 +11422,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -11565,7 +11565,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -11708,7 +11708,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -11851,7 +11851,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -11994,7 +11994,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -12137,7 +12137,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -12280,7 +12280,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -12423,7 +12423,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -12604,7 +12604,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -12753,7 +12753,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -12902,7 +12902,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -13051,7 +13051,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -13206,7 +13206,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -13361,7 +13361,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -13516,7 +13516,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -13671,7 +13671,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -13826,7 +13826,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -13981,7 +13981,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -14136,7 +14136,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -14317,7 +14317,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -14472,7 +14472,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -14633,7 +14633,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -14794,7 +14794,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -14955,7 +14955,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -15110,7 +15110,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -15265,7 +15265,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -15420,7 +15420,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -15575,7 +15575,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -15736,7 +15736,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -15897,7 +15897,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -16058,7 +16058,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -16219,7 +16219,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -16374,7 +16374,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -16535,7 +16535,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -16696,7 +16696,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -16857,7 +16857,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -17018,7 +17018,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -17179,7 +17179,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -17334,7 +17334,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -17501,7 +17501,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -17662,7 +17662,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -17823,7 +17823,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -17984,7 +17984,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -18145,7 +18145,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -18326,7 +18326,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -18481,7 +18481,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -18636,7 +18636,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -18797,7 +18797,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -18964,7 +18964,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -19125,7 +19125,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -19286,7 +19286,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -19447,7 +19447,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -19608,7 +19608,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -19769,7 +19769,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -19930,7 +19930,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -20097,7 +20097,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -20264,7 +20264,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -20431,7 +20431,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -20598,7 +20598,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -20765,7 +20765,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -20934,7 +20934,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -21083,7 +21083,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -21232,7 +21232,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -21387,7 +21387,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -21556,7 +21556,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -21705,7 +21705,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -21862,7 +21862,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -22005,7 +22005,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -22148,7 +22148,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -22285,7 +22285,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -22431,7 +22431,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_scanned_tuples_sum\") / mean(\"tdg_scanned_tuples_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_scanned_tuples_sum\" FROM \"autogen\".\"tarantool_app_http\"\nWHERE (\"metric_name\" = 'tdg_scanned_tuples_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_scanned_tuples_count\" FROM \"autogen\".\"tarantool_app_http\"\nWHERE (\"metric_name\" = 'tdg_scanned_tuples_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_type_name\" fill(none)\n",
+                     "query": "SELECT mean(\"tdg_scanned_tuples_sum\") / mean(\"tdg_scanned_tuples_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_scanned_tuples_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_scanned_tuples_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_scanned_tuples_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_scanned_tuples_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_type_name\" fill(none)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -22538,7 +22538,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_returned_tuples_sum\") / mean(\"tdg_returned_tuples_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_returned_tuples_sum\" FROM \"autogen\".\"tarantool_app_http\"\nWHERE (\"metric_name\" = 'tdg_returned_tuples_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_returned_tuples_count\" FROM \"autogen\".\"tarantool_app_http\"\nWHERE (\"metric_name\" = 'tdg_returned_tuples_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_type_name\" fill(none)\n",
+                     "query": "SELECT mean(\"tdg_returned_tuples_sum\") / mean(\"tdg_returned_tuples_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_returned_tuples_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_returned_tuples_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_returned_tuples_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_returned_tuples_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_type_name\" fill(none)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -22650,7 +22650,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -22781,7 +22781,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -22938,7 +22938,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -23075,7 +23075,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -23212,7 +23212,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -23349,7 +23349,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -23486,7 +23486,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -23623,7 +23623,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -23792,7 +23792,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -23924,7 +23924,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_graphql_query_time_sum\") / mean(\"tdg_graphql_query_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_graphql_query_time_sum\" FROM \"autogen\".\"tarantool_app_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_query_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_graphql_query_time_count\" FROM \"autogen\".\"tarantool_app_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_query_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_operation_name\",\n\"label_pairs_schema\", \"label_pairs_entity\" fill(none)\n",
+                     "query": "SELECT mean(\"tdg_graphql_query_time_sum\") / mean(\"tdg_graphql_query_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_graphql_query_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_query_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_graphql_query_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_query_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_operation_name\",\n\"label_pairs_schema\", \"label_pairs_entity\" fill(none)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -24054,7 +24054,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -24209,7 +24209,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -24341,7 +24341,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_graphql_mutation_time_sum\") / mean(\"tdg_graphql_mutation_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_graphql_mutation_time_sum\" FROM \"autogen\".\"tarantool_app_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_mutation_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_graphql_mutation_time_count\" FROM \"autogen\".\"tarantool_app_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_mutation_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_operation_name\",\n\"label_pairs_schema\", \"label_pairs_entity\" fill(none)\n",
+                     "query": "SELECT mean(\"tdg_graphql_mutation_time_sum\") / mean(\"tdg_graphql_mutation_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_graphql_mutation_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_mutation_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_graphql_mutation_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_mutation_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_operation_name\",\n\"label_pairs_schema\", \"label_pairs_entity\" fill(none)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -24471,7 +24471,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -24634,7 +24634,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -24783,7 +24783,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -24932,7 +24932,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -25081,7 +25081,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -25230,7 +25230,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -25379,7 +25379,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -25528,7 +25528,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -25677,7 +25677,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -25826,7 +25826,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -25975,7 +25975,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -26124,7 +26124,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -26273,7 +26273,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -26422,7 +26422,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -26571,7 +26571,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -26720,7 +26720,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -26869,7 +26869,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -27018,7 +27018,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -27167,7 +27167,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -27348,7 +27348,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -27515,7 +27515,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -27682,7 +27682,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -27849,7 +27849,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -28016,7 +28016,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -28183,7 +28183,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -28350,7 +28350,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -28517,7 +28517,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -28684,7 +28684,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -28851,7 +28851,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -29018,7 +29018,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -29185,7 +29185,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -29366,7 +29366,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -29515,7 +29515,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -29664,7 +29664,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -29813,7 +29813,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -29939,7 +29939,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_jobs_execution_time_sum\") / mean(\"tdg_jobs_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_jobs_execution_time_sum\" FROM \"autogen\".\"tarantool_app_http\"\nWHERE (\"metric_name\" = 'tdg_jobs_execution_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_jobs_execution_time_count\" FROM \"autogen\".\"tarantool_app_http\"\nWHERE (\"metric_name\" = 'tdg_jobs_execution_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\" fill(none)\n",
+                     "query": "SELECT mean(\"tdg_jobs_execution_time_sum\") / mean(\"tdg_jobs_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_jobs_execution_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_jobs_execution_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_jobs_execution_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_jobs_execution_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\" fill(none)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -30063,7 +30063,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -30212,7 +30212,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -30361,7 +30361,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -30510,7 +30510,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -30659,7 +30659,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -30785,7 +30785,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_tasks_execution_time_sum\") / mean(\"tdg_tasks_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_tasks_execution_time_sum\" FROM \"autogen\".\"tarantool_app_http\"\nWHERE (\"metric_name\" = 'tdg_tasks_execution_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_tasks_execution_time_count\" FROM \"autogen\".\"tarantool_app_http\"\nWHERE (\"metric_name\" = 'tdg_tasks_execution_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\",\n\"label_pairs_kind\" fill(none)\n",
+                     "query": "SELECT mean(\"tdg_tasks_execution_time_sum\") / mean(\"tdg_tasks_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_tasks_execution_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_tasks_execution_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_tasks_execution_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_tasks_execution_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\",\n\"label_pairs_kind\" fill(none)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -30909,7 +30909,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -31058,7 +31058,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -31207,7 +31207,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -31356,7 +31356,7 @@
                            "type": "fill"
                         }
                      ],
-                     "measurement": "tarantool_app_http",
+                     "measurement": "tarantool_http",
                      "policy": "autogen",
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -31482,7 +31482,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_system_tasks_execution_time_sum\") / mean(\"tdg_system_tasks_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_system_tasks_execution_time_sum\" FROM \"autogen\".\"tarantool_app_http\"\nWHERE (\"metric_name\" = 'tdg_system_tasks_execution_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_system_tasks_execution_time_count\" FROM \"autogen\".\"tarantool_app_http\"\nWHERE (\"metric_name\" = 'tdg_system_tasks_execution_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\",\n\"label_pairs_kind\" fill(none)\n",
+                     "query": "SELECT mean(\"tdg_system_tasks_execution_time_sum\") / mean(\"tdg_system_tasks_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_system_tasks_execution_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_system_tasks_execution_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_system_tasks_execution_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_system_tasks_execution_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\",\n\"label_pairs_kind\" fill(none)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",

--- a/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
+++ b/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
@@ -12,7 +12,8 @@
          "description": "InfluxDB Tarantool metrics measurement",
          "label": "Measurement",
          "name": "INFLUXDB_MEASUREMENT",
-         "type": "constant"
+         "type": "constant",
+         "value": "tarantool_http"
       },
       {
          "description": "InfluxDB Tarantool metrics policy",

--- a/tests/Prometheus/dashboard_compiled.json
+++ b/tests/Prometheus/dashboard_compiled.json
@@ -12,7 +12,8 @@
          "description": "Prometheus Tarantool metrics job",
          "label": "Job",
          "name": "PROMETHEUS_JOB",
-         "type": "constant"
+         "type": "constant",
+         "value": "tarantool"
       },
       {
          "description": "Time range for computing rps graphs with rate(). At the very minimum it should be two times the scrape interval.",

--- a/tests/Prometheus/dashboard_static.sh
+++ b/tests/Prometheus/dashboard_static.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 make DATASOURCE=Prometheus \
-     JOB=tarantool_app \
+     JOB=tarantool \
      RATE_TIME_RANGE=2m \
      OUTPUT_STATIC_DASHBOARD=./tests/Prometheus/dashboard_static_test_output.json \
      build-static-prometheus

--- a/tests/Prometheus/dashboard_static_compiled.json
+++ b/tests/Prometheus/dashboard_static_compiled.json
@@ -133,7 +133,7 @@
                ],
                "targets": [
                   {
-                     "expr": "up{job=~\"tarantool_app\"} * on(instance) group_left(alias) tnt_info_uptime{job=~\"tarantool_app\"} or\non(instance) label_replace(up{job=~\"tarantool_app\"}, \"alias\", \"Not available\", \"instance\", \".*\")\n",
+                     "expr": "up{job=~\"tarantool\"} * on(instance) group_left(alias) tnt_info_uptime{job=~\"tarantool\"} or\non(instance) label_replace(up{job=~\"tarantool\"}, \"alias\", \"Not available\", \"instance\", \".*\")\n",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -190,7 +190,7 @@
                "pluginVersion": "6.6.0",
                "targets": [
                   {
-                     "expr": "sum(up{job=~\"tarantool_app\"})",
+                     "expr": "sum(up{job=~\"tarantool\"})",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "",
@@ -244,7 +244,7 @@
                "pluginVersion": "6.6.0",
                "targets": [
                   {
-                     "expr": "sum(tnt_slab_arena_used{job=~\"tarantool_app\"})",
+                     "expr": "sum(tnt_slab_arena_used{job=~\"tarantool\"})",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "",
@@ -298,7 +298,7 @@
                "pluginVersion": "6.6.0",
                "targets": [
                   {
-                     "expr": "sum(tnt_slab_quota_size{job=~\"tarantool_app\"})",
+                     "expr": "sum(tnt_slab_quota_size{job=~\"tarantool\"})",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "",
@@ -352,7 +352,7 @@
                "pluginVersion": "6.6.0",
                "targets": [
                   {
-                     "expr": "sum(rate(http_server_request_latency_count{job=~\"tarantool_app\"}[2m]))",
+                     "expr": "sum(rate(http_server_request_latency_count{job=~\"tarantool\"}[2m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "",
@@ -406,7 +406,7 @@
                "pluginVersion": "6.6.0",
                "targets": [
                   {
-                     "expr": "sum(rate(tnt_net_requests_total{job=~\"tarantool_app\"}[2m]))",
+                     "expr": "sum(rate(tnt_net_requests_total{job=~\"tarantool\"}[2m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "",
@@ -460,7 +460,7 @@
                "pluginVersion": "6.6.0",
                "targets": [
                   {
-                     "expr": "sum(rate(tnt_stats_op_total{job=~\"tarantool_app\"}[2m]))",
+                     "expr": "sum(rate(tnt_stats_op_total{job=~\"tarantool\"}[2m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "",
@@ -516,7 +516,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_cartridge_issues{job=~\"tarantool_app\",level=\"warning\"}",
+                     "expr": "tnt_cartridge_issues{job=~\"tarantool\",level=\"warning\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -606,7 +606,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_cartridge_issues{job=~\"tarantool_app\",level=\"critical\"}",
+                     "expr": "tnt_cartridge_issues{job=~\"tarantool\",level=\"critical\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -750,7 +750,7 @@
                },
                "targets": [
                   {
-                     "expr": "tnt_replication_status{job=~\"tarantool_app\"}",
+                     "expr": "tnt_replication_status{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} {{stream}} ({{id}})",
@@ -859,7 +859,7 @@
                },
                "targets": [
                   {
-                     "expr": "tnt_read_only{job=~\"tarantool_app\"}",
+                     "expr": "tnt_read_only{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -913,7 +913,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_replication_lag{job=~\"tarantool_app\"}",
+                     "expr": "tnt_replication_lag{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} ({{id}})",
@@ -1000,7 +1000,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_clock_delta{job=~\"tarantool_app\"}",
+                     "expr": "tnt_clock_delta{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} ({{delta}})",
@@ -1108,7 +1108,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(http_server_request_latency_count{job=~\"tarantool_app\",status=~\"^2\\\\d{2}$\"}[2m])",
+                     "expr": "rate(http_server_request_latency_count{job=~\"tarantool\",status=~\"^2\\\\d{2}$\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
@@ -1198,7 +1198,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(http_server_request_latency_count{job=~\"tarantool_app\",status=~\"^4\\\\d{2}$\"}[2m])",
+                     "expr": "rate(http_server_request_latency_count{job=~\"tarantool\",status=~\"^4\\\\d{2}$\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
@@ -1288,7 +1288,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(http_server_request_latency_count{job=~\"tarantool_app\",status=~\"^5\\\\d{2}$\"}[2m])",
+                     "expr": "rate(http_server_request_latency_count{job=~\"tarantool\",status=~\"^5\\\\d{2}$\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
@@ -1378,7 +1378,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "http_server_request_latency{job=~\"tarantool_app\",quantile=\"0.99\",status=~\"^2\\\\d{2}$\"}",
+                     "expr": "http_server_request_latency{job=~\"tarantool\",quantile=\"0.99\",status=~\"^2\\\\d{2}$\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
@@ -1468,7 +1468,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "http_server_request_latency{job=~\"tarantool_app\",quantile=\"0.99\",status=~\"^4\\\\d{2}$\"}",
+                     "expr": "http_server_request_latency{job=~\"tarantool\",quantile=\"0.99\",status=~\"^4\\\\d{2}$\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
@@ -1558,7 +1558,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "http_server_request_latency{job=~\"tarantool_app\",quantile=\"0.99\",status=~\"^5\\\\d{2}$\"}",
+                     "expr": "http_server_request_latency{job=~\"tarantool\",quantile=\"0.99\",status=~\"^5\\\\d{2}$\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
@@ -1668,7 +1668,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_info_memory_net{job=~\"tarantool_app\"}",
+                     "expr": "tnt_info_memory_net{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1758,7 +1758,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_received_total{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tnt_net_received_total{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1848,7 +1848,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_sent_total{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tnt_net_sent_total{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1938,7 +1938,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_total{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tnt_net_requests_total{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2028,7 +2028,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_current{job=~\"tarantool_app\"}",
+                     "expr": "tnt_net_requests_current{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2118,7 +2118,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_in_progress_total{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tnt_net_requests_in_progress_total{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2208,7 +2208,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_in_progress_current{job=~\"tarantool_app\"}",
+                     "expr": "tnt_net_requests_in_progress_current{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2298,7 +2298,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_in_stream_queue_total{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tnt_net_requests_in_stream_queue_total{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2388,7 +2388,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_in_stream_queue_current{job=~\"tarantool_app\"}",
+                     "expr": "tnt_net_requests_in_stream_queue_current{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2478,7 +2478,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_connections_total{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tnt_net_connections_total{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2568,7 +2568,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_connections_current{job=~\"tarantool_app\"}",
+                     "expr": "tnt_net_connections_current{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2692,7 +2692,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_used_ratio{job=~\"tarantool_app\"}",
+                     "expr": "tnt_slab_quota_used_ratio{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2782,7 +2782,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_used_ratio{job=~\"tarantool_app\"}",
+                     "expr": "tnt_slab_arena_used_ratio{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2872,7 +2872,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_used_ratio{job=~\"tarantool_app\"}",
+                     "expr": "tnt_slab_items_used_ratio{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2962,7 +2962,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_used{job=~\"tarantool_app\"}",
+                     "expr": "tnt_slab_quota_used{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3052,7 +3052,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_used{job=~\"tarantool_app\"}",
+                     "expr": "tnt_slab_arena_used{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3142,7 +3142,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_used{job=~\"tarantool_app\"}",
+                     "expr": "tnt_slab_items_used{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3232,7 +3232,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_size{job=~\"tarantool_app\"}",
+                     "expr": "tnt_slab_quota_size{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3322,7 +3322,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_size{job=~\"tarantool_app\"}",
+                     "expr": "tnt_slab_arena_size{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3412,7 +3412,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_size{job=~\"tarantool_app\"}",
+                     "expr": "tnt_slab_items_size{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3522,7 +3522,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_len{job=~\"tarantool_app\", engine=\"memtx\"}",
+                     "expr": "tnt_space_len{job=~\"tarantool\", engine=\"memtx\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3612,7 +3612,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_tuples{job=~\"tarantool_app\", engine=\"vinyl\"}",
+                     "expr": "tnt_vinyl_tuples{job=~\"tarantool\", engine=\"vinyl\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3702,7 +3702,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_bsize{job=~\"tarantool_app\", engine=\"memtx\"}",
+                     "expr": "tnt_space_bsize{job=~\"tarantool\", engine=\"memtx\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3792,7 +3792,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_index_bsize{job=~\"tarantool_app\"}",
+                     "expr": "tnt_space_index_bsize{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}} ({{index_name}})",
@@ -3882,7 +3882,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_total_bsize{job=~\"tarantool_app\", engine=\"memtx\"}",
+                     "expr": "tnt_space_total_bsize{job=~\"tarantool\", engine=\"memtx\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3992,7 +3992,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_disk_data_size{job=~\"tarantool_app\"}",
+                     "expr": "tnt_vinyl_disk_data_size{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4082,7 +4082,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_disk_index_size{job=~\"tarantool_app\"}",
+                     "expr": "tnt_vinyl_disk_index_size{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4172,7 +4172,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_page_index{job=~\"tarantool_app\"}",
+                     "expr": "tnt_vinyl_memory_page_index{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4262,7 +4262,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_bloom_filter{job=~\"tarantool_app\"}",
+                     "expr": "tnt_vinyl_memory_bloom_filter{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4352,7 +4352,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_dump_bandwidth{job=~\"tarantool_app\"}",
+                     "expr": "tnt_vinyl_regulator_dump_bandwidth{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4442,7 +4442,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_write_rate{job=~\"tarantool_app\"}",
+                     "expr": "tnt_vinyl_regulator_write_rate{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4532,7 +4532,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_rate_limit{job=~\"tarantool_app\"}",
+                     "expr": "tnt_vinyl_regulator_rate_limit{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4622,7 +4622,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_dump_watermark{job=~\"tarantool_app\"}",
+                     "expr": "tnt_vinyl_regulator_dump_watermark{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4712,7 +4712,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_blocked_writers{job=~\"tarantool_app\"}",
+                     "expr": "tnt_vinyl_regulator_blocked_writers{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4802,7 +4802,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_commit{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tnt_vinyl_tx_commit{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4892,7 +4892,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_rollback{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tnt_vinyl_tx_rollback{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4982,7 +4982,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_conflict{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tnt_vinyl_tx_conflict{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5072,7 +5072,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_tx_read_views{job=~\"tarantool_app\"}",
+                     "expr": "tnt_vinyl_tx_read_views{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5162,7 +5162,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_scheduler_tasks{job=~\"tarantool_app\", status=\"inprogress\"}",
+                     "expr": "tnt_vinyl_scheduler_tasks{job=~\"tarantool\", status=\"inprogress\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5252,7 +5252,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_tasks{job=~\"tarantool_app\",status=\"failed\"}[2m])",
+                     "expr": "rate(tnt_vinyl_scheduler_tasks{job=~\"tarantool\",status=\"failed\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5342,7 +5342,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_dump_time{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tnt_vinyl_scheduler_dump_time{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5432,7 +5432,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_dump_total{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tnt_vinyl_scheduler_dump_total{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5542,7 +5542,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_cpu_user_time{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tnt_cpu_user_time{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5632,7 +5632,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_cpu_system_time{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tnt_cpu_system_time{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5742,7 +5742,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_info_memory_lua{job=~\"tarantool_app\"}",
+                     "expr": "tnt_info_memory_lua{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5832,7 +5832,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_info_memory_tx{job=~\"tarantool_app\"}",
+                     "expr": "tnt_info_memory_tx{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5922,7 +5922,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_csw{job=~\"tarantool_app\"}",
+                     "expr": "tnt_fiber_csw{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6012,7 +6012,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_ev_loop_time{job=~\"tarantool_app\"}",
+                     "expr": "tnt_ev_loop_time{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6102,7 +6102,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_amount{job=~\"tarantool_app\"}",
+                     "expr": "tnt_fiber_amount{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6192,7 +6192,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_memused{job=~\"tarantool_app\"}",
+                     "expr": "tnt_fiber_memused{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6282,7 +6282,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_memalloc{job=~\"tarantool_app\"}",
+                     "expr": "tnt_fiber_memalloc{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6392,7 +6392,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_snap_restore{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(lj_jit_snap_restore{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6482,7 +6482,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_trace_num{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(lj_jit_trace_num{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6572,7 +6572,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_trace_abort{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(lj_jit_trace_abort{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6662,7 +6662,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_jit_mcode_size{job=~\"tarantool_app\"}",
+                     "expr": "lj_jit_mcode_size{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6752,7 +6752,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_strhash_hit{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(lj_strhash_hit{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6842,7 +6842,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_strhash_miss{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(lj_strhash_miss{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6932,7 +6932,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_atomic{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(lj_gc_steps_atomic{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7022,7 +7022,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_sweepstring{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(lj_gc_steps_sweepstring{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7112,7 +7112,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_finalize{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(lj_gc_steps_finalize{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7202,7 +7202,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_sweep{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(lj_gc_steps_sweep{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7292,7 +7292,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_propagate{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(lj_gc_steps_propagate{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7382,7 +7382,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_pause{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(lj_gc_steps_pause{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7472,7 +7472,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_strnum{job=~\"tarantool_app\"}",
+                     "expr": "lj_gc_strnum{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7562,7 +7562,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_tabnum{job=~\"tarantool_app\"}",
+                     "expr": "lj_gc_tabnum{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7652,7 +7652,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_cdatanum{job=~\"tarantool_app\"}",
+                     "expr": "lj_gc_cdatanum{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7742,7 +7742,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_udatanum{job=~\"tarantool_app\"}",
+                     "expr": "lj_gc_udatanum{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7832,7 +7832,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_memory{job=~\"tarantool_app\"}",
+                     "expr": "lj_gc_memory{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7922,7 +7922,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_freed{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(lj_gc_freed{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8012,7 +8012,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_allocated{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(lj_gc_allocated{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8122,7 +8122,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool_app\",operation=\"select\"}[2m])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"select\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8212,7 +8212,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool_app\",operation=\"insert\"}[2m])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"insert\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8302,7 +8302,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool_app\",operation=\"replace\"}[2m])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"replace\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8392,7 +8392,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool_app\",operation=\"upsert\"}[2m])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"upsert\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8482,7 +8482,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool_app\",operation=\"update\"}[2m])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"update\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8572,7 +8572,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool_app\",operation=\"delete\"}[2m])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"delete\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8662,7 +8662,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool_app\",operation=\"call\"}[2m])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"call\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8752,7 +8752,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool_app\",operation=\"eval\"}[2m])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"eval\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8842,7 +8842,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool_app\",operation=\"error\"}[2m])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"error\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8932,7 +8932,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool_app\",operation=\"auth\"}[2m])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"auth\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9022,7 +9022,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool_app\",operation=\"prepare\"}[2m])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"prepare\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9112,7 +9112,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool_app\",operation=\"execute\"}[2m])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"execute\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9222,7 +9222,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"select\",status=\"ok\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"select\",status=\"ok\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -9312,7 +9312,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"select\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"select\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -9402,7 +9402,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"select\",status=\"error\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"select\",status=\"error\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -9492,7 +9492,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"select\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"select\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -9582,7 +9582,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_tuples_fetched{job=~\"tarantool_app\",operation=\"select\"}[2m]) /\n(sum without (status) (rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"select\"}[2m])))\n",
+                     "expr": "rate(tnt_crud_tuples_fetched{job=~\"tarantool\",operation=\"select\"}[2m]) /\n(sum without (status) (rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"select\"}[2m])))\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -9672,7 +9672,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_tuples_lookup{job=~\"tarantool_app\",operation=\"select\"}[2m]) /\n(sum without (status) (rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"select\"}[2m])))\n",
+                     "expr": "rate(tnt_crud_tuples_lookup{job=~\"tarantool\",operation=\"select\"}[2m]) /\n(sum without (status) (rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"select\"}[2m])))\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -9762,7 +9762,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_map_reduces{job=~\"tarantool_app\",operation=\"select\"}[2m])",
+                     "expr": "rate(tnt_crud_map_reduces{job=~\"tarantool\",operation=\"select\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -9852,7 +9852,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"insert\",status=\"ok\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"insert\",status=\"ok\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -9942,7 +9942,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"insert\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"insert\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10032,7 +10032,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"insert\",status=\"error\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"insert\",status=\"error\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10122,7 +10122,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"insert\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"insert\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10212,7 +10212,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"insert_many\",status=\"ok\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"insert_many\",status=\"ok\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10302,7 +10302,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"insert_many\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"insert_many\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10392,7 +10392,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"insert_many\",status=\"error\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"insert_many\",status=\"error\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10482,7 +10482,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"insert_many\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"insert_many\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10572,7 +10572,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"replace\",status=\"ok\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"replace\",status=\"ok\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10662,7 +10662,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"replace\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"replace\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10752,7 +10752,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"replace\",status=\"error\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"replace\",status=\"error\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10842,7 +10842,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"replace\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"replace\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10932,7 +10932,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"replace_many\",status=\"ok\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"replace_many\",status=\"ok\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11022,7 +11022,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"replace_many\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"replace_many\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11112,7 +11112,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"replace_many\",status=\"error\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"replace_many\",status=\"error\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11202,7 +11202,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"replace_many\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"replace_many\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11292,7 +11292,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"upsert\",status=\"ok\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"upsert\",status=\"ok\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11382,7 +11382,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"upsert\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"upsert\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11472,7 +11472,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"upsert\",status=\"error\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"upsert\",status=\"error\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11562,7 +11562,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"upsert\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"upsert\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11652,7 +11652,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"upsert_many\",status=\"ok\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"upsert_many\",status=\"ok\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11742,7 +11742,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"upsert_many\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"upsert_many\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11832,7 +11832,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"upsert_many\",status=\"error\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"upsert_many\",status=\"error\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11922,7 +11922,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"upsert_many\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"upsert_many\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12012,7 +12012,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"update\",status=\"ok\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"update\",status=\"ok\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12102,7 +12102,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"update\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"update\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12192,7 +12192,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"update\",status=\"error\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"update\",status=\"error\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12282,7 +12282,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"update\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"update\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12372,7 +12372,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"delete\",status=\"ok\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"delete\",status=\"ok\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12462,7 +12462,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"delete\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"delete\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12552,7 +12552,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"delete\",status=\"error\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"delete\",status=\"error\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12642,7 +12642,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"delete\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"delete\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12732,7 +12732,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"count\",status=\"ok\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"count\",status=\"ok\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12822,7 +12822,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"count\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"count\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12912,7 +12912,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"count\",status=\"error\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"count\",status=\"error\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13002,7 +13002,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"count\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"count\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13092,7 +13092,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"get\",status=\"ok\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"get\",status=\"ok\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13182,7 +13182,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"get\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"get\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13272,7 +13272,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"get\",status=\"error\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"get\",status=\"error\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13362,7 +13362,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"get\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"get\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13452,7 +13452,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"borders\",status=\"ok\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"borders\",status=\"ok\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13542,7 +13542,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"borders\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"borders\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13632,7 +13632,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"borders\",status=\"error\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"borders\",status=\"error\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13722,7 +13722,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"borders\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"borders\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13812,7 +13812,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"len\",status=\"ok\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"len\",status=\"ok\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13902,7 +13902,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"len\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"len\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13992,7 +13992,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"len\",status=\"error\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"len\",status=\"error\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14082,7 +14082,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"len\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"len\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14172,7 +14172,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"truncate\",status=\"ok\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"truncate\",status=\"ok\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14262,7 +14262,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"truncate\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"truncate\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14352,7 +14352,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool_app\",operation=\"truncate\",status=\"error\"}[2m])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"truncate\",status=\"error\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14442,7 +14442,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool_app\",operation=\"truncate\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"truncate\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14552,7 +14552,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(expirationd_checked_count{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(expirationd_checked_count{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -14642,7 +14642,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(expirationd_expired_count{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(expirationd_expired_count{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -14732,7 +14732,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "expirationd_restarts{job=~\"tarantool_app\"}",
+                     "expr": "expirationd_restarts{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -14822,7 +14822,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "expirationd_working_time{job=~\"tarantool_app\"}",
+                     "expr": "expirationd_working_time{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",

--- a/tests/Prometheus/dashboard_tdg_compiled.json
+++ b/tests/Prometheus/dashboard_tdg_compiled.json
@@ -12,7 +12,8 @@
          "description": "Prometheus Tarantool metrics job",
          "label": "Job",
          "name": "PROMETHEUS_JOB",
-         "type": "constant"
+         "type": "constant",
+         "value": "tarantool"
       },
       {
          "description": "Time range for computing rps graphs with rate(). At the very minimum it should be two times the scrape interval.",

--- a/tests/Prometheus/dashboard_tdg_static.sh
+++ b/tests/Prometheus/dashboard_tdg_static.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
 make DATASOURCE=Prometheus \
-     JOB=tarantool_app \
+     JOB=tarantool \
      RATE_TIME_RANGE=2m \
      build-static-tdg-prometheus

--- a/tests/Prometheus/dashboard_tdg_static_compiled.json
+++ b/tests/Prometheus/dashboard_tdg_static_compiled.json
@@ -133,7 +133,7 @@
                ],
                "targets": [
                   {
-                     "expr": "up{job=~\"tarantool_app\"} * on(instance) group_left(alias) tnt_info_uptime{job=~\"tarantool_app\"} or\non(instance) label_replace(up{job=~\"tarantool_app\"}, \"alias\", \"Not available\", \"instance\", \".*\")\n",
+                     "expr": "up{job=~\"tarantool\"} * on(instance) group_left(alias) tnt_info_uptime{job=~\"tarantool\"} or\non(instance) label_replace(up{job=~\"tarantool\"}, \"alias\", \"Not available\", \"instance\", \".*\")\n",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -190,7 +190,7 @@
                "pluginVersion": "6.6.0",
                "targets": [
                   {
-                     "expr": "sum(up{job=~\"tarantool_app\"})",
+                     "expr": "sum(up{job=~\"tarantool\"})",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "",
@@ -244,7 +244,7 @@
                "pluginVersion": "6.6.0",
                "targets": [
                   {
-                     "expr": "sum(tnt_slab_arena_used{job=~\"tarantool_app\"})",
+                     "expr": "sum(tnt_slab_arena_used{job=~\"tarantool\"})",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "",
@@ -298,7 +298,7 @@
                "pluginVersion": "6.6.0",
                "targets": [
                   {
-                     "expr": "sum(tnt_slab_quota_size{job=~\"tarantool_app\"})",
+                     "expr": "sum(tnt_slab_quota_size{job=~\"tarantool\"})",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "",
@@ -352,7 +352,7 @@
                "pluginVersion": "6.6.0",
                "targets": [
                   {
-                     "expr": "sum(rate(http_server_request_latency_count{job=~\"tarantool_app\"}[2m]))",
+                     "expr": "sum(rate(http_server_request_latency_count{job=~\"tarantool\"}[2m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "",
@@ -406,7 +406,7 @@
                "pluginVersion": "6.6.0",
                "targets": [
                   {
-                     "expr": "sum(rate(tnt_net_requests_total{job=~\"tarantool_app\"}[2m]))",
+                     "expr": "sum(rate(tnt_net_requests_total{job=~\"tarantool\"}[2m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "",
@@ -460,7 +460,7 @@
                "pluginVersion": "6.6.0",
                "targets": [
                   {
-                     "expr": "sum(rate(tnt_stats_op_total{job=~\"tarantool_app\"}[2m]))",
+                     "expr": "sum(rate(tnt_stats_op_total{job=~\"tarantool\"}[2m]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "",
@@ -516,7 +516,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_cartridge_issues{job=~\"tarantool_app\",level=\"warning\"}",
+                     "expr": "tnt_cartridge_issues{job=~\"tarantool\",level=\"warning\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -606,7 +606,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_cartridge_issues{job=~\"tarantool_app\",level=\"critical\"}",
+                     "expr": "tnt_cartridge_issues{job=~\"tarantool\",level=\"critical\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -750,7 +750,7 @@
                },
                "targets": [
                   {
-                     "expr": "tnt_replication_status{job=~\"tarantool_app\"}",
+                     "expr": "tnt_replication_status{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} {{stream}} ({{id}})",
@@ -859,7 +859,7 @@
                },
                "targets": [
                   {
-                     "expr": "tnt_read_only{job=~\"tarantool_app\"}",
+                     "expr": "tnt_read_only{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -913,7 +913,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_replication_lag{job=~\"tarantool_app\"}",
+                     "expr": "tnt_replication_lag{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} ({{id}})",
@@ -1000,7 +1000,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_clock_delta{job=~\"tarantool_app\"}",
+                     "expr": "tnt_clock_delta{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} ({{delta}})",
@@ -1108,7 +1108,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_info_memory_net{job=~\"tarantool_app\"}",
+                     "expr": "tnt_info_memory_net{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1198,7 +1198,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_received_total{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tnt_net_received_total{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1288,7 +1288,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_sent_total{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tnt_net_sent_total{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1378,7 +1378,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_total{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tnt_net_requests_total{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1468,7 +1468,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_current{job=~\"tarantool_app\"}",
+                     "expr": "tnt_net_requests_current{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1558,7 +1558,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_in_progress_total{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tnt_net_requests_in_progress_total{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1648,7 +1648,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_in_progress_current{job=~\"tarantool_app\"}",
+                     "expr": "tnt_net_requests_in_progress_current{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1738,7 +1738,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_in_stream_queue_total{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tnt_net_requests_in_stream_queue_total{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1828,7 +1828,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_in_stream_queue_current{job=~\"tarantool_app\"}",
+                     "expr": "tnt_net_requests_in_stream_queue_current{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1918,7 +1918,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_connections_total{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tnt_net_connections_total{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2008,7 +2008,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_connections_current{job=~\"tarantool_app\"}",
+                     "expr": "tnt_net_connections_current{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2132,7 +2132,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_used_ratio{job=~\"tarantool_app\"}",
+                     "expr": "tnt_slab_quota_used_ratio{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2222,7 +2222,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_used_ratio{job=~\"tarantool_app\"}",
+                     "expr": "tnt_slab_arena_used_ratio{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2312,7 +2312,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_used_ratio{job=~\"tarantool_app\"}",
+                     "expr": "tnt_slab_items_used_ratio{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2402,7 +2402,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_used{job=~\"tarantool_app\"}",
+                     "expr": "tnt_slab_quota_used{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2492,7 +2492,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_used{job=~\"tarantool_app\"}",
+                     "expr": "tnt_slab_arena_used{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2582,7 +2582,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_used{job=~\"tarantool_app\"}",
+                     "expr": "tnt_slab_items_used{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2672,7 +2672,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_size{job=~\"tarantool_app\"}",
+                     "expr": "tnt_slab_quota_size{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2762,7 +2762,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_size{job=~\"tarantool_app\"}",
+                     "expr": "tnt_slab_arena_size{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2852,7 +2852,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_size{job=~\"tarantool_app\"}",
+                     "expr": "tnt_slab_items_size{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2962,7 +2962,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_len{job=~\"tarantool_app\", engine=\"memtx\"}",
+                     "expr": "tnt_space_len{job=~\"tarantool\", engine=\"memtx\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3052,7 +3052,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_tuples{job=~\"tarantool_app\", engine=\"vinyl\"}",
+                     "expr": "tnt_vinyl_tuples{job=~\"tarantool\", engine=\"vinyl\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3142,7 +3142,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_bsize{job=~\"tarantool_app\", engine=\"memtx\"}",
+                     "expr": "tnt_space_bsize{job=~\"tarantool\", engine=\"memtx\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3232,7 +3232,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_index_bsize{job=~\"tarantool_app\"}",
+                     "expr": "tnt_space_index_bsize{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}} ({{index_name}})",
@@ -3322,7 +3322,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_total_bsize{job=~\"tarantool_app\", engine=\"memtx\"}",
+                     "expr": "tnt_space_total_bsize{job=~\"tarantool\", engine=\"memtx\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3432,7 +3432,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_disk_data_size{job=~\"tarantool_app\"}",
+                     "expr": "tnt_vinyl_disk_data_size{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3522,7 +3522,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_disk_index_size{job=~\"tarantool_app\"}",
+                     "expr": "tnt_vinyl_disk_index_size{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3612,7 +3612,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_page_index{job=~\"tarantool_app\"}",
+                     "expr": "tnt_vinyl_memory_page_index{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3702,7 +3702,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_bloom_filter{job=~\"tarantool_app\"}",
+                     "expr": "tnt_vinyl_memory_bloom_filter{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3792,7 +3792,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_dump_bandwidth{job=~\"tarantool_app\"}",
+                     "expr": "tnt_vinyl_regulator_dump_bandwidth{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3882,7 +3882,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_write_rate{job=~\"tarantool_app\"}",
+                     "expr": "tnt_vinyl_regulator_write_rate{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3972,7 +3972,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_rate_limit{job=~\"tarantool_app\"}",
+                     "expr": "tnt_vinyl_regulator_rate_limit{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4062,7 +4062,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_dump_watermark{job=~\"tarantool_app\"}",
+                     "expr": "tnt_vinyl_regulator_dump_watermark{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4152,7 +4152,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_blocked_writers{job=~\"tarantool_app\"}",
+                     "expr": "tnt_vinyl_regulator_blocked_writers{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4242,7 +4242,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_commit{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tnt_vinyl_tx_commit{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4332,7 +4332,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_rollback{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tnt_vinyl_tx_rollback{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4422,7 +4422,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_conflict{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tnt_vinyl_tx_conflict{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4512,7 +4512,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_tx_read_views{job=~\"tarantool_app\"}",
+                     "expr": "tnt_vinyl_tx_read_views{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4602,7 +4602,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_scheduler_tasks{job=~\"tarantool_app\", status=\"inprogress\"}",
+                     "expr": "tnt_vinyl_scheduler_tasks{job=~\"tarantool\", status=\"inprogress\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4692,7 +4692,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_tasks{job=~\"tarantool_app\",status=\"failed\"}[2m])",
+                     "expr": "rate(tnt_vinyl_scheduler_tasks{job=~\"tarantool\",status=\"failed\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4782,7 +4782,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_dump_time{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tnt_vinyl_scheduler_dump_time{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4872,7 +4872,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_dump_total{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tnt_vinyl_scheduler_dump_total{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4982,7 +4982,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_cpu_user_time{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tnt_cpu_user_time{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5072,7 +5072,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_cpu_system_time{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tnt_cpu_system_time{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5162,7 +5162,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_cpu_thread{job=~\"tarantool_app\",kind=\"user\"}[2m])",
+                     "expr": "rate(tnt_cpu_thread{job=~\"tarantool\",kind=\"user\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{thread_name}}",
@@ -5252,7 +5252,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_cpu_thread{job=~\"tarantool_app\",kind=\"system\"}[2m])",
+                     "expr": "rate(tnt_cpu_thread{job=~\"tarantool\",kind=\"system\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{thread_name}}",
@@ -5362,7 +5362,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_info_memory_lua{job=~\"tarantool_app\"}",
+                     "expr": "tnt_info_memory_lua{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5452,7 +5452,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_info_memory_tx{job=~\"tarantool_app\"}",
+                     "expr": "tnt_info_memory_tx{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5542,7 +5542,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_csw{job=~\"tarantool_app\"}",
+                     "expr": "tnt_fiber_csw{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5632,7 +5632,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_ev_loop_time{job=~\"tarantool_app\"}",
+                     "expr": "tnt_ev_loop_time{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5722,7 +5722,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_amount{job=~\"tarantool_app\"}",
+                     "expr": "tnt_fiber_amount{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5812,7 +5812,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_memused{job=~\"tarantool_app\"}",
+                     "expr": "tnt_fiber_memused{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5902,7 +5902,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_memalloc{job=~\"tarantool_app\"}",
+                     "expr": "tnt_fiber_memalloc{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6012,7 +6012,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_snap_restore{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(lj_jit_snap_restore{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6102,7 +6102,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_trace_num{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(lj_jit_trace_num{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6192,7 +6192,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_trace_abort{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(lj_jit_trace_abort{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6282,7 +6282,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_jit_mcode_size{job=~\"tarantool_app\"}",
+                     "expr": "lj_jit_mcode_size{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6372,7 +6372,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_strhash_hit{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(lj_strhash_hit{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6462,7 +6462,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_strhash_miss{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(lj_strhash_miss{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6552,7 +6552,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_atomic{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(lj_gc_steps_atomic{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6642,7 +6642,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_sweepstring{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(lj_gc_steps_sweepstring{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6732,7 +6732,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_finalize{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(lj_gc_steps_finalize{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6822,7 +6822,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_sweep{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(lj_gc_steps_sweep{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6912,7 +6912,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_propagate{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(lj_gc_steps_propagate{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7002,7 +7002,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_pause{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(lj_gc_steps_pause{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7092,7 +7092,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_strnum{job=~\"tarantool_app\"}",
+                     "expr": "lj_gc_strnum{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7182,7 +7182,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_tabnum{job=~\"tarantool_app\"}",
+                     "expr": "lj_gc_tabnum{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7272,7 +7272,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_cdatanum{job=~\"tarantool_app\"}",
+                     "expr": "lj_gc_cdatanum{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7362,7 +7362,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_udatanum{job=~\"tarantool_app\"}",
+                     "expr": "lj_gc_udatanum{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7452,7 +7452,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_memory{job=~\"tarantool_app\"}",
+                     "expr": "lj_gc_memory{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7542,7 +7542,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_freed{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(lj_gc_freed{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7632,7 +7632,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_allocated{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(lj_gc_allocated{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7742,7 +7742,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool_app\",operation=\"select\"}[2m])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"select\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7832,7 +7832,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool_app\",operation=\"insert\"}[2m])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"insert\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7922,7 +7922,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool_app\",operation=\"replace\"}[2m])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"replace\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8012,7 +8012,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool_app\",operation=\"upsert\"}[2m])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"upsert\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8102,7 +8102,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool_app\",operation=\"update\"}[2m])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"update\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8192,7 +8192,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool_app\",operation=\"delete\"}[2m])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"delete\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8282,7 +8282,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool_app\",operation=\"call\"}[2m])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"call\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8372,7 +8372,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool_app\",operation=\"eval\"}[2m])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"eval\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8462,7 +8462,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool_app\",operation=\"error\"}[2m])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"error\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8552,7 +8552,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool_app\",operation=\"auth\"}[2m])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"auth\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8642,7 +8642,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool_app\",operation=\"prepare\"}[2m])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"prepare\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8732,7 +8732,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool_app\",operation=\"execute\"}[2m])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"execute\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8842,7 +8842,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_replyq{job=~\"tarantool_app\"}",
+                     "expr": "tdg_kafka_replyq{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -8932,7 +8932,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_msg_size{job=~\"tarantool_app\"}",
+                     "expr": "tdg_kafka_msg_size{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -9022,7 +9022,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_msg_cnt{job=~\"tarantool_app\"}",
+                     "expr": "tdg_kafka_msg_cnt{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -9112,7 +9112,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_tx{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_tx{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -9202,7 +9202,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_tx_bytes{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_tx_bytes{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -9292,7 +9292,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_rx{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_rx{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -9382,7 +9382,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_rx_bytes{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_rx_bytes{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -9472,7 +9472,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_txmsgs{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_txmsgs{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -9562,7 +9562,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_txmsg_bytes{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_txmsg_bytes{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -9652,7 +9652,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_rxmsgs{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_rxmsgs{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -9742,7 +9742,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_rxmsg_bytes{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_rxmsg_bytes{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -9852,7 +9852,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_stateage{job=~\"tarantool_app\"}",
+                     "expr": "tdg_kafka_broker_stateage{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -9942,7 +9942,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_connects{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_broker_connects{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -10032,7 +10032,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_disconnects{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_broker_disconnects{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -10122,7 +10122,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_wakeups{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_broker_wakeups{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -10212,7 +10212,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_outbuf_cnt{job=~\"tarantool_app\"}",
+                     "expr": "tdg_kafka_broker_outbuf_cnt{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -10302,7 +10302,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_outbuf_msg_cnt{job=~\"tarantool_app\"}",
+                     "expr": "tdg_kafka_broker_outbuf_msg_cnt{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -10392,7 +10392,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_waitresp_cnt{job=~\"tarantool_app\"}",
+                     "expr": "tdg_kafka_broker_waitresp_cnt{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -10482,7 +10482,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_waitresp_msg_cnt{job=~\"tarantool_app\"}",
+                     "expr": "tdg_kafka_broker_waitresp_msg_cnt{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -10572,7 +10572,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_tx{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_broker_tx{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -10662,7 +10662,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_txbytes{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_broker_txbytes{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -10752,7 +10752,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_txerrs{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_broker_txerrs{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -10842,7 +10842,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_txretries{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_broker_txretries{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -10932,7 +10932,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_txidle{job=~\"tarantool_app\"}",
+                     "expr": "tdg_kafka_broker_txidle{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -11022,7 +11022,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_req_timeouts{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_broker_req_timeouts{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -11112,7 +11112,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_rx{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_broker_rx{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -11202,7 +11202,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_rxbytes{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_broker_rxbytes{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -11292,7 +11292,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_rxerrs{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_broker_rxerrs{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -11382,7 +11382,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_rxcorriderrs{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_broker_rxcorriderrs{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -11472,7 +11472,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_rxidle{job=~\"tarantool_app\"}",
+                     "expr": "tdg_kafka_broker_rxidle{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -11562,7 +11562,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_rxpartial{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_broker_rxpartial{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -11652,7 +11652,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_req{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_broker_req{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{request}} — {{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -11742,7 +11742,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_int_latency{job=~\"tarantool_app\",quantile=\"0.99\"}",
+                     "expr": "tdg_kafka_broker_int_latency{job=~\"tarantool\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -11832,7 +11832,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_outbuf_latency{job=~\"tarantool_app\",quantile=\"0.99\"}",
+                     "expr": "tdg_kafka_broker_outbuf_latency{job=~\"tarantool\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -11922,7 +11922,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_rtt{job=~\"tarantool_app\",quantile=\"0.99\"}",
+                     "expr": "tdg_kafka_broker_rtt{job=~\"tarantool\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -12012,7 +12012,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_throttle{job=~\"tarantool_app\",quantile=\"0.99\"}",
+                     "expr": "tdg_kafka_broker_throttle{job=~\"tarantool\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -12122,7 +12122,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_age{job=~\"tarantool_app\"}",
+                     "expr": "tdg_kafka_topic_age{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -12212,7 +12212,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_metadata_age{job=~\"tarantool_app\"}",
+                     "expr": "tdg_kafka_topic_metadata_age{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -12302,7 +12302,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_batchsize{job=~\"tarantool_app\",quantile=\"0.99\"}",
+                     "expr": "tdg_kafka_topic_batchsize{job=~\"tarantool\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -12392,7 +12392,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_batchcnt{job=~\"tarantool_app\",quantile=\"0.99\"}",
+                     "expr": "tdg_kafka_topic_batchcnt{job=~\"tarantool\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -12482,7 +12482,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_partitions_msgq_cnt{job=~\"tarantool_app\"}",
+                     "expr": "tdg_kafka_topic_partitions_msgq_cnt{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -12572,7 +12572,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_partitions_xmit_msgq_cnt{job=~\"tarantool_app\"}",
+                     "expr": "tdg_kafka_topic_partitions_xmit_msgq_cnt{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -12662,7 +12662,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_partitions_fetchq_cnt{job=~\"tarantool_app\"}",
+                     "expr": "tdg_kafka_topic_partitions_fetchq_cnt{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -12752,7 +12752,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_partitions_msgq_bytes{job=~\"tarantool_app\"}",
+                     "expr": "tdg_kafka_topic_partitions_msgq_bytes{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -12842,7 +12842,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_partitions_xmit_msgq_bytes{job=~\"tarantool_app\"}",
+                     "expr": "tdg_kafka_topic_partitions_xmit_msgq_bytes{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -12932,7 +12932,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_partitions_fetchq_size{job=~\"tarantool_app\"}",
+                     "expr": "tdg_kafka_topic_partitions_fetchq_size{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -13022,7 +13022,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_topic_partitions_txmsgs{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_topic_partitions_txmsgs{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -13112,7 +13112,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_topic_partitions_txbytes{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_topic_partitions_txbytes{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -13202,7 +13202,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_topic_partitions_rxmsgs{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_topic_partitions_rxmsgs{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -13292,7 +13292,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_topic_partitions_rxbytes{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_topic_partitions_rxbytes{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -13382,7 +13382,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_topic_partitions_rx_ver_drops{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_topic_partitions_rx_ver_drops{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -13472,7 +13472,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_partitions_msgs_inflight{job=~\"tarantool_app\"}",
+                     "expr": "tdg_kafka_topic_partitions_msgs_inflight{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -13582,7 +13582,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_cgrp_stateage{job=~\"tarantool_app\"}",
+                     "expr": "tdg_kafka_cgrp_stateage{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -13672,7 +13672,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_cgrp_rebalance_age{job=~\"tarantool_app\"}",
+                     "expr": "tdg_kafka_cgrp_rebalance_age{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -13762,7 +13762,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_cgrp_rebalance_cnt{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_kafka_cgrp_rebalance_cnt{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -13852,7 +13852,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_cgrp_assignment_size{job=~\"tarantool_app\"}",
+                     "expr": "tdg_kafka_cgrp_assignment_size{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -13962,7 +13962,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_eos_idemp_stateage{job=~\"tarantool_app\"}",
+                     "expr": "tdg_kafka_eos_idemp_stateage{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -14052,7 +14052,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_eos_txn_stateage{job=~\"tarantool_app\"}",
+                     "expr": "tdg_kafka_eos_txn_stateage{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -14162,7 +14162,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_expiration_checked_count{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_expiration_checked_count{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -14252,7 +14252,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_expiration_expired_count{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_expiration_expired_count{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -14342,7 +14342,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_expiration_restarts{job=~\"tarantool_app\"}",
+                     "expr": "tdg_expiration_restarts{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -14432,7 +14432,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_expiration_working_time{job=~\"tarantool_app\"}",
+                     "expr": "tdg_expiration_working_time{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -14542,7 +14542,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_scanned_tuples_sum{job=~\"tarantool_app\"} /\ntdg_scanned_tuples_count{job=~\"tarantool_app\"}\n",
+                     "expr": "tdg_scanned_tuples_sum{job=~\"tarantool\"} /\ntdg_scanned_tuples_count{job=~\"tarantool\"}\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type_name}} — {{alias}}",
@@ -14632,7 +14632,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_returned_tuples_sum{job=~\"tarantool_app\"} /\ntdg_returned_tuples_count{job=~\"tarantool_app\"}\n",
+                     "expr": "tdg_returned_tuples_sum{job=~\"tarantool\"} /\ntdg_returned_tuples_count{job=~\"tarantool\"}\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type_name}} — {{alias}}",
@@ -14722,7 +14722,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_scanned_tuples_max{job=~\"tarantool_app\"}",
+                     "expr": "tdg_scanned_tuples_max{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -14812,7 +14812,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_returned_tuples_max{job=~\"tarantool_app\"}",
+                     "expr": "tdg_returned_tuples_max{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -14922,7 +14922,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_connector_input_file_processed_count{job=~\"tarantool_app\"}",
+                     "expr": "tdg_connector_input_file_processed_count{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{connector_name}} — {{alias}}",
@@ -15012,7 +15012,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_connector_input_file_processed_objects_count{job=~\"tarantool_app\"}",
+                     "expr": "tdg_connector_input_file_processed_objects_count{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{connector_name}} — {{alias}}",
@@ -15102,7 +15102,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_connector_input_file_failed_count{job=~\"tarantool_app\"}",
+                     "expr": "tdg_connector_input_file_failed_count{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{connector_name}} — {{alias}}",
@@ -15192,7 +15192,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_connector_input_file_size{job=~\"tarantool_app\"}",
+                     "expr": "tdg_connector_input_file_size{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{connector_name}} — {{alias}}",
@@ -15282,7 +15282,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_connector_input_file_current_bytes_processed{job=~\"tarantool_app\"}",
+                     "expr": "tdg_connector_input_file_current_bytes_processed{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{connector_name}} — {{alias}}",
@@ -15372,7 +15372,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_connector_input_file_current_processed_objects{job=~\"tarantool_app\"}",
+                     "expr": "tdg_connector_input_file_current_processed_objects{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{connector_name}} — {{alias}}",
@@ -15482,7 +15482,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_graphql_query_time_count{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_graphql_query_time_count{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{operation_name}} ({{schema}}, {{entity}}) — {{alias}}",
@@ -15572,7 +15572,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_graphql_query_time_sum{job=~\"tarantool_app\"} /\ntdg_graphql_query_time_count{job=~\"tarantool_app\"}\n",
+                     "expr": "tdg_graphql_query_time_sum{job=~\"tarantool\"} /\ntdg_graphql_query_time_count{job=~\"tarantool\"}\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{operation_name}} ({{schema}}, {{entity}}) — {{alias}}",
@@ -15662,7 +15662,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_graphql_query_fail{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_graphql_query_fail{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{operation_name}} ({{schema}}, {{entity}}) — {{alias}}",
@@ -15752,7 +15752,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_graphql_mutation_time_count{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_graphql_mutation_time_count{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{operation_name}} ({{schema}}, {{entity}}) — {{alias}}",
@@ -15842,7 +15842,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_graphql_mutation_time_sum{job=~\"tarantool_app\"} /\ntdg_graphql_mutation_time_count{job=~\"tarantool_app\"}\n",
+                     "expr": "tdg_graphql_mutation_time_sum{job=~\"tarantool\"} /\ntdg_graphql_mutation_time_count{job=~\"tarantool\"}\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{operation_name}} ({{schema}}, {{entity}}) — {{alias}}",
@@ -15932,7 +15932,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_graphql_mutation_fail{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_graphql_mutation_fail{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{operation_name}} ({{schema}}, {{entity}}) — {{alias}}",
@@ -16042,7 +16042,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool_app\",method=\"repository.put\"}[2m])",
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",method=\"repository.put\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -16132,7 +16132,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool_app\",method=\"repository.put\",quantile=\"0.99\"}",
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",method=\"repository.put\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -16222,7 +16222,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool_app\",method=\"repository.put_batch\"}[2m])",
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",method=\"repository.put_batch\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -16312,7 +16312,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool_app\",method=\"repository.put_batch\",quantile=\"0.99\"}",
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",method=\"repository.put_batch\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -16402,7 +16402,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool_app\",method=\"repository.find\"}[2m])",
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",method=\"repository.find\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -16492,7 +16492,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool_app\",method=\"repository.find\",quantile=\"0.99\"}",
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",method=\"repository.find\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -16582,7 +16582,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool_app\",method=\"repository.update\"}[2m])",
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",method=\"repository.update\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -16672,7 +16672,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool_app\",method=\"repository.update\",quantile=\"0.99\"}",
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",method=\"repository.update\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -16762,7 +16762,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool_app\",method=\"repository.get\"}[2m])",
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",method=\"repository.get\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -16852,7 +16852,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool_app\",method=\"repository.get\",quantile=\"0.99\"}",
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",method=\"repository.get\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -16942,7 +16942,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool_app\",method=\"repository.delete\"}[2m])",
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",method=\"repository.delete\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -17032,7 +17032,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool_app\",method=\"repository.delete\",quantile=\"0.99\"}",
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",method=\"repository.delete\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -17122,7 +17122,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool_app\",method=\"repository.count\"}[2m])",
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",method=\"repository.count\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -17212,7 +17212,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool_app\",method=\"repository.count\",quantile=\"0.99\"}",
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",method=\"repository.count\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -17302,7 +17302,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool_app\",method=\"repository.map_reduce\"}[2m])",
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",method=\"repository.map_reduce\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -17392,7 +17392,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool_app\",method=\"repository.map_reduce\",quantile=\"0.99\"}",
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",method=\"repository.map_reduce\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -17482,7 +17482,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool_app\",method=\"repository.call_on_storage\"}[2m])",
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",method=\"repository.call_on_storage\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -17572,7 +17572,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool_app\",method=\"repository.call_on_storage\",quantile=\"0.99\"}",
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",method=\"repository.call_on_storage\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -17682,7 +17682,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool_app\",method=\"GET\",status_code=~\"^2\\\\d{2}$\"}[2m])",
+                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool\",method=\"GET\",status_code=~\"^2\\\\d{2}$\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
@@ -17772,7 +17772,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool_app\",method=\"GET\",status_code=~\"^4\\\\d{2}$\"}[2m])",
+                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool\",method=\"GET\",status_code=~\"^4\\\\d{2}$\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
@@ -17862,7 +17862,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool_app\",method=\"GET\",status_code=~\"^5\\\\d{2}$\"}[2m])",
+                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool\",method=\"GET\",status_code=~\"^5\\\\d{2}$\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
@@ -17952,7 +17952,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_rest_exec_time{job=~\"tarantool_app\",method=\"GET\",status_code=~\"^2\\\\d{2}$\",quantile=\"0.99\"}",
+                     "expr": "tdg_rest_exec_time{job=~\"tarantool\",method=\"GET\",status_code=~\"^2\\\\d{2}$\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
@@ -18042,7 +18042,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_rest_exec_time{job=~\"tarantool_app\",method=\"GET\",status_code=~\"^4\\\\d{2}$\",quantile=\"0.99\"}",
+                     "expr": "tdg_rest_exec_time{job=~\"tarantool\",method=\"GET\",status_code=~\"^4\\\\d{2}$\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
@@ -18132,7 +18132,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_rest_exec_time{job=~\"tarantool_app\",method=\"GET\",status_code=~\"^5\\\\d{2}$\",quantile=\"0.99\"}",
+                     "expr": "tdg_rest_exec_time{job=~\"tarantool\",method=\"GET\",status_code=~\"^5\\\\d{2}$\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
@@ -18222,7 +18222,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool_app\",method!=\"GET\",status_code=~\"^2\\\\d{2}$\"}[2m])",
+                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool\",method!=\"GET\",status_code=~\"^2\\\\d{2}$\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
@@ -18312,7 +18312,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool_app\",method!=\"GET\",status_code=~\"^4\\\\d{2}$\"}[2m])",
+                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool\",method!=\"GET\",status_code=~\"^4\\\\d{2}$\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
@@ -18402,7 +18402,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool_app\",method!=\"GET\",status_code=~\"^5\\\\d{2}$\"}[2m])",
+                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool\",method!=\"GET\",status_code=~\"^5\\\\d{2}$\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
@@ -18492,7 +18492,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_rest_exec_time{job=~\"tarantool_app\",method!=\"GET\",status_code=~\"^2\\\\d{2}$\",quantile=\"0.99\"}",
+                     "expr": "tdg_rest_exec_time{job=~\"tarantool\",method!=\"GET\",status_code=~\"^2\\\\d{2}$\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
@@ -18582,7 +18582,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_rest_exec_time{job=~\"tarantool_app\",method!=\"GET\",status_code=~\"^4\\\\d{2}$\",quantile=\"0.99\"}",
+                     "expr": "tdg_rest_exec_time{job=~\"tarantool\",method!=\"GET\",status_code=~\"^4\\\\d{2}$\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
@@ -18672,7 +18672,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_rest_exec_time{job=~\"tarantool_app\",method!=\"GET\",status_code=~\"^5\\\\d{2}$\",quantile=\"0.99\"}",
+                     "expr": "tdg_rest_exec_time{job=~\"tarantool\",method!=\"GET\",status_code=~\"^5\\\\d{2}$\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
@@ -18782,7 +18782,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_jobs_started{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_jobs_started{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -18872,7 +18872,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_jobs_failed{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_jobs_failed{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -18962,7 +18962,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_jobs_succeeded{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_jobs_succeeded{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -19052,7 +19052,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_jobs_running{job=~\"tarantool_app\"}",
+                     "expr": "tdg_jobs_running{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -19142,7 +19142,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_jobs_execution_time_sum{job=~\"tarantool_app\"} /\ntdg_jobs_execution_time_count{job=~\"tarantool_app\"}\n",
+                     "expr": "tdg_jobs_execution_time_sum{job=~\"tarantool\"} /\ntdg_jobs_execution_time_count{job=~\"tarantool\"}\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -19232,7 +19232,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_tasks_started{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_tasks_started{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
@@ -19322,7 +19322,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_tasks_failed{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_tasks_failed{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
@@ -19412,7 +19412,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_tasks_succeeded{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_tasks_succeeded{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
@@ -19502,7 +19502,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_tasks_stopped{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_tasks_stopped{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
@@ -19592,7 +19592,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_tasks_running{job=~\"tarantool_app\"}",
+                     "expr": "tdg_tasks_running{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
@@ -19682,7 +19682,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_tasks_execution_time_sum{job=~\"tarantool_app\"} /\ntdg_tasks_execution_time_count{job=~\"tarantool_app\"}\n",
+                     "expr": "tdg_tasks_execution_time_sum{job=~\"tarantool\"} /\ntdg_tasks_execution_time_count{job=~\"tarantool\"}\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
@@ -19772,7 +19772,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_system_tasks_started{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_system_tasks_started{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
@@ -19862,7 +19862,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_system_tasks_failed{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_system_tasks_failed{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
@@ -19952,7 +19952,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_system_tasks_succeeded{job=~\"tarantool_app\"}[2m])",
+                     "expr": "rate(tdg_system_tasks_succeeded{job=~\"tarantool\"}[2m])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
@@ -20042,7 +20042,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_system_tasks_running{job=~\"tarantool_app\"}",
+                     "expr": "tdg_system_tasks_running{job=~\"tarantool\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
@@ -20132,7 +20132,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_system_tasks_execution_time_sum{job=~\"tarantool_app\"} /\ntdg_system_tasks_execution_time_count{job=~\"tarantool_app\"}\n",
+                     "expr": "tdg_system_tasks_execution_time_sum{job=~\"tarantool\"} /\ntdg_system_tasks_execution_time_count{job=~\"tarantool\"}\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{kind}}) — {{alias}}",

--- a/tests/Prometheus/dashboard_with_custom_panels_compiled.json
+++ b/tests/Prometheus/dashboard_with_custom_panels_compiled.json
@@ -12,7 +12,8 @@
          "description": "Prometheus Tarantool metrics job",
          "label": "Job",
          "name": "PROMETHEUS_JOB",
-         "type": "constant"
+         "type": "constant",
+         "value": "tarantool"
       },
       {
          "description": "Time range for computing rps graphs with rate(). At the very minimum it should be two times the scrape interval.",


### PR DESCRIPTION
### dashboard: set default Prometheus job

Set default Prometheus job to `tarantool`. After this patch, it will be possible to import dashboard with `community.ansible.ansible_dashboard`, if Prometheus is configured to collect Tarantool metrics with
 tarantool` job.

This patch also changes all examples job names to `tarantool`.

### dashboard: set default InfluxDB measurement

Set default InfluxDB measurement to `tarantool_http`. After this patch, it will be possible to import dashboard with
`community.ansible.ansible_dashboard`, if Telegraf is configured to collect Tarantool metrics with `http` plugin and `tarantool_` prefix.

This patch also changes all examples measurement names to `tarantool_http`.

Closes #138