### PR TITLE
Alerting documentation

### DIFF
--- a/doc/monitoring/alerting.rst
+++ b/doc/monitoring/alerting.rst
@@ -1,0 +1,410 @@
+.. _monitoring-alerting-page:
+
+===============================================================================
+Alerting
+===============================================================================
+
+You can set up alerts on metrics to get a notification when something went
+wrong. We will use `Prometheus alert rules <https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/>`_
+as an example here. You can get full ``alerts.yml`` file at
+`tarantool/grafana-dashboard GitHub repo <https://github.com/tarantool/grafana-dashboard/tree/master/example_cluster/prometheus/alerts.yml>`_.
+
+.. _monitoring-alerting-tarantool:
+
+-------------------------------------------------------------------------------
+Tarantool metrics
+-------------------------------------------------------------------------------
+
+You can use internal Tarantool metrics to monitor detailed RAM consumption,
+replication state, database engine status, track business logic issues (like
+HTTP 4xx and 5xx responses or low request rate) and external modules statistics
+(like ``CRUD`` errors or Cartridge issues). Evaluation timeouts, severity
+levels and thresholds (especially ones for business logic) are placed here for
+the sake of example: you may want to increase or decrease them for your
+application. Also, don't forget to set sane rate time ranges based on your
+Prometheus configuration.
+
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+Lua memory
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+The Lua memory is limited to 2 GB per instance. Monitoring ``tnt_info_memory_lua``
+metric may prevent memory overflow and detect the presence of bad Lua code
+practices.
+
+..  code-block:: yaml
+
+    - alert: HighLuaMemoryWarning
+      expr: tnt_info_memory_lua >= (512 * 1024 * 1024)
+      for: 1m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') Lua runtime warning"
+        description: "'{{ $labels.alias }}' instance of job '{{ $labels.job }}' uses too much Lua memory
+          and may hit threshold soon."
+
+    - alert: HighLuaMemoryAlert
+      expr: tnt_info_memory_lua >= (1024 * 1024 * 1024)
+      for: 1m
+      labels:
+        severity: page
+      annotations:
+        summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') Lua runtime alert"
+        description: "'{{ $labels.alias }}' instance of job '{{ $labels.job }}' uses too much Lua memory
+          and likely to hit threshold soon."
+
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+Memtx arena memory
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+By monitoring :ref:`slab allocation statistics <box_slab_info>` you can see
+how many free RAM is remaining to store memtx tuples and indexes for an
+instance. If Tarantool hit the limits, the instance will become unavailable
+for write operations, so this alert may help you see when it's time to increase
+your ``memtx_memory`` limit or to add a new storage to a vshard cluster.
+
+..  code-block:: yaml
+
+    - alert: LowMemtxArenaRemainingWarning
+      expr: (tnt_slab_quota_used_ratio >= 80) and (tnt_slab_arena_used_ratio >= 80)
+      for: 1m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') low arena memory remaining"
+        description: "Low arena memory (tuples and indexes) remaining for '{{ $labels.alias }}' instance of job '{{ $labels.job }}'.
+          Consider increasing memtx_memory or number of storages in case of sharded data."
+
+    - alert: LowMemtxArenaRemaining
+      expr: (tnt_slab_quota_used_ratio >= 90) and (tnt_slab_arena_used_ratio >= 90)
+      for: 1m
+      labels:
+        severity: page
+      annotations:
+        summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') low arena memory remaining"
+        description: "Low arena memory (tuples and indexes) remaining for '{{ $labels.alias }}' instance of job '{{ $labels.job }}'.
+          You are likely to hit limit soon.
+          It is strongly recommended to increase memtx_memory or number of storages in case of sharded data."
+
+    - alert: LowMemtxItemsRemainingWarning
+      expr: (tnt_slab_quota_used_ratio >= 80) and (tnt_slab_items_used_ratio >= 80)
+      for: 1m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') low items memory remaining"
+        description: "Low items memory (tuples) remaining for '{{ $labels.alias }}' instance of job '{{ $labels.job }}'.
+          Consider increasing memtx_memory or number of storages in case of sharded data."
+
+    - alert: LowMemtxItemsRemaining
+      expr: (tnt_slab_quota_used_ratio >= 90) and (tnt_slab_items_used_ratio >= 90)
+      for: 1m
+      labels:
+        severity: page
+      annotations:
+        summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') low items memory remaining"
+        description: "Low items memory (tuples) remaining for '{{ $labels.alias }}' instance of job '{{ $labels.job }}'.
+          You are likely to hit limit soon.
+          It is strongly recommended to increase memtx_memory or number of storages in case of sharded data."
+
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+Vinyl engine status
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+You can monitor :ref:`vinyl regulator <box_introspection-box_stat_vinyl_regulator>`
+performance to track possible scheduler or disk issues.
+
+..  code-block:: yaml
+
+    - alert: LowVinylRegulatorRateLimit
+      expr: tnt_vinyl_regulator_rate_limit < 100000
+      for: 1m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') have low vinyl regulator rate limit"
+        description: "Instance '{{ $labels.alias }}' of job '{{ $labels.job }}' have low vinyl engine regulator rate limit.
+          This indicates issues with the disk or the scheduler."
+
+
+:ref:`Vinyl transactions <box_introspection-box_stat_vinyl_tx>` errors are likely
+to lead to user requests errors.
+
+..  code-block:: yaml
+
+    - alert: HighVinylTxConflictRate
+      expr: rate(tnt_vinyl_tx_conflict[5m]) / rate(tnt_vinyl_tx_commit[5m]) > 0.05
+      for: 1m
+      labels:
+        severity: critical
+      annotations:
+        summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') have high vinyl tx conflict rate"
+        description: "Instance '{{ $labels.alias }}' of job '{{ $labels.job }}' have
+          high vinyl transactions conflict rate. It indicates that vinyl is not healthy."
+
+:ref:`Vinyl scheduler <box_introspection-box_stat_vinyl>` failed tasks
+are a good signal of disk issues and may be the reason of increasing RAM
+consumption.
+
+..  code-block:: yaml
+
+    - alert: HighVinylSchedulerFailedTasksRate
+      expr: rate(tnt_vinyl_scheduler_tasks{status="failed"}[5m]) > 0.1
+      for: 1m
+      labels:
+        severity: critical
+      annotations:
+        summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') have high vinyl scheduler failed tasks rate"
+        description: "Instance '{{ $labels.alias }}' of job '{{ $labels.job }}' have
+          high vinyl scheduler failed tasks rate."
+
+
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+Replication state
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+If ``tnt_replication_status`` is equal to ``0``, instance :ref:`replication <box_info_replication>`
+status is not equal to ``"follows"``: replication is either not ready yet or
+has been stopped due to some reason. 
+
+..  code-block:: yaml
+
+    - alert: ReplicationNotRunning
+      expr: tnt_replication_status == 0
+      for: 1m
+      labels:
+        severity: critical
+      annotations:
+        summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') {{ $labels.stream }} (id {{ $labels.id }})
+          replication is not running"
+        description: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') {{ $labels.stream }} (id {{ $labels.id }})
+          replication is not running. Check Cartridge UI for details."
+
+Even if async replication is ``"follows"``, it could be considered malfunctioning
+if the lag is too high. It also may affect Tarantool garbage collector work,
+see :ref:`box.info.gc() <box_info_gc>`.
+
+..  code-block:: yaml
+
+    - alert: HighReplicationLag
+      expr: tnt_replication_lag > 1
+      for: 1m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') have high replication lag (id {{ $labels.id }})"
+        description: "Instance '{{ $labels.alias }}' of job '{{ $labels.job }}' have high replication lag
+          (id {{ $labels.id }}), check up your network and cluster state."
+
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+Event loop
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+High :ref:`fiber <fiber-fibers>` event loop time leads to bad application
+performance, timeouts and various warnings. The reason could be a high quantity
+of working fibers or fibers that spend too much time without any yields or
+sleeps.
+
+..  code-block:: yaml
+
+    - alert: HighEVLoopTime
+      expr: tnt_ev_loop_time > 0.1
+      for: 1m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') event loop has high cycle duration"
+        description: "Instance '{{ $labels.alias }}' of job '{{ $labels.job }}' event loop has high cycle duration.
+          Some high loaded fiber has too little yields. It may be the reason of 'Too long WAL write' warnings."
+
+
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+Cartridge issues
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+:ref:`Cartridge issues and warnings <cartridge-troubleshooting>` aggregate
+both single instance or replicaset issues (like memory or replication issues
+we've discussed in another paragraphs) and Cartridge cluster malfunctions
+(for example, clusteride config issues).
+
+..  code-block:: yaml
+
+    - alert: CartridgeWarningIssues
+      expr: tnt_cartridge_issues{level="warning"} > 0
+      for: 1m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') has 'warning'-level Cartridge issues"
+        description: "Instance '{{ $labels.alias }}' of job '{{ $labels.job }}' has 'warning'-level Cartridge issues.
+          Possible reasons: high replication lag, replication long idle,
+          failover or switchover issues, clock issues, memory fragmentation,
+          configuration issues, alien members."
+
+    - alert: CartridgeCriticalIssues
+      expr: tnt_cartridge_issues{level="critical"} > 0
+      for: 1m
+      labels:
+        severity: page
+      annotations:
+        summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') has 'critical'-level Cartridge issues"
+        description: "Instance '{{ $labels.alias }}' of job '{{ $labels.job }}' has 'critical'-level Cartridge issues.
+          Possible reasons: replication process critical fail,
+          running out of available memory."
+
+
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+HTTP server statistics
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+:ref:`metrics <metrics-reference>` allows to monitor `tarantool/http <https://github.com/tarantool/http>`_
+handles, see :ref:`"Collecting HTTP request latency statistics" <metrics-api_reference-collecting_http_statistics>`.
+Here we use a ``summary`` collector with a default name and 0.99 quantile
+computation.
+
+Too many responses with error codes usually is a sign of API issues or
+application malfunction.
+
+..  code-block:: yaml
+
+    - alert: HighInstanceHTTPClientErrorRate
+      expr: sum by (job, instance, method, path, alias) (rate(http_server_request_latency_count{ job="tarantool", status=~"^4\\d{2}$" }[5m])) > 10
+      for: 1m
+      labels:
+        severity: page
+      annotations:
+        summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') high rate of client error responses"
+        description: "Too many {{ $labels.method }} requests to {{ $labels.path }} path 
+          on '{{ $labels.alias }}' instance of job '{{ $labels.job }}' get client error (4xx) responses."
+
+    - alert: HighHTTPClientErrorRate
+      expr: sum by (job, method, path) (rate(http_server_request_latency_count{ job="tarantool", status=~"^4\\d{2}$" }[5m])) > 20
+      for: 1m
+      labels:
+        severity: page
+      annotations:
+        summary: "Job '{{ $labels.job }}' high rate of client error responses"
+        description: "Too many {{ $labels.method }} requests to {{ $labels.path }} path
+          on instances of job '{{ $labels.job }}' get client error (4xx) responses."
+
+    - alert: HighHTTPServerErrorRate
+      expr: sum by (job, instance, method, path, alias) (rate(http_server_request_latency_count{ job="tarantool", status=~"^5\\d{2}$" }[5m])) > 0
+      for: 1m
+      labels:
+        severity: page
+      annotations:
+        summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') server error responses"
+        description: "Some {{ $labels.method }} requests to {{ $labels.path }} path 
+          on '{{ $labels.alias }}' instance of job '{{ $labels.job }}' get server error (5xx) responses."
+
+Responding with high latency is a synonym of insufficient performance. It may
+be a sign of application malfunction. Or maybe you need to add more routers to
+your cluster.
+
+..  code-block:: yaml
+
+    - alert: HighHTTPLatency
+      expr: http_server_request_latency{ job="tarantool", quantile="0.99" } > 0.1
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') high HTTP latency"
+        description: "Some {{ $labels.method }} requests to {{ $labels.path }} path with {{ $labels.status }} response status
+          on '{{ $labels.alias }}' instance of job '{{ $labels.job }}' are processed too long."
+
+Having too little requests when you expect them may detect balancer, external
+client or network malfunction.
+
+..  code-block:: yaml
+
+    - alert: LowRouterHTTPRequestRate
+      expr: sum by (job, instance, alias) (rate(http_server_request_latency_count{ job="tarantool", alias=~"^.*router.*$" }[5m])) < 10
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Router '{{ $labels.alias }}' ('{{ $labels.job }}') low activity"
+        description: "Router '{{ $labels.alias }}' instance of job '{{ $labels.job }}' gets too little requests.
+          Please, check up your balancer middleware."
+
+
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+CRUD module statistics
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+If your application uses `CRUD <https://github.com/tarantool/crud>`_ module
+requests, monitoring module statistics may track internal errors caused by
+invalid process of input and internal parameters.
+
+..  code-block:: yaml
+
+    - alert: HighCRUDErrorRate
+      expr: rate(tnt_crud_stats_count{ job="tarantool", status="error" }[5m]) > 0.1
+      for: 1m
+      labels:
+        severity: critical
+      annotations:
+        summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') too many CRUD {{ $labels.operation }} errors."
+        description: "Too many {{ $labels.operation }} CRUD requests for '{{ $labels.name }}' space on
+          '{{ $labels.alias }}' instance of job '{{ $labels.job }}' get module error responses."
+
+Statistics could also monitor requests performance. Too high request latency
+will lead to high latency of client responses. It may be caused by network
+or disk issues. Read requests with bad (with respect to space indexes and
+sharding schema) conditions may lead to full-scans or map reduces and also
+could be the reason of high latency.
+
+..  code-block:: yaml
+
+    - alert: HighCRUDLatency
+      expr: tnt_crud_stats{ job="tarantool", quantile="0.99" } > 0.1
+      for: 1m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') too high CRUD {{ $labels.operation }} latency."
+        description: "Some {{ $labels.operation }} {{ $labels.status }} CRUD requests for '{{ $labels.name }}' space on
+          '{{ $labels.alias }}' instance of job '{{ $labels.job }}' are processed too long."
+
+You also can directly monitor map reduces and scan rate.
+
+..  code-block:: yaml
+
+    - alert: HighCRUDMapReduceRate
+      expr: rate(tnt_crud_map_reduces{ job="tarantool" }[5m]) > 0.1
+      for: 1m
+      labels:
+        severity: warning
+      annotations:
+        summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') too many CRUD {{ $labels.operation }} map reduces."
+        description: "There are too many {{ $labels.operation }} CRUD map reduce requests for '{{ $labels.name }}' space on
+          '{{ $labels.alias }}' instance of job '{{ $labels.job }}'.
+          Check your request conditions or consider changing sharding schema."
+
+
+.. _monitoring-alerting-server:
+
+-------------------------------------------------------------------------------
+Server-side monitoring
+-------------------------------------------------------------------------------
+
+If there are no Tarantool metrics, you may miss critical conditions. Prometheus
+provide ``up`` metric to monitor the health of its targets.
+
+..  code-block:: yaml
+
+    - alert: InstanceDown
+      expr: up == 0
+      for: 1m
+      labels:
+        severity: page
+      annotations:
+        summary: "Instance '{{ $labels.instance }}' ('{{ $labels.job }}') down"
+        description: "'{{ $labels.instance }}' of job '{{ $labels.job }}' has been down for more than a minute."
+
+Do not forget to monitor your server's CPU, disk and RAM from server side with
+your favorite tools. For example, on some high CPU consumption cases Tarantool
+instance may stop to send metrics, so you can track such breakdowns only from
+the outside.

--- a/doc/monitoring/grafana_dashboard.rst
+++ b/doc/monitoring/grafana_dashboard.rst
@@ -17,7 +17,7 @@ space operations, and HTTP load panels, based on default `metrics <https://githu
 package functionality.
 
 Dashboard requires using ``metrics`` **0.13.0** or newer for complete experience;
-``'alias'`` :ref:`global label <tarantool-metrics>` must be set on each instance
+``'alias'`` :ref:`global label <metrics-api_reference-labels>` must be set on each instance
 to properly display panels (e.g. provided with ``cartridge.roles.metrics`` role).
 
 To support `CRUD <https://github.com/tarantool/crud>`_ statistics, install ``CRUD``
@@ -76,9 +76,9 @@ Collect metrics with server agents
 -------------------------------------------------------------------------------
 
 To collect metrics for Prometheus, first set up metrics output with
-``prometheus`` format. You can use :ref:`cartridge.roles.metrics <cartridge-role>`
-configuration or set up the :ref:`Prometheus output plugin <prometheus>` manually.
-To start collecting metrics,
+``prometheus`` format. You can use :ref:`cartridge.roles.metrics <monitoring-getting_started-cartridge_role>`
+configuration or set up the :ref:`Prometheus output plugin <metrics-plugins-available>`
+manually. To start collecting metrics,
 `add a job <https://prometheus.io/docs/prometheus/latest/getting_started/#configure-prometheus-to-monitor-the-sample-targets>`_
 to Prometheus configuration with each Tarantool instance URI as a target and
 metrics path as it was configured on Tarantool instances:
@@ -97,9 +97,9 @@ metrics path as it was configured on Tarantool instances:
 
 To collect metrics for InfluxDB, use the Telegraf agent.
 First off, configure Tarantool metrics output in ``json`` format
-with :ref:`cartridge.roles.metrics <cartridge-role>` configuration or
-corresponding :ref:`JSON output plugin <json>`. To start collecting metrics,
-add `http input <https://github.com/influxdata/telegraf/blob/release-1.17/plugins/inputs/http/README.md>`_
+with :ref:`cartridge.roles.metrics <monitoring-getting_started-cartridge_role>`
+configuration or corresponding :ref:`JSON output plugin <metrics-plugins-available>`.
+To start collecting metrics, add `http input <https://github.com/influxdata/telegraf/blob/release-1.17/plugins/inputs/http/README.md>`_
 to Telegraf configuration including each Tarantool instance metrics URL:
 
 ..  code-block:: toml

--- a/doc/monitoring/grafana_dashboard.rst
+++ b/doc/monitoring/grafana_dashboard.rst
@@ -32,6 +32,13 @@ with latency quantiles.
         stats_quantiles=true
     }
 
