### PR TITLE
Release 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [1.4.0] - 2022-08-03
+Grafana revisions: [InfluxDB revision 14](https://grafana.com/api/dashboards/12567/revisions/14/download), [Prometheus revision 14](https://grafana.com/api/dashboards/13054/revisions/14/download), [InfluxDB TDG revision 3](https://grafana.com/api/dashboards/16405/revisions/3/download), [Prometheus TDG revision 3](https://grafana.com/api/dashboards/16406/revisions/3/download).
 
 ## Added
 - Options to build static dashboards


### PR DESCRIPTION
Grafana revisions:
- InfluxDB revision 14 [1]
- Prometheus revision 14 [2]
- InfluxDB TDG revision 3 [3]
- Prometheus TDG revision 3 [4]

Added:
- Options to build static dashboards
- Runtime arena memory panel
- Vinyl tuple cache and level 0 memory panels

Changed:
- Set default Prometheus job to `tarantool`
- Set default InfluxDB measurement to `tarantool_http`
- Use in-built `$__rate_interval` instead of user-defined `$rate_time_range`
- Use `fill(null)` in InfluxQL requests

1. https://grafana.com/api/dashboards/12567/revisions/14/download
2. https://grafana.com/api/dashboards/13054/revisions/14/download
3. https://grafana.com/api/dashboards/16405/revisions/3/download
4. https://grafana.com/api/dashboards/16406/revisions/3/download