+To support `expirationd <https://github.com/tarantool/expirationd>`_ statistics,
+install ``expirationd`` **1.2.0** or newer. Call ``expirationd.cfg`` on instance
+to enable statistics export.
+
+..  code-block:: lua
+
+    expirationd.cfg{metrics = true}
 
 .. image:: images/Prometheus_dashboard_1.png
    :width: 30%

--- a/example_cluster/prometheus/alerts.yml
+++ b/example_cluster/prometheus/alerts.yml
@@ -14,8 +14,8 @@ groups:
 
 - name: tarantool-common
   rules:
-  # Warning for any instance that uses too Lua runtime memory.
-  - alert: LuaRuntimeWarning
+  # Warning for any instance that uses too much Lua runtime memory.
+  - alert: HighLuaMemoryWarning
     expr: tnt_info_memory_lua >= (512 * 1024 * 1024) 
     for: 1m
     labels:
@@ -25,8 +25,8 @@ groups:
       description: "'{{ $labels.alias }}' instance of job '{{ $labels.job }}' uses too much Lua memory
         and may hit threshold soon."
 
-  # Alert for any instance that uses too Lua runtime memory.
-  - alert: LuaRuntimeAlert
+  # Alert for any instance that uses too much Lua runtime memory.
+  - alert: HighLuaMemory
     expr: tnt_info_memory_lua >= (1024 * 1024 * 1024) 
     for: 1m
     labels:
@@ -37,7 +37,7 @@ groups:
         and likely to hit threshold soon."
 
   # Warning for any instance that have low remaining arena memory.
-  - alert: MemtxArenaWarning
+  - alert: LowMemtxArenaRemainingWarning
     expr: (tnt_slab_quota_used_ratio >= 80) and (tnt_slab_arena_used_ratio >= 80)
     for: 1m
     labels:
@@ -48,7 +48,7 @@ groups:
         Consider increasing memtx_memory or number of storages in case of sharded data."
 
   # Alert for any instance that have low remaining arena memory.
-  - alert: MemtxArenaAlert
+  - alert: LowMemtxArenaRemaining
     expr: (tnt_slab_quota_used_ratio >= 90) and (tnt_slab_arena_used_ratio >= 90)
     for: 1m
     labels:
@@ -60,7 +60,7 @@ groups:
       It is strongly recommended to increase memtx_memory or number of storages in case of sharded data."
 
   # Warning for any instance that have low remaining items memory.
-  - alert: MemtxItemsWarning
+  - alert: LowMemtxItemsRemainingWarning
     expr: (tnt_slab_quota_used_ratio >= 80) and (tnt_slab_items_used_ratio >= 80)
     for: 1m
     labels:
@@ -71,7 +71,7 @@ groups:
         Consider increasing memtx_memory or number of storages in case of sharded data."
 
   # Alert for any instance that have low remaining arena memory.
-  - alert: MemtxItemsAlert
+  - alert: LowMemtxItemsRemaining
     expr: (tnt_slab_quota_used_ratio >= 90) and (tnt_slab_items_used_ratio >= 90)
     for: 1m
     labels:
@@ -178,7 +178,7 @@ groups:
 - name: tarantool-crud
   rules:
   # Alert for CRUD module request errors.
-  - alert: CRUDHighErrorRate
+  - alert: HighCRUDErrorRate
     expr: rate(tnt_crud_stats_count{ job="tarantool", status="error" }[5m]) > 0.1
     for: 1m
     labels:
@@ -189,7 +189,7 @@ groups:
       '{{ $labels.alias }}' instance of job '{{ $labels.job }}' get module error responses."
 
   # Warning for CRUD module requests too long responses.
-  - alert: CRUDHighLatency
+  - alert: HighCRUDLatency
     expr: tnt_crud_stats{ job="tarantool", quantile="0.99" } > 0.1
     for: 1m
     labels:
@@ -200,7 +200,7 @@ groups:
       '{{ $labels.alias }}' instance of job '{{ $labels.job }}' are processed too long."
 
   # Warning for too many map reduce CRUD module requests.
-  - alert: CRUDHighMapReduceRate
+  - alert: HighCRUDMapReduceRate
     expr: rate(tnt_crud_map_reduces{ job="tarantool" }[5m]) > 0.1
     for: 1m
     labels:
@@ -218,7 +218,7 @@ groups:
   # Beware that metric name depends on name of the collector you use in HTTP metrics middleware
   # and request depends on type of this collector.
   # This example based on summary collector with default name.
-  - alert: HTTPHighLatency
+  - alert: HighHTTPLatency
     expr: http_server_request_latency{ job="tarantool", quantile="0.99" } > 0.1
     for: 5m
     labels:
@@ -228,43 +228,43 @@ groups:
       description: "Some {{ $labels.method }} requests to {{ $labels.path }} path with {{ $labels.status }} response status
         on '{{ $labels.alias }}' instance of job '{{ $labels.job }}' are processed too long."
 
-  # Warning for any endpoint of an instance in tarantool job that sends too much 4xx responses.
+  # Alert for any endpoint of an instance in tarantool job that sends too much 4xx responses.
   # Beware that metric name depends on name of the collector you use in HTTP metrics middleware
   # and request depends on type of this collector.
   # This example based on summary collector with default name.
-  - alert: HTTPHighClientErrorRateInstance
+  - alert: HighInstanceHTTPClientErrorRate
     expr: sum by (job, instance, method, path, alias) (rate(http_server_request_latency_count{ job="tarantool", status=~"^4\\d{2}$" }[5m])) > 10
     for: 1m
     labels:
-      severity: warning
+      severity: page
     annotations:
       summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') high rate of client error responses"
       description: "Too many {{ $labels.method }} requests to {{ $labels.path }} path 
         on '{{ $labels.alias }}' instance of job '{{ $labels.job }}' get client error (4xx) responses."
 
-  # Warning for any endpoint in tarantool job that sends too much 4xx responses (cluster overall).
+  # Alert for any endpoint in tarantool job that sends too much 4xx responses (cluster overall).
   # Beware that metric name depends on name of the collector you use in HTTP metrics middleware
   # and request depends on type of this collector.
   # This example based on summary collector with default name.
-  - alert: HTTPHighClientErrorRate
+  - alert: HighHTTPClientErrorRate
     expr: sum by (job, method, path) (rate(http_server_request_latency_count{ job="tarantool", status=~"^4\\d{2}$" }[5m])) > 20
     for: 1m
     labels:
-      severity: warning
+      severity: page
     annotations:
       summary: "Job '{{ $labels.job }}' high rate of client error responses"
       description: "Too many {{ $labels.method }} requests to {{ $labels.path }} path
         on instances of job '{{ $labels.job }}' get client error (4xx) responses."
 
-  # Warning for any endpoint of an instance in tarantool job that sends 5xx responses.
+  # Alert for any endpoint of an instance in tarantool job that sends 5xx responses.
   # Beware that metric name depends on name of the collector you use in HTTP metrics middleware
   # and request depends on type of this collector.
   # This example based on summary collector with default name.
-  - alert: HTTPServerErrors
+  - alert: HighHTTPServerErrorRate
     expr: sum by (job, instance, method, path, alias) (rate(http_server_request_latency_count{ job="tarantool", status=~"^5\\d{2}$" }[5m])) > 0
     for: 1m
     labels:
-      severity: warning
+      severity: page
     annotations:
       summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') server error responses"
       description: "Some {{ $labels.method }} requests to {{ $labels.path }} path 
@@ -274,7 +274,7 @@ groups:
   # Beware that metric name depends on name of the collector you use in HTTP metrics middleware
   # and request depends on type of this collector.
   # This example based on summary collector with default name.
-  - alert: HTTPLowRequestRateRouter
+  - alert: LowRouterHTTPRequestRate
     expr: sum by (job, instance, alias) (rate(http_server_request_latency_count{ job="tarantool", alias=~"^.*router.*$" }[5m])) < 10
     for: 5m
     labels:

--- a/example_cluster/prometheus/alerts.yml
+++ b/example_cluster/prometheus/alerts.yml
@@ -131,7 +131,7 @@ groups:
 
   # Alert for Tarantool high vinyl transactions conflict rate.
   - alert: HighVinylTxConflictRate
-    expr: rate(tnt_vinyl_tx_conflict[2m]) / rate(tnt_vinyl_tx_commit[2m]) > 0.05
+    expr: rate(tnt_vinyl_tx_conflict[5m]) / rate(tnt_vinyl_tx_commit[5m]) > 0.05
     for: 1m
     labels:
       severity: critical
@@ -142,7 +142,7 @@ groups:
 
   # Alert for Tarantool high vinyl scheduler failed tasks rate.
   - alert: HighVinylSchedulerFailedTasksRate
-    expr: rate(tnt_vinyl_scheduler_tasks{status="failed"}[2m]) > 0.1
+    expr: rate(tnt_vinyl_scheduler_tasks{status="failed"}[5m]) > 0.1
     for: 1m
     labels:
       severity: critical

--- a/example_cluster/prometheus/alerts.yml
+++ b/example_cluster/prometheus/alerts.yml
@@ -16,7 +16,7 @@ groups:
   rules:
   # Warning for any instance that uses too much Lua runtime memory.
   - alert: HighLuaMemoryWarning
-    expr: tnt_info_memory_lua >= (512 * 1024 * 1024) 
+    expr: tnt_info_memory_lua >= (512 * 1024 * 1024)
     for: 1m
     labels:
       severity: warning
@@ -27,7 +27,7 @@ groups:
 
   # Alert for any instance that uses too much Lua runtime memory.
   - alert: HighLuaMemory
-    expr: tnt_info_memory_lua >= (1024 * 1024 * 1024) 
+    expr: tnt_info_memory_lua >= (1024 * 1024 * 1024)
     for: 1m
     labels:
       severity: page
@@ -56,8 +56,8 @@ groups:
     annotations:
       summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') low arena memory remaining"
       description: "Low arena memory (tuples and indexes) remaining for '{{ $labels.alias }}' instance of job '{{ $labels.job }}'.
-      You are likely to hit limit soon.
-      It is strongly recommended to increase memtx_memory or number of storages in case of sharded data."
+        You are likely to hit limit soon.
+        It is strongly recommended to increase memtx_memory or number of storages in case of sharded data."
 
   # Warning for any instance that have low remaining items memory.
   - alert: LowMemtxItemsRemainingWarning
@@ -170,9 +170,9 @@ groups:
       severity: critical
     annotations:
       summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') {{ $labels.stream }} (id {{ $labels.id }})
-         replication is not running"
+        replication is not running"
       description: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') {{ $labels.stream }} (id {{ $labels.id }})
-         replication is not running. Check Cartridge UI for details."
+        replication is not running. Check Cartridge UI for details."
 
 
 - name: tarantool-crud
@@ -186,7 +186,7 @@ groups:
     annotations:
       summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') too many CRUD {{ $labels.operation }} errors."
       description: "Too many {{ $labels.operation }} CRUD requests for '{{ $labels.name }}' space on
-      '{{ $labels.alias }}' instance of job '{{ $labels.job }}' get module error responses."
+        '{{ $labels.alias }}' instance of job '{{ $labels.job }}' get module error responses."
 
   # Warning for CRUD module requests too long responses.
   - alert: HighCRUDLatency
@@ -197,7 +197,7 @@ groups:
     annotations:
       summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') too high CRUD {{ $labels.operation }} latency."
       description: "Some {{ $labels.operation }} {{ $labels.status }} CRUD requests for '{{ $labels.name }}' space on
-      '{{ $labels.alias }}' instance of job '{{ $labels.job }}' are processed too long."
+        '{{ $labels.alias }}' instance of job '{{ $labels.job }}' are processed too long."
 
   # Warning for too many map reduce CRUD module requests.
   - alert: HighCRUDMapReduceRate
@@ -208,8 +208,8 @@ groups:
     annotations:
       summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') too many CRUD {{ $labels.operation }} map reduces."
       description: "There are too many {{ $labels.operation }} CRUD map reduce requests for '{{ $labels.name }}' space on
-      '{{ $labels.alias }}' instance of job '{{ $labels.job }}'.
-      Check your request conditions or consider changing sharding schema."
+        '{{ $labels.alias }}' instance of job '{{ $labels.job }}'.
+        Check your request conditions or consider changing sharding schema."
 
 
 - name: tarantool-business
@@ -281,5 +281,5 @@ groups:
       severity: warning
     annotations:
       summary: "Router '{{ $labels.alias }}' ('{{ $labels.job }}') low activity"
-      description: Router '{{ $labels.alias }}' instance of job '{{ $labels.job }}' gets too little requests.
+      description: "Router '{{ $labels.alias }}' instance of job '{{ $labels.job }}' gets too little requests.
         Please, check up your balancer middleware."

--- a/example_cluster/prometheus/alerts.yml
+++ b/example_cluster/prometheus/alerts.yml
@@ -109,14 +109,14 @@ groups:
 
   # Alert for Tarantool replication high lag (both for masters and replicas).
   - alert: HighReplicationLag
-    expr: '{__name__=~"tnt_replication_[[:digit:]]{1,2}_lag"} > 1'
+    expr: tnt_replication_lag > 1
     for: 1m
     labels:
       severity: warning
     annotations:
-      summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') have high replication lag"
-      description: "Instance '{{ $labels.alias }}' of job '{{ $labels.job }}' have high replication lag,
-        check up your network and cluster state."
+      summary: "Instance '{{ $labels.alias }}' ('{{ $labels.job }}') have high replication lag (id {{ $labels.id }})"
+      description: "Instance '{{ $labels.alias }}' of job '{{ $labels.job }}' have high replication lag
+        (id {{ $labels.id }}), check up your network and cluster state."
 
   # Alert for Tarantool low vinyl engine regulator rate limit.
   - alert: LowVinylRegulatorRateLimit

--- a/example_cluster/prometheus/test_alerts.yml
+++ b/example_cluster/prometheus/test_alerts.yml
@@ -32,7 +32,7 @@ tests:
         values: '209715200+104857600x8' # 200 Mb + 100 Mb each interval
     alert_rule_test:
       - eval_time: 2m
-        alertname: LuaRuntimeWarning
+        alertname: HighLuaMemoryWarning
         exp_alerts:
           - exp_labels:
               severity: warning
@@ -44,7 +44,7 @@ tests:
               description: "'tnt_router' instance of job 'tarantool' uses too much Lua memory
                 and may hit threshold soon."
       - eval_time: 2m
-        alertname: LuaRuntimeAlert
+        alertname: HighLuaMemory
         exp_alerts: # no alert firing
 
 
@@ -54,7 +54,7 @@ tests:
         values: '419430400+209715200x8' # 400 Mb + 200 Mb each interval
     alert_rule_test:
       - eval_time: 2m
-        alertname: LuaRuntimeWarning
+        alertname: HighLuaMemoryWarning
         exp_alerts:
           - exp_labels:
               severity: warning
@@ -66,7 +66,7 @@ tests:
               description: "'tnt_router' instance of job 'tarantool' uses too much Lua memory
                 and may hit threshold soon."
       - eval_time: 2m
-        alertname: LuaRuntimeAlert
+        alertname: HighLuaMemory
         exp_alerts:
           - exp_labels:
               severity: page
@@ -87,10 +87,10 @@ tests:
         values: '92+0x2 76+0x8'
     alert_rule_test:
       - eval_time: 2m
-        alertname: MemtxArenaWarning
+        alertname: LowMemtxArenaRemainingWarning
         exp_alerts: # no alert firing
       - eval_time: 2m
-        alertname: MemtxArenaAlert
+        alertname: LowMemtxArenaRemaining
         exp_alerts: # no alert firing
 
 
@@ -102,7 +102,7 @@ tests:
         values: '92+0x2 82+0x8'
     alert_rule_test:
       - eval_time: 2m
-        alertname: MemtxArenaWarning
+        alertname: LowMemtxArenaRemainingWarning
         exp_alerts:
           - exp_labels:
               severity: warning
@@ -114,7 +114,7 @@ tests:
               description: "Low arena memory (tuples and indexes) remaining for 'tnt_router' instance of job 'tarantool'.
                 Consider increasing memtx_memory or number of storages in case of sharded data."
       - eval_time: 2m
-        alertname: MemtxArenaAlert
+        alertname: LowMemtxArenaRemaining
         exp_alerts: # no alert firing
 
 
@@ -126,7 +126,7 @@ tests:
         values: '92+0x2 91+0x8'
     alert_rule_test:
       - eval_time: 2m
-        alertname: MemtxArenaWarning
+        alertname: LowMemtxArenaRemainingWarning
         exp_alerts:
           - exp_labels:
               severity: warning
@@ -138,7 +138,7 @@ tests:
               description: "Low arena memory (tuples and indexes) remaining for 'tnt_router' instance of job 'tarantool'.
                 Consider increasing memtx_memory or number of storages in case of sharded data."
       - eval_time: 2m
-        alertname: MemtxArenaAlert
+        alertname: LowMemtxArenaRemaining
         exp_alerts:
           - exp_labels:
               severity: page
@@ -160,10 +160,10 @@ tests:
         values: '95+0x2 79+0x8'
     alert_rule_test:
       - eval_time: 2m
-        alertname: MemtxItemsWarning
+        alertname: LowMemtxItemsRemainingWarning
         exp_alerts: # no alert firing
       - eval_time: 2m
-        alertname: MemtxItemsAlert
+        alertname: LowMemtxItemsRemaining
         exp_alerts: # no alert firing
 
 
@@ -175,7 +175,7 @@ tests:
         values: '92+0x2 82+0x8'
     alert_rule_test:
       - eval_time: 2m
-        alertname: MemtxItemsWarning
+        alertname: LowMemtxItemsRemainingWarning
         exp_alerts:
           - exp_labels:
               severity: warning
@@ -187,7 +187,7 @@ tests:
               description: "Low items memory (tuples) remaining for 'tnt_router' instance of job 'tarantool'.
                 Consider increasing memtx_memory or number of storages in case of sharded data."
       - eval_time: 2m
-        alertname: MemtxItemsAlert
+        alertname: LowMemtxItemsRemaining
         exp_alerts: # no alert firing
 
 
@@ -396,7 +396,7 @@ tests:
         values: '0+100x100'
     alert_rule_test:
       - eval_time: 5m
-        alertname: CRUDHighErrorRate
+        alertname: HighCRUDErrorRate
         exp_alerts:
           - exp_labels:
               severity: critical
@@ -418,7 +418,7 @@ tests:
         values: '0.11+0x0'
     alert_rule_test:
       - eval_time: 2m
-        alertname: CRUDHighLatency
+        alertname: HighCRUDLatency
         exp_alerts:
           - exp_labels:
               severity: warning
@@ -441,7 +441,7 @@ tests:
         values: '0+100x100'
     alert_rule_test:
       - eval_time: 5m
-        alertname: CRUDHighMapReduceRate
+        alertname: HighCRUDMapReduceRate
         exp_alerts:
           - exp_labels:
               severity: warning
@@ -471,7 +471,7 @@ tests:
           values: '0.11+0x60'
     alert_rule_test:
       - eval_time: 10m
-        alertname: HTTPHighLatency
+        alertname: HighHTTPLatency
         exp_alerts:
           - exp_labels:
               severity: warning
@@ -502,10 +502,10 @@ tests:
           values: '0.02+0x100'
     alert_rule_test:
       - eval_time: 5m
-        alertname: HTTPHighClientErrorRateInstance
+        alertname: HighInstanceHTTPClientErrorRate
         exp_alerts:
           - exp_labels:
-              severity: warning
+              severity: page
               instance: app:8081
               alias: tnt_router
               job: tarantool
@@ -551,13 +551,13 @@ tests:
           values: '0.02+0x100'
     alert_rule_test:
       - eval_time: 5m
-        alertname: HTTPHighClientErrorRateInstance
+        alertname: HighHTTPClientErrorRateInstance
         exp_alerts: # no alert firing
       - eval_time: 5m
-        alertname: HTTPHighClientErrorRate
+        alertname: HighHTTPClientErrorRate
         exp_alerts:
           - exp_labels:
-              severity: warning
+              severity: page
               job: tarantool
               path: /hell0
               method: GET
@@ -580,10 +580,10 @@ tests:
           values: '0+0x10 0.01+0x100'
     alert_rule_test:
       - eval_time: 5m
-        alertname: HTTPServerErrors
+        alertname: HighHTTPServerErrorRate
         exp_alerts:
           - exp_labels:
-              severity: warning
+              severity: page
               instance: app:8081
               alias: tnt_router
               job: tarantool
@@ -608,7 +608,7 @@ tests:
           values: '0+0x10 0.01+0x100'
     alert_rule_test:
       - eval_time: 15m
-        alertname: HTTPLowRequestRateRouter
+        alertname: LowRouterHTTPRequestRate
         exp_alerts:
           - exp_labels:
               severity: warning

--- a/example_cluster/prometheus/test_alerts.yml
+++ b/example_cluster/prometheus/test_alerts.yml
@@ -333,9 +333,9 @@ tests:
   - interval: 15s
     input_series:
       - series: tnt_vinyl_scheduler_tasks{job="tarantool", instance="app:8081", alias="tnt_storage_master", status="failed"}
-        values: '2+3x10'
+        values: '2+3x40'
     alert_rule_test:
-      - eval_time: 2m
+      - eval_time: 5m
         alertname: HighVinylSchedulerFailedTasksRate
         exp_alerts:
           - exp_labels:

--- a/example_cluster/prometheus/test_alerts.yml
+++ b/example_cluster/prometheus/test_alerts.yml
@@ -258,9 +258,9 @@ tests:
 
   - interval: 15s
     input_series:
-      - series: tnt_replication_1_lag{job="tarantool", instance="app:8081", alias="tnt_storage_master"}
+      - series: tnt_replication_lag{job="tarantool", instance="app:8081", alias="tnt_storage_master", id="1"}
         values: '0+0x10'
-      - series: tnt_replication_2_lag{job="tarantool", instance="app:8082", alias="tnt_storage_replica"}
+      - series: tnt_replication_lag{job="tarantool", instance="app:8082", alias="tnt_storage_replica", id="2"}
         values: '1+15x10'
     alert_rule_test:
       - eval_time: 2m
@@ -271,10 +271,11 @@ tests:
               instance: app:8082
               alias: tnt_storage_replica
               job: tarantool
+              id: "2"
             exp_annotations:
-              summary: "Instance 'tnt_storage_replica' ('tarantool') have high replication lag"
-              description: "Instance 'tnt_storage_replica' of job 'tarantool' have high replication lag,
-                check up your network and cluster state."
+              summary: "Instance 'tnt_storage_replica' ('tarantool') have high replication lag (id 2)"
+              description: "Instance 'tnt_storage_replica' of job 'tarantool' have high replication lag
+                (id 2), check up your network and cluster state."
 
 
   - interval: 15s

--- a/example_cluster/prometheus/test_alerts.yml
+++ b/example_cluster/prometheus/test_alerts.yml
@@ -387,7 +387,7 @@ tests:
             exp_annotations:
               summary: "Instance 'tnt_storage_master' ('tarantool') upstream (id 1) replication is not running"
               description: "Instance 'tnt_storage_master' ('tarantool') upstream (id 1) replication is
-                 not running. Check Cartridge UI for details."
+                not running. Check Cartridge UI for details."
 
 
   - interval: 15s
@@ -453,8 +453,8 @@ tests:
             exp_annotations:
               summary: "Instance 'tnt_router' ('tarantool') too many CRUD select map reduces."
               description: "There are too many select CRUD map reduce requests for 'customers' space on
-              'tnt_router' instance of job 'tarantool'.
-              Check your request conditions or consider changing sharding schema."
+                'tnt_router' instance of job 'tarantool'.
+                Check your request conditions or consider changing sharding schema."
 
 
   - interval: 15s
@@ -617,5 +617,5 @@ tests:
               job: tarantool
             exp_annotations:
               summary: "Router 'tnt_router' ('tarantool') low activity"
-              description: Router 'tnt_router' instance of job 'tarantool' gets too little requests.
+              description: "Router 'tnt_router' instance of job 'tarantool' gets too little requests.
                 Please, check up your balancer middleware."


### PR DESCRIPTION
Should be merged together with https://github.com/tarantool/metrics/pull/394

This PR introduces "Alerting" documentation page to a "Monitoring" section. Contents are based on this repo [``alerts.yml``](https://github.com/tarantool/grafana-dashboard/blob/8a11235e5a2293d271b1a60feb351c6107e64364/example_cluster/prometheus/alerts.yml) example file and are expected to be updated together with it.

This PR also introduces several minor fixes and reworks in example alert file.

This PR also fixes links in another documentation page: [``grafana_dashboard.rst``](https://github.com/tarantool/grafana-dashboard/blob/8a11235e5a2293d271b1a60feb351c6107e64364/doc/monitoring/grafana_dashboard.rst). The issue was found while working on "Alerting" page.

See commit comments for more details.

Closes #64