### PR TITLE
dashboard: add instance variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- Variable to select displayed cluster instances
+
+
 ## [1.4.0] - 2022-08-03
 Grafana revisions: [InfluxDB revision 14](https://grafana.com/api/dashboards/12567/revisions/14/download), [Prometheus revision 14](https://grafana.com/api/dashboards/13054/revisions/14/download), [InfluxDB TDG revision 3](https://grafana.com/api/dashboards/16405/revisions/3/download), [Prometheus TDG revision 3](https://grafana.com/api/dashboards/16406/revisions/3/download).
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 JOB ?= tarantool
 POLICY ?= autogen
 MEASUREMENT ?= tarantool_http
+WITH_INSTANCE_VARIABLE ?= FALSE
 OUTPUT_STATIC_DASHBOARD ?= dashboard.json
 
 .PHONY: build-deps
@@ -16,9 +17,11 @@ ifndef DATASOURCE
 		false
 endif
 	# JOB is optional, default is "tarantool"
+	# WITH_INSTANCE_VARIABLE is optional, default is "FALSE"
 	jsonnet -J ./vendor -J . \
 		--ext-str DATASOURCE=${DATASOURCE} \
 		--ext-str JOB=${JOB} \
+		--ext-str WITH_INSTANCE_VARIABLE=${WITH_INSTANCE_VARIABLE} \
 		dashboard/build/prometheus/${DASHBOARD_BUILD_SOURCE} -o ${OUTPUT_STATIC_DASHBOARD}
 
 .PHONY: build-static-prometheus
@@ -37,10 +40,12 @@ ifndef DATASOURCE
 endif
 	# POLICY is optional, default is "autogen"
 	# MEASUREMENT is optional, default is "tarantool_http"
+	# WITH_INSTANCE_VARIABLE is optional, default is "FALSE"
 	jsonnet -J ./vendor -J . \
 		--ext-str DATASOURCE=${DATASOURCE} \
 		--ext-str POLICY=${POLICY} \
 		--ext-str MEASUREMENT=${MEASUREMENT} \
+		--ext-str WITH_INSTANCE_VARIABLE=${WITH_INSTANCE_VARIABLE} \
 		dashboard/build/influxdb/${DASHBOARD_BUILD_SOURCE} -o ${OUTPUT_STATIC_DASHBOARD}
 
 .PHONY: build-static-influxdb

--- a/README.md
+++ b/README.md
@@ -112,10 +112,12 @@ make test-deps
 ```
 to install build dependencies and dependencies that are required to run tests locally.
 
-To build a static dashboard with no input and dynamic variables, run `make` commands.
+To build a static dashboard with no input, run `make` commands.
 ```bash
 make DATASOURCE=Prometheus JOB=tarantool \
-     OUTPUT_STATIC_DASHBOARD=mydashboard.json build-static-prometheus
+     WITH_INSTANCE_VARIABLE=FALSE \
+     OUTPUT_STATIC_DASHBOARD=mydashboard.json \
+     build-static-prometheus
 ```
 Following targets are available:
 - `build-static-prometheus`: Tarantool dashboard for a Prometheus datasource;
@@ -126,13 +128,20 @@ Following targets are available:
 Variables for Prometheus targets:
 - `DATASOURCE`: name of a Prometheus data source;
 - `JOB` (optional, default `tarantool`): name of a Prometheus job collecting your application metrics;
+- `WITH_INSTANCE_VARIABLE` (optional, default `FALSE`): build a dashboard with variable which
+  can be used to select displayed cluster instances;
 - `OUTPUT_STATIC_DASHBOARD` (optional, default `dashboard.json`): compiled dashboard file.
 
 Variables for InfluxDB targets:
 - `DATASOURCE`: name of a InfluxDB data source;
 - `POLICY` (optional, default `autogen`): InfluxDB metrics retention policy;
 - `MEASUREMENT` (optional, default `tarantool_http`): name of a InfluxDB measurement with your application metrics;
+- `WITH_INSTANCE_VARIABLE` (optional, default `FALSE`): build a dashboard with variable which
+  can be used to select displayed cluster instances;
 - `OUTPUT_STATIC_DASHBOARD` (optional, default `dashboard.json`): compiled dashboard file.
+
+With `WITH_INSTANCE_VARIABLE=FALSE`, dashboard will contain no dynamic variables and Grafana alerts can be used.
+With `WITH_INSTANCE_VARIABLE=TRUE`, dashboard will contain instance dynamic variable (but no inputs).
 
 You can also compile configurable Prometheus dashboard template (the same we publish to
 Grafana Official & community built dashboards) with

--- a/dashboard/build/influxdb/dashboard.libsonnet
+++ b/dashboard/build/influxdb/dashboard.libsonnet
@@ -6,7 +6,8 @@ local variable = import 'dashboard/variable.libsonnet';
 dashboard_raw(
   datasource=variable.datasource.influxdb,
   policy=variable.influxdb.policy,
-  measurement=variable.influxdb.measurement
+  measurement=variable.influxdb.measurement,
+  alias=variable.influxdb.alias,
 ).addInput(
   name='DS_INFLUXDB',
   label='InfluxDB bank',
@@ -26,4 +27,15 @@ dashboard_raw(
   type='constant',
   value='autogen',
   description='InfluxDB Tarantool metrics policy'
+).addTemplate(
+  grafana.template.new(
+    name='alias',
+    datasource=variable.datasource.influxdb,
+    query=std.format('SHOW TAG VALUES FROM "%s" WITH KEY="label_pairs_alias"', variable.influxdb.measurement),
+    includeAll=true,
+    multi=true,
+    current='all',
+    label='Instances',
+    refresh='time',
+  )
 )

--- a/dashboard/build/influxdb/dashboard_raw.libsonnet
+++ b/dashboard/build/influxdb/dashboard_raw.libsonnet
@@ -4,7 +4,7 @@ local dashboard = import 'dashboard/dashboard.libsonnet';
 local section = import 'dashboard/section.libsonnet';
 local variable = import 'dashboard/variable.libsonnet';
 
-function(datasource, policy, measurement) dashboard.new(
+function(datasource, policy, measurement, alias) dashboard.new(
   grafana.dashboard.new(
     title='Tarantool dashboard',
     description='Dashboard for Tarantool application and database server monitoring, based on grafonnet library.',
@@ -46,6 +46,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.http(
@@ -53,6 +54,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.net(
@@ -60,6 +62,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.slab(
@@ -67,6 +70,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.space(
@@ -74,6 +78,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.vinyl(
@@ -81,6 +86,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.cpu(
@@ -88,6 +94,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.runtime(
@@ -95,6 +102,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.luajit(
@@ -102,6 +110,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.operations(
@@ -109,6 +118,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.crud(
@@ -116,6 +126,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.expirationd(
@@ -123,5 +134,6 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 )

--- a/dashboard/build/influxdb/dashboard_static.jsonnet
+++ b/dashboard/build/influxdb/dashboard_static.jsonnet
@@ -1,7 +1,41 @@
-local dashboard_raw = import 'dashboard/build/influxdb/dashboard_raw.libsonnet';
+local grafana = import 'grafonnet/grafana.libsonnet';
 
-dashboard_raw(
-  datasource=std.extVar('DATASOURCE'),
-  policy=std.extVar('POLICY'),
-  measurement=std.extVar('MEASUREMENT'),
-).build()
+local dashboard_raw = import 'dashboard/build/influxdb/dashboard_raw.libsonnet';
+local variable = import 'dashboard/variable.libsonnet';
+
+local DATASOURCE = std.extVar('DATASOURCE');
+local POLICY = std.extVar('POLICY');
+local MEASUREMENT = std.extVar('MEASUREMENT');
+local WITH_INSTANCE_VARIABLE = (std.asciiUpper(std.extVar('WITH_INSTANCE_VARIABLE')) == 'TRUE');
+
+if WITH_INSTANCE_VARIABLE then
+  dashboard_raw(
+    datasource=DATASOURCE,
+    policy=POLICY,
+    measurement=MEASUREMENT,
+    alias=variable.influxdb.alias,
+  ).addTemplate(
+    grafana.template.new(
+      name='alias',
+      datasource=DATASOURCE,
+      query=std.format(
+        'SHOW TAG VALUES FROM %(policy_prefix)s"%(measurement)s" WITH KEY="label_pairs_alias"',
+        {
+          policy_prefix: if POLICY == 'default' then '' else std.format('"%s".', POLICY),
+          measurement: MEASUREMENT,
+        },
+      ),
+      includeAll=true,
+      multi=true,
+      current='all',
+      label='Instances',
+      refresh='time',
+    )
+  ).build()
+else
+  dashboard_raw(
+    datasource=std.extVar('DATASOURCE'),
+    policy=std.extVar('POLICY'),
+    measurement=std.extVar('MEASUREMENT'),
+    alias='/^.*$/',
+  ).build()

--- a/dashboard/build/influxdb/tdg_dashboard.libsonnet
+++ b/dashboard/build/influxdb/tdg_dashboard.libsonnet
@@ -6,7 +6,8 @@ local variable = import 'dashboard/variable.libsonnet';
 tdg_dashboard_raw(
   datasource=variable.datasource.influxdb,
   policy=variable.influxdb.policy,
-  measurement=variable.influxdb.measurement
+  measurement=variable.influxdb.measurement,
+  alias=variable.influxdb.alias,
 ).addInput(
   name='DS_INFLUXDB',
   label='InfluxDB bank',
@@ -26,4 +27,15 @@ tdg_dashboard_raw(
   type='constant',
   value='autogen',
   description='InfluxDB Tarantool metrics policy'
+).addTemplate(
+  grafana.template.new(
+    name='alias',
+    datasource=variable.datasource.influxdb,
+    query=std.format('SHOW TAG VALUES FROM "%s" WITH KEY="label_pairs_alias"', variable.influxdb.measurement),
+    includeAll=true,
+    multi=true,
+    current='all',
+    label='Instances',
+    refresh='time',
+  )
 )

--- a/dashboard/build/influxdb/tdg_dashboard_raw.libsonnet
+++ b/dashboard/build/influxdb/tdg_dashboard_raw.libsonnet
@@ -4,7 +4,7 @@ local dashboard = import 'dashboard/dashboard.libsonnet';
 local section = import 'dashboard/section.libsonnet';
 local variable = import 'dashboard/variable.libsonnet';
 
-function(datasource, policy, measurement) dashboard.new(
+function(datasource, policy, measurement, alias) dashboard.new(
   grafana.dashboard.new(
     title='Tarantool Data Grid dashboard',
     description='Dashboard for Tarantool Data Grid ver. 2 application monitoring, based on grafonnet library.',
@@ -46,6 +46,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.net(
@@ -53,6 +54,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.slab(
@@ -60,6 +62,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.space(
@@ -67,6 +70,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.vinyl(
@@ -74,6 +78,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.cpu_extended(
@@ -81,6 +86,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.runtime(
@@ -88,6 +94,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.luajit(
@@ -95,6 +102,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.operations(
@@ -102,6 +110,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.tdg_kafka_common(
@@ -109,6 +118,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.tdg_kafka_brokers(
@@ -116,6 +126,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.tdg_kafka_topics(
@@ -123,6 +134,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.tdg_kafka_consumer(
@@ -130,6 +142,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.tdg_kafka_producer(
@@ -137,6 +150,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.tdg_expirationd(
@@ -144,6 +158,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.tdg_tuples(
@@ -151,6 +166,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.tdg_file_connectors(
@@ -158,6 +174,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.tdg_graphql(
@@ -165,6 +182,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.tdg_iproto(
@@ -172,6 +190,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.tdg_rest_api(
@@ -179,6 +198,7 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 ).addPanels(
   section.tdg_tasks(
@@ -186,5 +206,6 @@ function(datasource, policy, measurement) dashboard.new(
     datasource=datasource,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   )
 )

--- a/dashboard/build/influxdb/tdg_dashboard_static.jsonnet
+++ b/dashboard/build/influxdb/tdg_dashboard_static.jsonnet
@@ -1,7 +1,41 @@
-local tdg_dashboard_raw = import 'dashboard/build/influxdb/tdg_dashboard_raw.libsonnet';
+local grafana = import 'grafonnet/grafana.libsonnet';
 
-tdg_dashboard_raw(
-  datasource=std.extVar('DATASOURCE'),
-  policy=std.extVar('POLICY'),
-  measurement=std.extVar('MEASUREMENT'),
-).build()
+local tdg_dashboard_raw = import 'dashboard/build/influxdb/tdg_dashboard_raw.libsonnet';
+local variable = import 'dashboard/variable.libsonnet';
+
+local DATASOURCE = std.extVar('DATASOURCE');
+local POLICY = std.extVar('POLICY');
+local MEASUREMENT = std.extVar('MEASUREMENT');
+local WITH_INSTANCE_VARIABLE = (std.asciiUpper(std.extVar('WITH_INSTANCE_VARIABLE')) == 'TRUE');
+
+if WITH_INSTANCE_VARIABLE then
+  tdg_dashboard_raw(
+    datasource=DATASOURCE,
+    policy=POLICY,
+    measurement=MEASUREMENT,
+    alias=variable.influxdb.alias,
+  ).addTemplate(
+    grafana.template.new(
+      name='alias',
+      datasource=DATASOURCE,
+      query=std.format(
+        'SHOW TAG VALUES FROM %(policy_prefix)s"%(measurement)s" WITH KEY="label_pairs_alias"',
+        {
+          policy_prefix: if POLICY == 'default' then '' else std.format('"%s".', POLICY),
+          measurement: MEASUREMENT,
+        },
+      ),
+      includeAll=true,
+      multi=true,
+      current='all',
+      label='Instances',
+      refresh='time',
+    )
+  ).build()
+else
+  tdg_dashboard_raw(
+    datasource=std.extVar('DATASOURCE'),
+    policy=std.extVar('POLICY'),
+    measurement=std.extVar('MEASUREMENT'),
+    alias='/^.*$/',
+  ).build()

--- a/dashboard/build/prometheus/dashboard.libsonnet
+++ b/dashboard/build/prometheus/dashboard.libsonnet
@@ -6,6 +6,7 @@ local variable = import 'dashboard/variable.libsonnet';
 dashboard_raw(
   datasource=variable.datasource.prometheus,
   job=variable.prometheus.job,
+  alias=variable.prometheus.alias,
 ).addInput(
   name='DS_PROMETHEUS',
   label='Prometheus',
@@ -26,5 +27,16 @@ dashboard_raw(
     current='${PROMETHEUS_JOB}',
     hide='variable',
     label='Prometheus job',
+  )
+).addTemplate(
+  grafana.template.new(
+    name='alias',
+    datasource=variable.datasource.prometheus,
+    query=std.format('label_values(tnt_info_uptime{job=~"%s"},alias)', variable.prometheus.job),
+    includeAll=true,
+    multi=true,
+    current='all',
+    label='Instances',
+    refresh='time',
   )
 )

--- a/dashboard/build/prometheus/dashboard_raw.libsonnet
+++ b/dashboard/build/prometheus/dashboard_raw.libsonnet
@@ -4,7 +4,7 @@ local dashboard = import 'dashboard/dashboard.libsonnet';
 local section = import 'dashboard/section.libsonnet';
 local variable = import 'dashboard/variable.libsonnet';
 
-function(datasource, job) dashboard.new(
+function(datasource, job, alias) dashboard.new(
   grafana.dashboard.new(
     title='Tarantool dashboard',
     description='Dashboard for Tarantool application and database server monitoring, based on grafonnet library.',
@@ -55,71 +55,83 @@ function(datasource, job) dashboard.new(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.http(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.net(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.slab(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.space(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.vinyl(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.cpu(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.runtime(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.luajit(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.operations(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.crud(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.expirationd(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 )

--- a/dashboard/build/prometheus/dashboard_static.jsonnet
+++ b/dashboard/build/prometheus/dashboard_static.jsonnet
@@ -1,6 +1,32 @@
-local dashboard_raw = import 'dashboard/build/prometheus/dashboard_raw.libsonnet';
+local grafana = import 'grafonnet/grafana.libsonnet';
 
-dashboard_raw(
-  datasource=std.extVar('DATASOURCE'),
-  job=std.extVar('JOB'),
-).build()
+local dashboard_raw = import 'dashboard/build/prometheus/dashboard_raw.libsonnet';
+local variable = import 'dashboard/variable.libsonnet';
+
+local DATASOURCE = std.extVar('DATASOURCE');
+local JOB = std.extVar('JOB');
+local WITH_INSTANCE_VARIABLE = (std.asciiUpper(std.extVar('WITH_INSTANCE_VARIABLE')) == 'TRUE');
+
+if WITH_INSTANCE_VARIABLE then
+  dashboard_raw(
+    datasource=DATASOURCE,
+    job=JOB,
+    alias=variable.prometheus.alias,
+  ).addTemplate(
+    grafana.template.new(
+      name='alias',
+      datasource=DATASOURCE,
+      query=std.format('label_values(tnt_info_uptime{job="%s"},alias)', JOB),
+      includeAll=true,
+      multi=true,
+      current='all',
+      label='Instances',
+      refresh='time',
+    )
+  ).build()
+else
+  dashboard_raw(
+    datasource=DATASOURCE,
+    job=JOB,
+    alias='.*',
+  ).build()

--- a/dashboard/build/prometheus/tdg_dashboard.libsonnet
+++ b/dashboard/build/prometheus/tdg_dashboard.libsonnet
@@ -6,6 +6,7 @@ local variable = import 'dashboard/variable.libsonnet';
 tdg_dashboard_raw(
   datasource=variable.datasource.prometheus,
   job=variable.prometheus.job,
+  alias=variable.prometheus.alias,
 ).addInput(
   name='DS_PROMETHEUS',
   label='Prometheus',
@@ -26,5 +27,16 @@ tdg_dashboard_raw(
     current='${PROMETHEUS_JOB}',
     hide='variable',
     label='Prometheus job',
+  )
+).addTemplate(
+  grafana.template.new(
+    name='alias',
+    datasource=variable.datasource.prometheus,
+    query='label_values(tnt_info_uptime{job=~"$job"},alias)',
+    includeAll=true,
+    multi=true,
+    current='all',
+    label='Instances',
+    refresh='time',
   )
 )

--- a/dashboard/build/prometheus/tdg_dashboard_raw.libsonnet
+++ b/dashboard/build/prometheus/tdg_dashboard_raw.libsonnet
@@ -4,7 +4,7 @@ local dashboard = import 'dashboard/dashboard.libsonnet';
 local section = import 'dashboard/section.libsonnet';
 local variable = import 'dashboard/variable.libsonnet';
 
-function(datasource, job) dashboard.new(
+function(datasource, job, alias) dashboard.new(
   grafana.dashboard.new(
     title='Tarantool Data Grid dashboard',
     description='Dashboard for Tarantool Data Grid ver. 2 application monitoring, based on grafonnet library.',
@@ -55,125 +55,146 @@ function(datasource, job) dashboard.new(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.net(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.slab(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.space(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.vinyl(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.cpu_extended(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.runtime(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.luajit(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.operations(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.tdg_kafka_common(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.tdg_kafka_brokers(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.tdg_kafka_topics(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.tdg_kafka_consumer(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.tdg_kafka_producer(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.tdg_expirationd(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.tdg_tuples(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.tdg_file_connectors(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.tdg_graphql(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.tdg_iproto(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.tdg_rest_api(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 ).addPanels(
   section.tdg_tasks(
     datasource_type=variable.datasource_type.prometheus,
     datasource=datasource,
     job=job,
+    alias=alias,
   )
 )

--- a/dashboard/build/prometheus/tdg_dashboard_static.jsonnet
+++ b/dashboard/build/prometheus/tdg_dashboard_static.jsonnet
@@ -1,6 +1,32 @@
-local tdg_dashboard_raw = import 'dashboard/build/prometheus/tdg_dashboard_raw.libsonnet';
+local grafana = import 'grafonnet/grafana.libsonnet';
 
-tdg_dashboard_raw(
-  datasource=std.extVar('DATASOURCE'),
-  job=std.extVar('JOB'),
-).build()
+local tdg_dashboard_raw = import 'dashboard/build/prometheus/tdg_dashboard_raw.libsonnet';
+local variable = import 'dashboard/variable.libsonnet';
+
+local DATASOURCE = std.extVar('DATASOURCE');
+local JOB = std.extVar('JOB');
+local WITH_INSTANCE_VARIABLE = (std.asciiUpper(std.extVar('WITH_INSTANCE_VARIABLE')) == 'TRUE');
+
+if WITH_INSTANCE_VARIABLE then
+  tdg_dashboard_raw(
+    datasource=DATASOURCE,
+    job=JOB,
+    alias=variable.prometheus.alias,
+  ).addTemplate(
+    grafana.template.new(
+      name='alias',
+      datasource=DATASOURCE,
+      query=std.format('label_values(tnt_info_uptime{job="%s"},alias)', JOB),
+      includeAll=true,
+      multi=true,
+      current='all',
+      label='Instances',
+      refresh='time',
+    )
+  ).build()
+else
+  tdg_dashboard_raw(
+    datasource=DATASOURCE,
+    job=JOB,
+    alias='.*',
+  ).build()

--- a/dashboard/panels/cluster.libsonnet
+++ b/dashboard/panels/cluster.libsonnet
@@ -319,6 +319,7 @@ local prometheus = grafana.prometheus;
     policy,
     measurement,
     job,
+    alias,
     level,
   ) = common.default_graph(
     title=title,
@@ -333,7 +334,7 @@ local prometheus = grafana.prometheus;
   ).addTarget(
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('tnt_cartridge_issues{job=~"%s",level="%s"}', [job, level]),
+        expr=std.format('tnt_cartridge_issues{job=~"%s",alias=~"%s",level="%s"}', [job, alias, level]),
         legendFormat='{{alias}}',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -343,7 +344,8 @@ local prometheus = grafana.prometheus;
         group_tags=['label_pairs_alias'],
         alias='$tag_label_pairs_alias',
         fill='null',
-      ).where('metric_name', '=', 'tnt_cartridge_issues').where('label_pairs_level', '=', level)
+      ).where('metric_name', '=', 'tnt_cartridge_issues').where('label_pairs_alias', '=~', alias)
+      .where('label_pairs_level', '=', level)
       .selectField('value').addConverter('last')
   ),
 
@@ -363,6 +365,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: cartridge_issues(
     title=title,
     description=description,
@@ -371,6 +374,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     level='warning',
   ),
 
@@ -389,6 +393,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: cartridge_issues(
     title=title,
     description=description,
@@ -397,6 +402,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     level='critical',
   ),
 
@@ -413,6 +419,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: timeseries.new(
     title=title,
     description=description,
@@ -429,7 +436,7 @@ local prometheus = grafana.prometheus;
   ).addTarget(
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('tnt_replication_status{job=~"%s"}', [job]),
+        expr=std.format('tnt_replication_status{job=~"%s",alias=~"%s"}', [job, alias]),
         legendFormat='{{alias}} {{stream}} ({{id}})',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -439,7 +446,7 @@ local prometheus = grafana.prometheus;
         group_tags=['label_pairs_alias', 'label_pairs_stream', 'label_pairs_id'],
         alias='$tag_label_pairs_alias $tag_label_pairs_stream ($tag_label_pairs_id)',
         fill='null',
-      ).where('metric_name', '=', 'tnt_replication_status')
+      ).where('metric_name', '=', 'tnt_replication_status').where('label_pairs_alias', '=~', alias)
       .selectField('value').addConverter('last')
   ),
 
@@ -457,6 +464,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: timeseries.new(
     title=title,
     description=description,
@@ -477,6 +485,7 @@ local prometheus = grafana.prometheus;
       job,
       policy,
       measurement,
+      alias,
       'last'
     )
   ),
@@ -493,6 +502,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -506,7 +516,7 @@ local prometheus = grafana.prometheus;
   ).addTarget(
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('tnt_replication_lag{job=~"%s"}', [job]),
+        expr=std.format('tnt_replication_lag{job=~"%s",alias=~"%s"}', [job, alias]),
         legendFormat='{{alias}} ({{id}})',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -516,7 +526,7 @@ local prometheus = grafana.prometheus;
         group_tags=['label_pairs_alias', 'label_pairs_id'],
         alias='$tag_label_pairs_alias ($tag_label_pairs_id)',
         fill='null',
-      ).where('metric_name', '=', 'tnt_replication_lag')
+      ).where('metric_name', '=', 'tnt_replication_lag').where('label_pairs_alias', '=~', alias)
       .selectField('value').addConverter('mean')
   ),
 
@@ -534,6 +544,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -548,7 +559,7 @@ local prometheus = grafana.prometheus;
   ).addTarget(
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('tnt_clock_delta{job=~"%s"}', [job]),
+        expr=std.format('tnt_clock_delta{job=~"%s",alias=~"%s"}', [job, alias]),
         legendFormat='{{alias}} ({{delta}})',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -558,7 +569,7 @@ local prometheus = grafana.prometheus;
         group_tags=['label_pairs_alias', 'label_pairs_delta'],
         alias='$tag_label_pairs_alias ($tag_label_pairs_delta)',
         fill='null',
-      ).where('metric_name', '=', 'tnt_clock_delta')
+      ).where('metric_name', '=', 'tnt_clock_delta').where('label_pairs_alias', '=~', alias)
       .selectField('value').addConverter('last')
   ),
 }

--- a/dashboard/panels/common.libsonnet
+++ b/dashboard/panels/common.libsonnet
@@ -53,11 +53,12 @@ local prometheus = grafana.prometheus;
     job=null,
     policy=null,
     measurement=null,
+    alias=null,
     converter='mean'
   )::
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('%s{job=~"%s"}', [metric_name, job]),
+        expr=std.format('%s{job=~"%s",alias=~"%s"}', [metric_name, job, alias]),
         legendFormat='{{alias}}',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -67,7 +68,7 @@ local prometheus = grafana.prometheus;
         group_tags=['label_pairs_alias'],
         alias='$tag_label_pairs_alias',
         fill='null',
-      ).where('metric_name', '=', metric_name)
+      ).where('metric_name', '=', metric_name).where('label_pairs_alias', '=~', alias)
       .selectField('value').addConverter(converter),
 
   default_rps_target(
@@ -76,11 +77,12 @@ local prometheus = grafana.prometheus;
     job=null,
     policy=null,
     measurement=null,
+    alias=null,
   )::
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('rate(%s{job=~"%s"}[$__rate_interval])',
-                        [metric_name, job]),
+        expr=std.format('rate(%s{job=~"%s",alias=~"%s"}[$__rate_interval])',
+                        [metric_name, job, alias]),
         legendFormat='{{alias}}',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -90,7 +92,7 @@ local prometheus = grafana.prometheus;
         group_tags=['label_pairs_alias'],
         alias='$tag_label_pairs_alias',
         fill='null',
-      ).where('metric_name', '=', metric_name)
+      ).where('metric_name', '=', metric_name).where('label_pairs_alias', '=~', alias)
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s']),
 
   group_by_fill_0_warning(

--- a/dashboard/panels/cpu.libsonnet
+++ b/dashboard/panels/cpu.libsonnet
@@ -17,6 +17,7 @@ local prometheus = grafana.prometheus;
     policy,
     measurement,
     job,
+    alias,
     metric_name,
   ) = common.default_graph(
     title=title,
@@ -31,7 +32,8 @@ local prometheus = grafana.prometheus;
     metric_name,
     job,
     policy,
-    measurement
+    measurement,
+    alias
   )),
 
   getrusage_cpu_user_time(
@@ -48,6 +50,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: getrusage_cpu_percentage_graph(
     title=title,
     description=description,
@@ -56,6 +59,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_cpu_user_time',
   ),
 
@@ -73,6 +77,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: getrusage_cpu_percentage_graph(
     title=title,
     description=description,
@@ -81,6 +86,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_cpu_system_time',
   ),
 
@@ -92,6 +98,7 @@ local prometheus = grafana.prometheus;
     policy,
     measurement,
     job,
+    alias,
     kind,
   ) = common.default_graph(
     title=title,
@@ -104,8 +111,8 @@ local prometheus = grafana.prometheus;
   ).addTarget(
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('rate(tnt_cpu_thread{job=~"%s",kind="%s"}[$__rate_interval])',
-                        [job, kind]),
+        expr=std.format('rate(tnt_cpu_thread{job=~"%s",alias=~"%s",kind="%s"}[$__rate_interval])',
+                        [job, alias, kind]),
         legendFormat='{{alias}} — {{thread_name}}',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -114,7 +121,8 @@ local prometheus = grafana.prometheus;
         measurement=measurement,
         group_tags=['label_pairs_alias', 'label_pairs_thread_name'],
         alias='$tag_label_pairs_alias — $tag_label_pairs_thread_name',
-      ).where('metric_name', '=', 'tnt_cpu_thread').where('label_pairs_kind', '=', kind)
+      ).where('metric_name', '=', 'tnt_cpu_thread').where('label_pairs_alias', '=~', alias)
+      .where('label_pairs_kind', '=', kind)
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s']),
   ),
 
@@ -136,6 +144,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: procstat_thread_time_graph(
     title,
     description,
@@ -144,6 +153,7 @@ local prometheus = grafana.prometheus;
     policy,
     measurement,
     job,
+    alias,
     'user',
   ),
 
@@ -161,6 +171,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: procstat_thread_time_graph(
     title,
     description,
@@ -169,6 +180,7 @@ local prometheus = grafana.prometheus;
     policy,
     measurement,
     job,
+    alias,
     'system',
   ),
 }

--- a/dashboard/panels/crud.libsonnet
+++ b/dashboard/panels/crud.libsonnet
@@ -36,6 +36,7 @@ local operation_rps_template(
   policy=null,
   measurement=null,
   job=null,
+  alias=null,
   operation=null,
   status=null,
       ) = common.default_graph(
@@ -57,8 +58,8 @@ local operation_rps_template(
   if datasource_type == variable.datasource_type.prometheus then
     prometheus.target(
       expr=std.format(
-        'rate(tnt_crud_stats_count{job=~"%s",operation="%s",status="%s"}[$__rate_interval])',
-        [job, operation, status]
+        'rate(tnt_crud_stats_count{job=~"%s",alias=~"%s",operation="%s",status="%s"}[$__rate_interval])',
+        [job, alias, operation, status]
       ),
       legendFormat='{{alias}} — {{name}}'
     )
@@ -70,6 +71,7 @@ local operation_rps_template(
       alias='$tag_label_pairs_alias — $tag_label_pairs_name',
       fill='null',
     ).where('metric_name', '=', 'tnt_crud_stats_count')
+    .where('label_pairs_alias', '=~', alias)
     .where('label_pairs_operation', '=', operation)
     .where('label_pairs_status', '=', status)
     .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s'])
@@ -83,6 +85,7 @@ local operation_latency_template(
   policy=null,
   measurement=null,
   job=null,
+  alias=null,
   operation=null,
   status=null,
       ) = common.default_graph(
@@ -105,8 +108,8 @@ local operation_latency_template(
   if datasource_type == variable.datasource_type.prometheus then
     prometheus.target(
       expr=std.format(
-        'tnt_crud_stats{job=~"%s",operation="%s",status="%s",quantile="0.99"}',
-        [job, operation, status]
+        'tnt_crud_stats{job=~"%s",alias=~"%s",operation="%s",status="%s",quantile="0.99"}',
+        [job, alias, operation, status]
       ),
       legendFormat='{{alias}} — {{name}}'
     )
@@ -118,6 +121,7 @@ local operation_latency_template(
       alias='$tag_label_pairs_alias — $tag_label_pairs_name',
       fill='null',
     ).where('metric_name', '=', 'tnt_crud_stats')
+    .where('label_pairs_alias', '=~', alias)
     .where('label_pairs_operation', '=', operation)
     .where('label_pairs_status', '=', status)
     .where('label_pairs_quantile', '=', '0.99')
@@ -132,6 +136,7 @@ local operation_rps(
   policy=null,
   measurement=null,
   job=null,
+  alias=null,
   operation=null,
   status=null,
       ) = operation_rps_template(
@@ -150,6 +155,7 @@ local operation_rps(
   policy=policy,
   measurement=measurement,
   job=job,
+  alias=alias,
   operation=operation,
   status=status,
 );
@@ -162,6 +168,7 @@ local operation_latency(
   policy=null,
   measurement=null,
   job=null,
+  alias=null,
   operation=null,
   status=null,
       ) = operation_latency_template(
@@ -179,6 +186,7 @@ local operation_latency(
   policy=policy,
   measurement=measurement,
   job=job,
+  alias=alias,
   operation=operation,
   status=status,
 );
@@ -191,6 +199,7 @@ local operation_rps_object(
   policy=null,
   measurement=null,
   job=null,
+  alias=null,
   operation=null,
   status=null,
       ) = operation_rps_template(
@@ -209,6 +218,7 @@ local operation_rps_object(
   policy=policy,
   measurement=measurement,
   job=job,
+  alias=alias,
   operation=operation,
   status=status,
 );
@@ -221,6 +231,7 @@ local operation_latency_object(
   policy=null,
   measurement=null,
   job=null,
+  alias=null,
   operation=null,
   status=null,
       ) = operation_latency_template(
@@ -238,6 +249,7 @@ local operation_latency_object(
   policy=policy,
   measurement=measurement,
   job=job,
+  alias=alias,
   operation=operation,
   status=status,
 );
@@ -250,6 +262,7 @@ local operation_rps_object_many(
   policy=null,
   measurement=null,
   job=null,
+  alias=null,
   operation_stripped=null,
   status=null,
       ) = operation_rps_template(
@@ -268,6 +281,7 @@ local operation_rps_object_many(
   policy=policy,
   measurement=measurement,
   job=job,
+  alias=alias,
   operation=std.format('%s_many', operation_stripped),
   status=status,
 );
@@ -280,6 +294,7 @@ local operation_latency_object_many(
   policy=null,
   measurement=null,
   job=null,
+  alias=null,
   operation_stripped=null,
   status=null,
       ) = operation_latency_template(
@@ -297,6 +312,7 @@ local operation_latency_object_many(
   policy=policy,
   measurement=measurement,
   job=job,
+  alias=alias,
   operation=std.format('%s_many', operation_stripped),
   status=status,
 );
@@ -309,6 +325,7 @@ local operation_rps_select(
   policy=null,
   measurement=null,
   job=null,
+  alias=null,
   status=null,
       ) = operation_rps_template(
   title=title,
@@ -326,6 +343,7 @@ local operation_rps_select(
   policy=policy,
   measurement=measurement,
   job=job,
+  alias=alias,
   operation='select',
   status=status,
 );
@@ -338,6 +356,7 @@ local operation_latency_select(
   policy=null,
   measurement=null,
   job=null,
+  alias=null,
   operation=null,
   status=null,
       ) = operation_latency_template(
@@ -355,6 +374,7 @@ local operation_latency_select(
   policy=policy,
   measurement=measurement,
   job=job,
+  alias=alias,
   operation='select',
   status=status,
 );
@@ -367,6 +387,7 @@ local operation_rps_borders(
   policy=null,
   measurement=null,
   job=null,
+  alias=null,
   status=null,
       ) = operation_rps_template(
   title=title,
@@ -384,6 +405,7 @@ local operation_rps_borders(
   policy=policy,
   measurement=measurement,
   job=job,
+  alias=alias,
   operation='borders',
   status=status,
 );
@@ -396,6 +418,7 @@ local operation_latency_borders(
   policy=null,
   measurement=null,
   job=null,
+  alias=null,
   operation=null,
   status=null,
       ) = operation_latency_template(
@@ -413,6 +436,7 @@ local operation_latency_borders(
   policy=policy,
   measurement=measurement,
   job=job,
+  alias=alias,
   operation='borders',
   status=status,
 );
@@ -425,6 +449,7 @@ local tuples_panel(
   policy=null,
   measurement=null,
   job=null,
+  alias=null,
   metric_name=null,
       ) = common.default_graph(
   title=title,
@@ -442,12 +467,13 @@ local tuples_panel(
     prometheus.target(
       expr=std.format(
         |||
-          rate(%(metric_name)s{job=~"%(job)s",operation="select"}[$__rate_interval]) /
+          rate(%(metric_name)s{job=~"%(job)s",alias=~"%(alias)s", operation="select"}[$__rate_interval]) /
           (sum without (status) (rate(tnt_crud_stats_count{job=~"%(job)s",operation="select"}[$__rate_interval])))
         |||,
         {
           metric_name: metric_name,
           job: job,
+          alias: alias,
         }
       ),
       legendFormat='{{alias}} — {{name}}'
@@ -459,18 +485,20 @@ local tuples_panel(
         SELECT mean("%(metric_name)s") / (mean("tnt_crud_stats_count_ok") + mean("tnt_crud_stats_count_error"))
         as "tnt_crud_tuples_per_request" FROM
         (SELECT "value" as "%(metric_name)s" FROM %(policy_prefix)s"%(measurement)s"
-        WHERE ("metric_name" = '%(metric_name)s' AND "label_pairs_operation" = 'select') AND $timeFilter),
+        WHERE ("metric_name" = '%(metric_name)s' AND "label_pairs_alias" =~ %(alias)s
+        AND "label_pairs_operation" = 'select') AND $timeFilter),
         (SELECT "value" as "tnt_crud_stats_count_error" FROM %(policy_prefix)s"%(measurement)s"
-        WHERE ("metric_name" = 'tnt_crud_stats_count' AND "label_pairs_operation" = 'select'
-        AND "label_pairs_status" = 'error') AND $timeFilter),
+        WHERE ("metric_name" = 'tnt_crud_stats_count' AND "label_pairs_alias" =~ %(alias)s
+        AND "label_pairs_operation" = 'select' AND "label_pairs_status" = 'error') AND $timeFilter),
         (SELECT "value" as "tnt_crud_stats_count_ok" FROM %(policy_prefix)s"%(measurement)s"
-        WHERE ("metric_name" = 'tnt_crud_stats_count' AND "label_pairs_operation" = 'select'
-        AND "label_pairs_status" = 'ok') AND $timeFilter)
+        WHERE ("metric_name" = 'tnt_crud_stats_count' AND "label_pairs_alias" =~ %(alias)s
+        AND "label_pairs_operation" = 'select' AND "label_pairs_status" = 'ok') AND $timeFilter)
         GROUP BY time($__interval * 2), "label_pairs_alias", "label_pairs_name" fill(0)
       |||, {
         metric_name: metric_name,
         policy_prefix: if policy == 'default' then '' else std.format('"%(policy)s".', policy),
         measurement: measurement,
+        alias: alias,
       }),
       alias='$tag_label_pairs_alias — $tag_label_pairs_name'
     )
@@ -488,6 +516,7 @@ local module = {
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: operation_rps_select(
     title=title,
     description=description,
@@ -496,6 +525,7 @@ local module = {
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     status='ok',
   ),
 
@@ -507,6 +537,7 @@ local module = {
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: operation_latency_select(
     title=title,
     description=description,
@@ -515,6 +546,7 @@ local module = {
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     status='ok',
   ),
 
@@ -526,6 +558,7 @@ local module = {
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: operation_rps_select(
     title=title,
     description=description,
@@ -534,6 +567,7 @@ local module = {
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     status='error',
   ),
 
@@ -545,6 +579,7 @@ local module = {
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: operation_latency_select(
     title=title,
     description=description,
@@ -553,6 +588,7 @@ local module = {
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     status='error',
   ),
 
@@ -567,6 +603,7 @@ local module = {
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: tuples_panel(
     title=title,
     description=description,
@@ -575,6 +612,7 @@ local module = {
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_crud_tuples_fetched',
   ),
 
@@ -590,6 +628,7 @@ local module = {
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: tuples_panel(
     title=title,
     description=description,
@@ -598,6 +637,7 @@ local module = {
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_crud_tuples_lookup',
   ),
 
@@ -613,6 +653,7 @@ local module = {
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -625,8 +666,8 @@ local module = {
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
         expr=std.format(
-          'rate(tnt_crud_map_reduces{job=~"%s",operation="select"}[$__rate_interval])',
-          [job],
+          'rate(tnt_crud_map_reduces{job=~"%s",alias=~"%s",operation="select"}[$__rate_interval])',
+          [job, alias],
         ),
         legendFormat='{{alias}} — {{name}}'
       )
@@ -638,6 +679,7 @@ local module = {
         alias='$tag_label_pairs_alias — $tag_label_pairs_name',
         fill='null',
       ).where('metric_name', '=', 'tnt_crud_map_reduces')
+      .where('label_pairs_alias', '=~', alias)
       .where('label_pairs_operation', '=', 'select')
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s'])
   ),
@@ -650,6 +692,7 @@ local module = {
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: operation_rps_borders(
     title=title,
     description=description,
@@ -658,6 +701,7 @@ local module = {
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     status='ok',
   ),
 
@@ -669,6 +713,7 @@ local module = {
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: operation_latency_borders(
     title=title,
     description=description,
@@ -677,6 +722,7 @@ local module = {
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     status='ok',
   ),
 
@@ -688,6 +734,7 @@ local module = {
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: operation_rps_borders(
     title=title,
     description=description,
@@ -696,6 +743,7 @@ local module = {
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     status='error',
   ),
 
@@ -707,6 +755,7 @@ local module = {
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: operation_latency_borders(
     title=title,
     description=description,
@@ -715,6 +764,7 @@ local module = {
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     status='error',
   ),
 };
@@ -734,6 +784,7 @@ local module_with_object_panels = std.foldl(function(_module, operation) (
       policy=null,
       measurement=null,
       job=null,
+      alias=null,
     ):: operation_rps_object(
       title=title,
       description=description,
@@ -742,6 +793,7 @@ local module_with_object_panels = std.foldl(function(_module, operation) (
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
       operation=operation,
       status='ok',
     ),
@@ -754,6 +806,7 @@ local module_with_object_panels = std.foldl(function(_module, operation) (
       policy=null,
       measurement=null,
       job=null,
+      alias=null,
     ):: operation_latency_object(
       title=title,
       description=description,
@@ -762,6 +815,7 @@ local module_with_object_panels = std.foldl(function(_module, operation) (
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
       operation=operation,
       status='ok',
     ),
@@ -774,6 +828,7 @@ local module_with_object_panels = std.foldl(function(_module, operation) (
       policy=null,
       measurement=null,
       job=null,
+      alias=null,
     ):: operation_rps_object(
       title=title,
       description=description,
@@ -782,6 +837,7 @@ local module_with_object_panels = std.foldl(function(_module, operation) (
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
       operation=operation,
       status='error',
     ),
@@ -794,6 +850,7 @@ local module_with_object_panels = std.foldl(function(_module, operation) (
       policy=null,
       measurement=null,
       job=null,
+      alias=null,
     ):: operation_latency_object(
       title=title,
       description=description,
@@ -802,6 +859,7 @@ local module_with_object_panels = std.foldl(function(_module, operation) (
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
       operation=operation,
       status='error',
     ),
@@ -819,6 +877,7 @@ local module_with_object_and_many_panels = std.foldl(function(_module, operation
       policy=null,
       measurement=null,
       job=null,
+      alias=null,
     ):: operation_rps_object_many(
       title=title,
       description=description,
@@ -827,6 +886,7 @@ local module_with_object_and_many_panels = std.foldl(function(_module, operation
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
       operation_stripped=operation_stripped,
       status='ok',
     ),
@@ -839,6 +899,7 @@ local module_with_object_and_many_panels = std.foldl(function(_module, operation
       policy=null,
       measurement=null,
       job=null,
+      alias=null,
     ):: operation_latency_object_many(
       title=title,
       description=description,
@@ -847,6 +908,7 @@ local module_with_object_and_many_panels = std.foldl(function(_module, operation
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
       operation_stripped=operation_stripped,
       status='ok',
     ),
@@ -859,6 +921,7 @@ local module_with_object_and_many_panels = std.foldl(function(_module, operation
       policy=null,
       measurement=null,
       job=null,
+      alias=null,
     ):: operation_rps_object_many(
       title=title,
       description=description,
@@ -867,6 +930,7 @@ local module_with_object_and_many_panels = std.foldl(function(_module, operation
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
       operation_stripped=operation_stripped,
       status='error',
     ),
@@ -879,6 +943,7 @@ local module_with_object_and_many_panels = std.foldl(function(_module, operation
       policy=null,
       measurement=null,
       job=null,
+      alias=null,
     ):: operation_latency_object_many(
       title=title,
       description=description,
@@ -887,6 +952,7 @@ local module_with_object_and_many_panels = std.foldl(function(_module, operation
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
       operation_stripped=operation_stripped,
       status='error',
     ),
@@ -904,6 +970,7 @@ std.foldl(function(_module, operation) (
       policy=null,
       measurement=null,
       job=null,
+      alias=null,
     ):: operation_rps(
       title=title,
       description=description,
@@ -912,6 +979,7 @@ std.foldl(function(_module, operation) (
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
       operation=operation,
       status='ok',
     ),
@@ -924,6 +992,7 @@ std.foldl(function(_module, operation) (
       policy=null,
       measurement=null,
       job=null,
+      alias=null,
     ):: operation_latency(
       title=title,
       description=description,
@@ -932,6 +1001,7 @@ std.foldl(function(_module, operation) (
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
       operation=operation,
       status='ok',
     ),
@@ -944,6 +1014,7 @@ std.foldl(function(_module, operation) (
       policy=null,
       measurement=null,
       job=null,
+      alias=null,
     ):: operation_rps(
       title=title,
       description=description,
@@ -952,6 +1023,7 @@ std.foldl(function(_module, operation) (
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
       operation=operation,
       status='error',
     ),
@@ -964,6 +1036,7 @@ std.foldl(function(_module, operation) (
       policy=null,
       measurement=null,
       job=null,
+      alias=null,
     ):: operation_latency(
       title=title,
       description=description,
@@ -972,6 +1045,7 @@ std.foldl(function(_module, operation) (
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
       operation=operation,
       status='error',
     ),

--- a/dashboard/panels/expirationd.libsonnet
+++ b/dashboard/panels/expirationd.libsonnet
@@ -15,10 +15,11 @@ local prometheus = grafana.prometheus;
     job=null,
     policy=null,
     measurement=null,
+    alias=null,
   ) =
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('%s{job=~"%s"}', [metric_name, job]),
+        expr=std.format('%s{job=~"%s",alias=~"%s"}', [metric_name, job, alias]),
         legendFormat='{{name}} — {{alias}}',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -32,6 +33,7 @@ local prometheus = grafana.prometheus;
         alias='$tag_label_pairs_name — $tag_label_pairs_alias',
         fill='null',
       ).where('metric_name', '=', metric_name)
+      .where('label_pairs_alias', '=~', alias)
       .selectField('value').addConverter('mean'),
 
   local rps_target(
@@ -40,11 +42,12 @@ local prometheus = grafana.prometheus;
     job=null,
     policy=null,
     measurement=null,
+    alias=null,
   ) =
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('rate(%s{job=~"%s"}[$__rate_interval])',
-                        [metric_name, job]),
+        expr=std.format('rate(%s{job=~"%s",alias=~"%s"}[$__rate_interval])',
+                        [metric_name, job, alias]),
         legendFormat='{{name}} — {{alias}}',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -58,6 +61,7 @@ local prometheus = grafana.prometheus;
         alias='$tag_label_pairs_name — $tag_label_pairs_alias',
         fill='null',
       ).where('metric_name', '=', metric_name)
+      .where('label_pairs_alias', '=~', alias)
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s']),
 
   tuples_checked(
@@ -71,6 +75,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -83,6 +88,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   tuples_expired(
@@ -96,6 +102,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -108,6 +115,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   restarts(
@@ -121,6 +129,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -133,6 +142,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   operation_time(
@@ -145,6 +155,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -157,5 +168,6 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 }

--- a/dashboard/panels/http.libsonnet
+++ b/dashboard/panels/http.libsonnet
@@ -17,6 +17,7 @@ local prometheus = grafana.prometheus;
     policy,
     measurement,
     job,
+    alias,
     metric_name,
     status_regex,
   ) = common.default_graph(
@@ -27,8 +28,8 @@ local prometheus = grafana.prometheus;
   ).addTarget(
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('rate(%s{job=~"%s",status=~"%s"}[$__rate_interval])',
-                        [metric_name, job, std.strReplace(status_regex, '\\', '\\\\')]),
+        expr=std.format('rate(%s{job=~"%s",alias=~"%s",status=~"%s"}[$__rate_interval])',
+                        [metric_name, job, alias, std.strReplace(status_regex, '\\', '\\\\')]),
         legendFormat='{{alias}} — {{method}} {{path}} (code {{status}})',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -38,7 +39,9 @@ local prometheus = grafana.prometheus;
         group_tags=['label_pairs_alias', 'label_pairs_path', 'label_pairs_method', 'label_pairs_status'],
         alias='$tag_label_pairs_alias — $tag_label_pairs_method $tag_label_pairs_path (code $tag_label_pairs_status)',
         fill='null',
-      ).where('metric_name', '=', metric_name).where('label_pairs_status', '=~', std.format('/%s/', status_regex))
+      ).where('metric_name', '=', metric_name)
+      .where('label_pairs_alias', '=~', alias)
+      .where('label_pairs_status', '=~', std.format('/%s/', status_regex))
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s'])
   ),
 
@@ -53,6 +56,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
     metric_name='http_server_request_latency_count',
   ):: rps_graph(
     title=title,
@@ -62,6 +66,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name=metric_name,
     status_regex='^2\\d{2}$',
   ),
@@ -77,6 +82,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
     metric_name='http_server_request_latency_count',
   ):: rps_graph(
     title=title,
@@ -86,6 +92,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name=metric_name,
     status_regex='^4\\d{2}$',
   ),
@@ -101,6 +108,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
     metric_name='http_server_request_latency_count',
   ):: rps_graph(
     title=title,
@@ -110,6 +118,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name=metric_name,
     status_regex='^5\\d{2}$',
   ),
@@ -122,6 +131,7 @@ local prometheus = grafana.prometheus;
     policy,
     measurement,
     job,
+    alias,
     metric_name,
     quantile,
     label,
@@ -136,7 +146,8 @@ local prometheus = grafana.prometheus;
   ).addTarget(
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('%s{job=~"%s",quantile="%s",status=~"%s"}', [metric_name, job, quantile, std.strReplace(status_regex, '\\', '\\\\')]),
+        expr=std.format('%s{job=~"%s",alias=~"%s",quantile="%s",status=~"%s"}',
+                        [metric_name, job, alias, quantile, std.strReplace(status_regex, '\\', '\\\\')]),
         legendFormat='{{alias}} — {{method}} {{path}} (code {{status}})',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -146,7 +157,9 @@ local prometheus = grafana.prometheus;
         group_tags=['label_pairs_alias', 'label_pairs_path', 'label_pairs_method', 'label_pairs_status'],
         alias='$tag_label_pairs_alias — $tag_label_pairs_method $tag_label_pairs_path (code $tag_label_pairs_status)',
         fill='null',
-      ).where('metric_name', '=', metric_name).where('label_pairs_quantile', '=', quantile)
+      ).where('metric_name', '=', metric_name)
+      .where('label_pairs_alias', '=~', alias)
+      .where('label_pairs_quantile', '=', quantile)
       .where('label_pairs_status', '=~', std.format('/%s/', status_regex)).selectField('value').addConverter('mean')
   ),
 
@@ -162,6 +175,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
     metric_name='http_server_request_latency',
     quantile='0.99',
     label='99th percentile',
@@ -173,6 +187,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name=metric_name,
     quantile=quantile,
     label=label,
@@ -191,6 +206,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
     metric_name='http_server_request_latency',
     quantile='0.99',
     label='99th percentile',
@@ -202,6 +218,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name=metric_name,
     quantile=quantile,
     label=label,
@@ -220,6 +237,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
     metric_name='http_server_request_latency',
     quantile='0.99',
     label='99th percentile',
@@ -231,6 +249,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name=metric_name,
     quantile=quantile,
     label=label,

--- a/dashboard/panels/luajit.libsonnet
+++ b/dashboard/panels/luajit.libsonnet
@@ -17,6 +17,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=version_warning(description),
@@ -28,7 +29,8 @@ local common = import 'dashboard/panels/common.libsonnet';
     'lj_jit_snap_restore',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   jit_traces(
@@ -41,6 +43,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=version_warning(description),
@@ -52,7 +55,8 @@ local common = import 'dashboard/panels/common.libsonnet';
     'lj_jit_trace_num',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   jit_traces_aborts(
@@ -65,6 +69,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=version_warning(description),
@@ -76,7 +81,8 @@ local common = import 'dashboard/panels/common.libsonnet';
     'lj_jit_trace_abort',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   machine_code_areas(
@@ -89,6 +95,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=version_warning(description),
@@ -101,7 +108,8 @@ local common = import 'dashboard/panels/common.libsonnet';
     'lj_jit_mcode_size',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   strhash_hit(
@@ -114,6 +122,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=version_warning(description),
@@ -125,7 +134,8 @@ local common = import 'dashboard/panels/common.libsonnet';
     'lj_strhash_hit',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   strhash_miss(
@@ -138,6 +148,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=version_warning(description),
@@ -149,7 +160,8 @@ local common = import 'dashboard/panels/common.libsonnet';
     'lj_strhash_miss',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   local gc_steps(
@@ -160,7 +172,8 @@ local common = import 'dashboard/panels/common.libsonnet';
     job,
     policy,
     measurement,
-    state
+    alias,
+    state,
   ) = common.default_graph(
     title=(if title != null then title else std.format('GC steps (%s)', state)),
     description=(
@@ -178,7 +191,8 @@ local common = import 'dashboard/panels/common.libsonnet';
     std.format('lj_gc_steps_%s', state),
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   gc_steps_atomic(
@@ -189,6 +203,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: gc_steps(
     title,
     description,
@@ -197,6 +212,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     job,
     policy,
     measurement,
+    alias,
     'atomic'
   ),
 
@@ -208,6 +224,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: gc_steps(
     title,
     description,
@@ -216,6 +233,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     job,
     policy,
     measurement,
+    alias,
     'sweepstring'
   ),
 
@@ -227,6 +245,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: gc_steps(
     title,
     description,
@@ -235,6 +254,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     job,
     policy,
     measurement,
+    alias,
     'finalize'
   ),
 
@@ -246,6 +266,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: gc_steps(
     title,
     description,
@@ -254,6 +275,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     job,
     policy,
     measurement,
+    alias,
     'sweep'
   ),
 
@@ -265,6 +287,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: gc_steps(
     title,
     description,
@@ -273,6 +296,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     job,
     policy,
     measurement,
+    alias,
     'propagate'
   ),
 
@@ -284,6 +308,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: gc_steps(
     title,
     description,
@@ -292,6 +317,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     job,
     policy,
     measurement,
+    alias,
     'pause'
   ),
 
@@ -303,6 +329,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     job,
     policy,
     measurement,
+    alias,
     metric_name
   ) = common.default_graph(
     title=title,
@@ -315,7 +342,8 @@ local common = import 'dashboard/panels/common.libsonnet';
     metric_name,
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   strings_allocated(
@@ -328,6 +356,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: allocated(
     title,
     description,
@@ -336,6 +365,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     job,
     policy,
     measurement,
+    alias,
     'lj_gc_strnum'
   ),
 
@@ -349,6 +379,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: allocated(
     title,
     description,
@@ -357,6 +388,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     job,
     policy,
     measurement,
+    alias,
     'lj_gc_tabnum'
   ),
 
@@ -370,6 +402,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: allocated(
     title,
     description,
@@ -378,6 +411,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     job,
     policy,
     measurement,
+    alias,
     'lj_gc_cdatanum'
   ),
 
@@ -391,6 +425,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: allocated(
     title,
     description,
@@ -399,6 +434,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     job,
     policy,
     measurement,
+    alias,
     'lj_gc_udatanum'
   ),
 
@@ -412,6 +448,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=version_warning(description),
@@ -424,7 +461,8 @@ local common = import 'dashboard/panels/common.libsonnet';
     'lj_gc_memory',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   gc_memory_freed(
@@ -437,6 +475,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=version_warning(description),
@@ -449,7 +488,8 @@ local common = import 'dashboard/panels/common.libsonnet';
     'lj_gc_freed',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   gc_memory_allocated(
@@ -462,6 +502,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=version_warning(description),
@@ -474,6 +515,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     'lj_gc_allocated',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 }

--- a/dashboard/panels/net.libsonnet
+++ b/dashboard/panels/net.libsonnet
@@ -14,6 +14,7 @@ local variable = import 'dashboard/variable.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -26,7 +27,8 @@ local variable = import 'dashboard/variable.libsonnet';
     'tnt_info_memory_net',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   local bytes_per_second_graph(
@@ -37,6 +39,7 @@ local variable = import 'dashboard/variable.libsonnet';
     policy,
     measurement,
     job,
+    alias,
     metric_name,
     labelY1,
   ) = common.default_graph(
@@ -51,7 +54,8 @@ local variable = import 'dashboard/variable.libsonnet';
     metric_name,
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   bytes_received_per_second(
@@ -65,6 +69,7 @@ local variable = import 'dashboard/variable.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: bytes_per_second_graph(
     title=title,
     description=description,
@@ -73,6 +78,7 @@ local variable = import 'dashboard/variable.libsonnet';
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_net_received_total',
     labelY1='received'
   ),
@@ -88,6 +94,7 @@ local variable = import 'dashboard/variable.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: bytes_per_second_graph(
     title=title,
     description=description,
@@ -96,6 +103,7 @@ local variable = import 'dashboard/variable.libsonnet';
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_net_sent_total',
     labelY1='sent'
   ),
@@ -114,6 +122,7 @@ local variable = import 'dashboard/variable.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -125,7 +134,8 @@ local variable = import 'dashboard/variable.libsonnet';
     'tnt_net_requests_total',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   net_pending(
@@ -141,6 +151,7 @@ local variable = import 'dashboard/variable.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -154,7 +165,8 @@ local variable = import 'dashboard/variable.libsonnet';
     'tnt_net_requests_current',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   requests_in_progress_per_second(
@@ -169,6 +181,7 @@ local variable = import 'dashboard/variable.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -181,6 +194,7 @@ local variable = import 'dashboard/variable.libsonnet';
     job,
     policy,
     measurement,
+    alias,
   )),
 
   requests_in_progress_current(
@@ -195,6 +209,7 @@ local variable = import 'dashboard/variable.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -208,6 +223,7 @@ local variable = import 'dashboard/variable.libsonnet';
     job,
     policy,
     measurement,
+    alias,
     'last'
   )),
 
@@ -224,6 +240,7 @@ local variable = import 'dashboard/variable.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -236,6 +253,7 @@ local variable = import 'dashboard/variable.libsonnet';
     job,
     policy,
     measurement,
+    alias,
   )),
 
   requests_in_queue_current(
@@ -250,6 +268,7 @@ local variable = import 'dashboard/variable.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -263,6 +282,7 @@ local variable = import 'dashboard/variable.libsonnet';
     job,
     policy,
     measurement,
+    alias,
     'last'
   )),
 
@@ -276,6 +296,7 @@ local variable = import 'dashboard/variable.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -288,6 +309,7 @@ local variable = import 'dashboard/variable.libsonnet';
     job,
     policy,
     measurement,
+    alias,
   )),
 
   current_connections(
@@ -300,6 +322,7 @@ local variable = import 'dashboard/variable.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -313,6 +336,7 @@ local variable = import 'dashboard/variable.libsonnet';
     job,
     policy,
     measurement,
+    alias,
     'last',
   )),
 }

--- a/dashboard/panels/operations.libsonnet
+++ b/dashboard/panels/operations.libsonnet
@@ -17,6 +17,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
     labelY1=null,
     operation=null,
   ) = common.default_graph(
@@ -28,7 +29,8 @@ local prometheus = grafana.prometheus;
   ).addTarget(
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('rate(tnt_stats_op_total{job=~"%s",operation="%s"}[$__rate_interval])', [job, operation]),
+        expr=std.format('rate(tnt_stats_op_total{job=~"%s",alias=~"%s",operation="%s"}[$__rate_interval])',
+                        [job, alias, operation]),
         legendFormat='{{alias}}'
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -38,7 +40,9 @@ local prometheus = grafana.prometheus;
         group_tags=['label_pairs_alias'],
         alias='$tag_label_pairs_alias',
         fill='null',
-      ).where('metric_name', '=', 'tnt_stats_op_total').where('label_pairs_operation', '=', operation)
+      ).where('metric_name', '=', 'tnt_stats_op_total')
+      .where('label_pairs_alias', '=~', alias)
+      .where('label_pairs_operation', '=', operation)
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s'])
   ),
 
@@ -50,6 +54,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
     operation=null,
   ) = operation_rps(
     title=(if title != null then title else std.format('%s space requests', std.asciiUpper(operation))),
@@ -62,6 +67,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     labelY1='requests per second',
     operation=operation,
   ),
@@ -74,6 +80,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: space_operation_rps(
     title=title,
     description=description,
@@ -82,6 +89,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     operation='select'
   ),
 
@@ -93,6 +101,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: space_operation_rps(
     title=title,
     description=description,
@@ -101,6 +110,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     operation='insert'
   ),
 
@@ -112,6 +122,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: space_operation_rps(
     title=title,
     description=description,
@@ -120,6 +131,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     operation='replace'
   ),
 
@@ -131,6 +143,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: space_operation_rps(
     title=title,
     description=description,
@@ -139,6 +152,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     operation='upsert'
   ),
 
@@ -150,6 +164,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: space_operation_rps(
     title=title,
     description=description,
@@ -158,6 +173,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     operation='update'
   ),
 
@@ -169,6 +185,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: space_operation_rps(
     title=title,
     description=description,
@@ -177,6 +194,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     operation='delete'
   ),
 
@@ -191,6 +209,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: operation_rps(
     title=title,
     description=description,
@@ -199,6 +218,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     labelY1='requests per second',
     operation='call'
   ),
@@ -214,6 +234,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: operation_rps(
     title=title,
     description=description,
@@ -222,6 +243,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     labelY1='requests per second',
     operation='eval'
   ),
@@ -237,6 +259,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: operation_rps(
     title=title,
     description=description,
@@ -245,6 +268,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     labelY1='errors per second',
     operation='error'
   ),
@@ -260,6 +284,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: operation_rps(
     title=title,
     description=description,
@@ -268,6 +293,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     labelY1='requests per second',
     operation='auth'
   ),
@@ -285,6 +311,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: operation_rps(
     title=title,
     description=description,
@@ -293,6 +320,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     labelY1='requests per second',
     operation='prepare'
   ),
@@ -310,6 +338,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: operation_rps(
     title=title,
     description=description,
@@ -318,6 +347,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     labelY1='requests per second',
     operation='execute'
   ),

--- a/dashboard/panels/runtime.libsonnet
+++ b/dashboard/panels/runtime.libsonnet
@@ -15,6 +15,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -27,7 +28,8 @@ local common = import 'dashboard/panels/common.libsonnet';
     'tnt_info_memory_lua',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   runtime_memory(
@@ -45,6 +47,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -59,7 +62,8 @@ local common = import 'dashboard/panels/common.libsonnet';
     'tnt_runtime_used',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   memory_tx(
@@ -75,6 +79,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -87,7 +92,8 @@ local common = import 'dashboard/panels/common.libsonnet';
     'tnt_info_memory_tx',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   fiber_count(
@@ -102,6 +108,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -115,6 +122,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     job,
     policy,
     measurement,
+    alias,
     'last'
   )),
 
@@ -129,6 +137,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -140,7 +149,8 @@ local common = import 'dashboard/panels/common.libsonnet';
     'tnt_fiber_csw',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   local fiber_memory(
@@ -151,6 +161,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy,
     measurement,
     job,
+    alias,
     metric_name,
   ) = common.default_graph(
     title=title,
@@ -163,7 +174,8 @@ local common = import 'dashboard/panels/common.libsonnet';
     metric_name,
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   fiber_memused(
@@ -175,7 +187,8 @@ local common = import 'dashboard/panels/common.libsonnet';
     datasource=null,
     policy=null,
     measurement=null,
-    job=null
+    job=null,
+    alias=null,
   ):: fiber_memory(
     title,
     description,
@@ -184,6 +197,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy,
     measurement,
     job,
+    alias,
     'tnt_fiber_memused'
   ),
 
@@ -196,7 +210,8 @@ local common = import 'dashboard/panels/common.libsonnet';
     datasource=null,
     policy=null,
     measurement=null,
-    job=null
+    job=null,
+    alias=null,
   ):: fiber_memory(
     title,
     description,
@@ -205,6 +220,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy,
     measurement,
     job,
+    alias,
     'tnt_fiber_memalloc'
   ),
 
@@ -223,6 +239,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -238,6 +255,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     job,
     policy,
     measurement,
+    alias,
     converter='last'
   )),
 }

--- a/dashboard/panels/slab.libsonnet
+++ b/dashboard/panels/slab.libsonnet
@@ -23,6 +23,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
     metric_name=null,
     format=null,
     labelY1=null,
@@ -43,6 +44,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     job,
     policy,
     measurement,
+    alias,
   )),
 
   local used_ratio(
@@ -53,6 +55,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy,
     measurement,
     job,
+    alias,
     metric_name,
   ) = used_panel(
     title,
@@ -62,6 +65,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy,
     measurement,
     job,
+    alias,
     metric_name,
     format='percent',
     labelY1='used ratio',
@@ -83,6 +87,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: used_ratio(
     title=title,
     description=description,
@@ -91,6 +96,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_slab_quota_used_ratio',
   ),
 
@@ -109,6 +115,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: used_ratio(
     title=title,
     description=description,
@@ -117,6 +124,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_slab_arena_used_ratio',
   ),
 
@@ -135,6 +143,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: used_ratio(
     title=title,
     description=description,
@@ -143,6 +152,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_slab_items_used_ratio',
   ),
 
@@ -154,6 +164,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy,
     measurement,
     job,
+    alias,
     metric_name,
   ) = used_panel(
     title,
@@ -163,6 +174,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy,
     measurement,
     job,
+    alias,
     metric_name,
     format='bytes',
     labelY1='in bytes',
@@ -179,6 +191,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: used_memory(
     title=title,
     description=description,
@@ -187,6 +200,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_slab_quota_used',
   ),
 
@@ -201,6 +215,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: used_memory(
     title=title,
     description=description,
@@ -209,6 +224,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_slab_quota_size',
   ),
 
@@ -223,6 +239,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: used_memory(
     title=title,
     description=description,
@@ -231,6 +248,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_slab_arena_used',
   ),
 
@@ -245,6 +263,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: used_memory(
     title=title,
     description=description,
@@ -253,6 +272,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_slab_arena_size',
   ),
 
@@ -267,6 +287,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: used_memory(
     title=title,
     description=description,
@@ -275,6 +296,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_slab_items_used',
   ),
 
@@ -289,6 +311,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: used_memory(
     title=title,
     description=description,
@@ -297,6 +320,7 @@ local common = import 'dashboard/panels/common.libsonnet';
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_slab_items_size',
   ),
 }

--- a/dashboard/panels/space.libsonnet
+++ b/dashboard/panels/space.libsonnet
@@ -17,6 +17,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
     metric_name=null,
     engine=null
   ) = common.default_graph(
@@ -31,7 +32,7 @@ local prometheus = grafana.prometheus;
   ).addTarget(
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('%s{job=~"%s", engine="%s"}', [metric_name, job, engine]),
+        expr=std.format('%s{job=~"%s", alias=~"%s", engine="%s"}', [metric_name, job, alias, engine]),
         legendFormat='{{alias}} — {{name}}',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -41,7 +42,9 @@ local prometheus = grafana.prometheus;
         group_tags=['label_pairs_alias', 'label_pairs_name'],
         alias='$tag_label_pairs_alias — $tag_label_pairs_name',
         fill='null',
-      ).where('metric_name', '=', metric_name).where('label_pairs_engine', '=', engine)
+      ).where('metric_name', '=', metric_name)
+      .where('label_pairs_alias', '=~', alias)
+      .where('label_pairs_engine', '=', engine)
       .selectField('value').addConverter('last')
   ),
 
@@ -56,6 +59,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: count(
     title=title,
     description=description,
@@ -64,6 +68,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_space_len',
     engine='memtx'
   ),
@@ -86,6 +91,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: count(
     title=title,
     description=description,
@@ -94,6 +100,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_vinyl_tuples',
     engine='vinyl'
   ),
@@ -106,6 +113,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
     metric_name=null,
   ) = common.default_graph(
     title=title,
@@ -117,7 +125,7 @@ local prometheus = grafana.prometheus;
   ).addTarget(
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('%s{job=~"%s", engine="memtx"}', [metric_name, job]),
+        expr=std.format('%s{job=~"%s", alias=~"%s", engine="memtx"}', [metric_name, job, alias]),
         legendFormat='{{alias}} — {{name}}',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -127,7 +135,9 @@ local prometheus = grafana.prometheus;
         group_tags=['label_pairs_alias', 'label_pairs_name'],
         alias='$tag_label_pairs_alias — $tag_label_pairs_name',
         fill='null',
-      ).where('metric_name', '=', metric_name).where('label_pairs_engine', '=', 'memtx')
+      ).where('metric_name', '=', metric_name)
+      .where('label_pairs_alias', '=~', alias)
+      .where('label_pairs_engine', '=', 'memtx')
       .selectField('value').addConverter('mean')
   ),
 
@@ -153,6 +163,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: bsize_memtx(
     title=title,
     description=description,
@@ -161,6 +172,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_space_bsize'
   ),
 
@@ -177,6 +189,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -187,7 +200,7 @@ local prometheus = grafana.prometheus;
   ).addTarget(
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('tnt_space_index_bsize{job=~"%s"}', [job]),
+        expr=std.format('tnt_space_index_bsize{job=~"%s", alias=~"%s"}', [job, alias]),
         legendFormat='{{alias}} — {{name}} ({{index_name}})',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -198,6 +211,7 @@ local prometheus = grafana.prometheus;
         alias='$tag_label_pairs_alias — $tag_label_pairs_name ($tag_label_pairs_index_name)',
         fill='null',
       ).where('metric_name', '=', 'tnt_space_index_bsize')
+      .where('label_pairs_alias', '=~', alias)
       .selectField('value').addConverter('mean')
   ),
 
@@ -223,6 +237,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: bsize_memtx(
     title=title,
     description=description,
@@ -231,6 +246,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_space_total_bsize'
   ),
 }

--- a/dashboard/panels/tdg/expirationd.libsonnet
+++ b/dashboard/panels/tdg/expirationd.libsonnet
@@ -15,10 +15,11 @@ local prometheus = grafana.prometheus;
     job=null,
     policy=null,
     measurement=null,
+    alias=null,
   ) =
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('%s{job=~"%s"}', [metric_name, job]),
+        expr=std.format('%s{job=~"%s",alias=~"%s"}', [metric_name, job, alias]),
         legendFormat='{{name}} — {{alias}}',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -32,6 +33,7 @@ local prometheus = grafana.prometheus;
         alias='$tag_label_pairs_name — $tag_label_pairs_alias',
         fill='null',
       ).where('metric_name', '=', metric_name)
+      .where('label_pairs_alias', '=~', alias)
       .selectField('value').addConverter('mean'),
 
   local rps_target(
@@ -40,11 +42,12 @@ local prometheus = grafana.prometheus;
     job=null,
     policy=null,
     measurement=null,
+    alias=null,
   ) =
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('rate(%s{job=~"%s"}[$__rate_interval])',
-                        [metric_name, job]),
+        expr=std.format('rate(%s{job=~"%s",alias=~"%s"}[$__rate_interval])',
+                        [metric_name, job, alias]),
         legendFormat='{{name}} — {{alias}}',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -58,6 +61,7 @@ local prometheus = grafana.prometheus;
         alias='$tag_label_pairs_name — $tag_label_pairs_alias',
         fill='null',
       ).where('metric_name', '=', metric_name)
+      .where('label_pairs_alias', '=~', alias)
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s']),
 
   tuples_checked(
@@ -71,6 +75,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -83,6 +88,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   tuples_expired(
@@ -96,6 +102,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -108,6 +115,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   restarts(
@@ -121,6 +129,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -133,6 +142,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   operation_time(
@@ -145,6 +155,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -157,5 +168,6 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 }

--- a/dashboard/panels/tdg/file_connectors.libsonnet
+++ b/dashboard/panels/tdg/file_connectors.libsonnet
@@ -15,10 +15,11 @@ local prometheus = grafana.prometheus;
     job=null,
     policy=null,
     measurement=null,
+    alias=null,
   ) =
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('%s{job=~"%s"}', [metric_name, job]),
+        expr=std.format('%s{job=~"%s",alias=~"%s"}', [metric_name, job, alias]),
         legendFormat='{{connector_name}} — {{alias}}',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -32,6 +33,7 @@ local prometheus = grafana.prometheus;
         alias='$tag_label_pairs_connector_name — $tag_label_pairs_alias',
         fill='null',
       ).where('metric_name', '=', metric_name)
+      .where('label_pairs_alias', '=~', alias)
       .selectField('value').addConverter('mean'),
 
   files_processed(
@@ -44,6 +46,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -58,6 +61,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   objects_processed(
@@ -70,6 +74,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -84,6 +89,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   files_process_errors(
@@ -96,6 +102,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -110,6 +117,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   file_size(
@@ -122,6 +130,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -135,6 +144,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   current_bytes_processed(
@@ -147,6 +157,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -160,6 +171,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   current_objects_processed(
@@ -172,6 +184,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -186,5 +199,6 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 }

--- a/dashboard/panels/tdg/iproto.libsonnet
+++ b/dashboard/panels/tdg/iproto.libsonnet
@@ -19,6 +19,7 @@ local prometheus = grafana.prometheus;
     job=null,
     policy=null,
     measurement=null,
+    alias=null,
     panel_width=6,
   ) = common_utils.default_graph(
     title=
@@ -40,8 +41,8 @@ local prometheus = grafana.prometheus;
   ).addTarget(
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('rate(%s{job=~"%s",method="repository.%s"}[$__rate_interval])',
-                        [metric_name, job, method_tail]),
+        expr=std.format('rate(%s{job=~"%s",alias=~"%s",method="repository.%s"}[$__rate_interval])',
+                        [metric_name, job, alias, method_tail]),
         legendFormat='{{type}} — {{alias}}',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -55,6 +56,7 @@ local prometheus = grafana.prometheus;
         alias='$tag_label_pairs_type — $tag_label_pairs_alias',
         fill='null',
       ).where('metric_name', '=', metric_name)
+      .where('label_pairs_alias', '=~', alias)
       .where('label_pairs_method', '=', std.format('repository.%s', method_tail))
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s']),
   ),
@@ -69,6 +71,7 @@ local prometheus = grafana.prometheus;
     job=null,
     policy=null,
     measurement=null,
+    alias=null,
     panel_width=6,
   ) = common_utils.default_graph(
     title=
@@ -90,8 +93,8 @@ local prometheus = grafana.prometheus;
   ).addTarget(
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('%s{job=~"%s",method="repository.%s",quantile="0.99"}',
-                        [metric_name, job, method_tail]),
+        expr=std.format('%s{job=~"%s",alias=~"%s",method="repository.%s",quantile="0.99"}',
+                        [metric_name, job, alias, method_tail]),
         legendFormat='{{type}} — {{alias}}',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -105,6 +108,7 @@ local prometheus = grafana.prometheus;
         alias='$tag_label_pairs_type — $tag_label_pairs_alias',
         fill='null',
       ).where('metric_name', '=', metric_name)
+      .where('label_pairs_alias', '=~', alias)
       .where('label_pairs_method', '=', std.format('repository.%s', method_tail))
       .where('label_pairs_quantile', '=', '0.99')
       .selectField('value').addConverter('mean'),
@@ -118,6 +122,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: rps_panel(
     title=title,
     description=description,
@@ -128,6 +133,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 
   put_latency(
@@ -138,6 +144,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: latency_panel(
     title=title,
     description=description,
@@ -148,6 +155,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 
   put_batch_rps(
@@ -158,6 +166,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: rps_panel(
     title=title,
     description=description,
@@ -168,6 +177,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 
   put_batch_latency(
@@ -178,6 +188,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: latency_panel(
     title=title,
     description=description,
@@ -188,6 +199,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 
   find_rps(
@@ -198,6 +210,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: rps_panel(
     title=title,
     description=description,
@@ -208,6 +221,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
     panel_width=12,
   ),
 
@@ -219,6 +233,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: latency_panel(
     title=title,
     description=description,
@@ -229,6 +244,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
     panel_width=12,
   ),
 
@@ -240,6 +256,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: rps_panel(
     title=title,
     description=description,
@@ -250,6 +267,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 
   update_latency(
@@ -260,6 +278,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: latency_panel(
     title=title,
     description=description,
@@ -270,6 +289,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 
   get_rps(
@@ -280,6 +300,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: rps_panel(
     title=title,
     description=description,
@@ -290,6 +311,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 
   get_latency(
@@ -300,6 +322,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: latency_panel(
     title=title,
     description=description,
@@ -310,6 +333,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 
   delete_rps(
@@ -320,6 +344,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: rps_panel(
     title=title,
     description=description,
@@ -330,6 +355,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 
   delete_latency(
@@ -340,6 +366,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: latency_panel(
     title=title,
     description=description,
@@ -350,6 +377,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 
   count_rps(
@@ -360,6 +388,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: rps_panel(
     title=title,
     description=description,
@@ -370,6 +399,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 
   count_latency(
@@ -380,6 +410,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: latency_panel(
     title=title,
     description=description,
@@ -390,6 +421,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 
   map_reduce_rps(
@@ -400,6 +432,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: rps_panel(
     title=title,
     description=description,
@@ -410,6 +443,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 
   map_reduce_latency(
@@ -420,6 +454,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: latency_panel(
     title=title,
     description=description,
@@ -430,6 +465,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 
   call_on_storage_rps(
@@ -440,6 +476,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: rps_panel(
     title=title,
     description=description,
@@ -450,6 +487,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 
   call_on_storage_latency(
@@ -460,6 +498,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: latency_panel(
     title=title,
     description=description,
@@ -470,5 +509,6 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 }

--- a/dashboard/panels/tdg/kafka/brokers.libsonnet
+++ b/dashboard/panels/tdg/kafka/brokers.libsonnet
@@ -15,10 +15,11 @@ local prometheus = grafana.prometheus;
     job=null,
     policy=null,
     measurement=null,
+    alias=null,
   ) =
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('%s{job=~"%s"}', [metric_name, job]),
+        expr=std.format('%s{job=~"%s",alias=~"%s"}', [metric_name, job, alias]),
         legendFormat='{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -35,6 +36,7 @@ local prometheus = grafana.prometheus;
         alias='$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)',
         fill='null',
       ).where('metric_name', '=', metric_name)
+      .where('label_pairs_alias', '=~', alias)
       .selectField('value').addConverter('mean'),
 
   local brokers_rps_target(
@@ -43,11 +45,12 @@ local prometheus = grafana.prometheus;
     job=null,
     policy=null,
     measurement=null,
+    alias=null,
   ) =
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('rate(%s{job=~"%s"}[$__rate_interval])',
-                        [metric_name, job]),
+        expr=std.format('rate(%s{job=~"%s",alias=~"%s"}[$__rate_interval])',
+                        [metric_name, job, alias]),
         legendFormat='{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -64,6 +67,7 @@ local prometheus = grafana.prometheus;
         alias='$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)',
         fill='null',
       ).where('metric_name', '=', metric_name)
+      .where('label_pairs_alias', '=~', alias)
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s']),
 
   local brokers_quantile_target(
@@ -72,11 +76,12 @@ local prometheus = grafana.prometheus;
     job=null,
     policy=null,
     measurement=null,
+    alias=null,
   ) =
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('%s{job=~"%s",quantile="0.99"}',
-                        [metric_name, job]),
+        expr=std.format('%s{job=~"%s",alias=~"%s",quantile="0.99"}',
+                        [metric_name, job, alias]),
         legendFormat='{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -92,7 +97,9 @@ local prometheus = grafana.prometheus;
         ],
         alias='$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)',
         fill='null',
-      ).where('metric_name', '=', metric_name).where('label_pairs_quantile', '=', '0.99')
+      ).where('metric_name', '=', metric_name)
+      .where('label_pairs_alias', '=~', alias)
+      .where('label_pairs_quantile', '=', '0.99')
       .selectField('value').addConverter('last'),
 
   stateage(
@@ -105,6 +112,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -118,7 +126,8 @@ local prometheus = grafana.prometheus;
     'tdg_kafka_broker_stateage',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   connects(
@@ -133,6 +142,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -144,7 +154,8 @@ local prometheus = grafana.prometheus;
     'tdg_kafka_broker_connects',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   disconnects(
@@ -158,6 +169,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -169,7 +181,8 @@ local prometheus = grafana.prometheus;
     'tdg_kafka_broker_disconnects',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   poll_wakeups(
@@ -183,6 +196,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -194,7 +208,8 @@ local prometheus = grafana.prometheus;
     'tdg_kafka_broker_wakeups',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   outbuf(
@@ -207,6 +222,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -218,7 +234,8 @@ local prometheus = grafana.prometheus;
     'tdg_kafka_broker_outbuf_cnt',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   outbuf_msg(
@@ -231,6 +248,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -242,7 +260,8 @@ local prometheus = grafana.prometheus;
     'tdg_kafka_broker_outbuf_msg_cnt',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   waitresp(
@@ -255,6 +274,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -266,7 +286,8 @@ local prometheus = grafana.prometheus;
     'tdg_kafka_broker_waitresp_cnt',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   waitresp_msg(
@@ -279,6 +300,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -290,7 +312,8 @@ local prometheus = grafana.prometheus;
     'tdg_kafka_broker_waitresp_msg_cnt',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   requests(
@@ -304,6 +327,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -314,7 +338,8 @@ local prometheus = grafana.prometheus;
     'tdg_kafka_broker_tx',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   request_bytes(
@@ -328,6 +353,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -339,6 +365,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   request_errors(
@@ -352,6 +379,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -363,6 +391,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   request_retries(
@@ -376,6 +405,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -387,6 +417,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   request_idle(
@@ -399,6 +430,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -411,7 +443,8 @@ local prometheus = grafana.prometheus;
     'tdg_kafka_broker_txidle',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   request_timeout(
@@ -425,6 +458,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -436,6 +470,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   responses(
@@ -449,6 +484,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -459,7 +495,8 @@ local prometheus = grafana.prometheus;
     'tdg_kafka_broker_rx',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   response_bytes(
@@ -473,6 +510,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -484,6 +522,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   response_errors(
@@ -497,6 +536,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -508,6 +548,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   response_corriderrs(
@@ -522,6 +563,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -533,6 +575,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   response_idle(
@@ -545,6 +588,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -557,7 +601,8 @@ local prometheus = grafana.prometheus;
     'tdg_kafka_broker_rxidle',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   response_partial(
@@ -571,6 +616,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -582,6 +628,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   requests_by_type(
@@ -595,6 +642,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -606,8 +654,8 @@ local prometheus = grafana.prometheus;
   ).addTarget(
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('rate(tdg_kafka_broker_req{job=~"%s"}[$__rate_interval])',
-                        [job]),
+        expr=std.format('rate(tdg_kafka_broker_req{job=~"%s",alias=~"%s"}[$__rate_interval])',
+                        [job, alias]),
         legendFormat='{{request}} — {{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -625,6 +673,7 @@ local prometheus = grafana.prometheus;
         alias='$tag_label_pairs_request — $tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)',
         fill='null',
       ).where('metric_name', '=', 'tdg_kafka_broker_req')
+      .where('label_pairs_alias', '=~', alias)
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s']),
   ),
 
@@ -638,6 +687,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -650,7 +700,8 @@ local prometheus = grafana.prometheus;
     'tdg_kafka_broker_int_latency',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   internal_request_latency(
@@ -663,6 +714,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -675,7 +727,8 @@ local prometheus = grafana.prometheus;
     'tdg_kafka_broker_outbuf_latency',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   broker_latency(
@@ -688,6 +741,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -700,7 +754,8 @@ local prometheus = grafana.prometheus;
     'tdg_kafka_broker_rtt',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   broker_throttle(
@@ -713,6 +768,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -725,6 +781,7 @@ local prometheus = grafana.prometheus;
     'tdg_kafka_broker_throttle',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 }

--- a/dashboard/panels/tdg/kafka/common.libsonnet
+++ b/dashboard/panels/tdg/kafka/common.libsonnet
@@ -16,6 +16,7 @@ local variable = import 'dashboard/variable.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -26,7 +27,8 @@ local variable = import 'dashboard/variable.libsonnet';
     'tdg_kafka_replyq',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   message_current(
@@ -39,6 +41,7 @@ local variable = import 'dashboard/variable.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -49,7 +52,8 @@ local variable = import 'dashboard/variable.libsonnet';
     'tdg_kafka_msg_size',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   message_size(
@@ -62,6 +66,7 @@ local variable = import 'dashboard/variable.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -73,7 +78,8 @@ local variable = import 'dashboard/variable.libsonnet';
     'tdg_kafka_msg_cnt',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   requests(
@@ -87,6 +93,7 @@ local variable = import 'dashboard/variable.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -99,6 +106,7 @@ local variable = import 'dashboard/variable.libsonnet';
     job,
     policy,
     measurement,
+    alias,
   )),
 
   request_bytes(
@@ -112,6 +120,7 @@ local variable = import 'dashboard/variable.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -124,6 +133,7 @@ local variable = import 'dashboard/variable.libsonnet';
     job,
     policy,
     measurement,
+    alias,
   )),
 
   responses(
@@ -137,6 +147,7 @@ local variable = import 'dashboard/variable.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -149,6 +160,7 @@ local variable = import 'dashboard/variable.libsonnet';
     job,
     policy,
     measurement,
+    alias,
   )),
 
   response_bytes(
@@ -162,6 +174,7 @@ local variable = import 'dashboard/variable.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -174,6 +187,7 @@ local variable = import 'dashboard/variable.libsonnet';
     job,
     policy,
     measurement,
+    alias,
   )),
 
   messages_sent(
@@ -187,6 +201,7 @@ local variable = import 'dashboard/variable.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -199,6 +214,7 @@ local variable = import 'dashboard/variable.libsonnet';
     job,
     policy,
     measurement,
+    alias,
   )),
 
   message_bytes_sent(
@@ -213,6 +229,7 @@ local variable = import 'dashboard/variable.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -225,6 +242,7 @@ local variable = import 'dashboard/variable.libsonnet';
     job,
     policy,
     measurement,
+    alias,
   )),
 
   messages_received(
@@ -238,6 +256,7 @@ local variable = import 'dashboard/variable.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -250,6 +269,7 @@ local variable = import 'dashboard/variable.libsonnet';
     job,
     policy,
     measurement,
+    alias,
   )),
 
   message_bytes_received(
@@ -264,6 +284,7 @@ local variable = import 'dashboard/variable.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -276,5 +297,6 @@ local variable = import 'dashboard/variable.libsonnet';
     job,
     policy,
     measurement,
+    alias,
   )),
 }

--- a/dashboard/panels/tdg/kafka/consumer.libsonnet
+++ b/dashboard/panels/tdg/kafka/consumer.libsonnet
@@ -14,6 +14,7 @@ local kafka_utils = import 'dashboard/panels/tdg/kafka/utils.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -27,7 +28,8 @@ local kafka_utils = import 'dashboard/panels/tdg/kafka/utils.libsonnet';
     'tdg_kafka_cgrp_stateage',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   rebalance_age(
@@ -40,6 +42,7 @@ local kafka_utils = import 'dashboard/panels/tdg/kafka/utils.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -51,7 +54,8 @@ local kafka_utils = import 'dashboard/panels/tdg/kafka/utils.libsonnet';
     'tdg_kafka_cgrp_rebalance_age',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   rebalances(
@@ -65,6 +69,7 @@ local kafka_utils = import 'dashboard/panels/tdg/kafka/utils.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -77,6 +82,7 @@ local kafka_utils = import 'dashboard/panels/tdg/kafka/utils.libsonnet';
     job,
     policy,
     measurement,
+    alias,
   )),
 
   assignment_size(
@@ -89,6 +95,7 @@ local kafka_utils = import 'dashboard/panels/tdg/kafka/utils.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -99,6 +106,7 @@ local kafka_utils = import 'dashboard/panels/tdg/kafka/utils.libsonnet';
     'tdg_kafka_cgrp_assignment_size',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 }

--- a/dashboard/panels/tdg/kafka/producer.libsonnet
+++ b/dashboard/panels/tdg/kafka/producer.libsonnet
@@ -14,6 +14,7 @@ local kafka_utils = import 'dashboard/panels/tdg/kafka/utils.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -27,7 +28,8 @@ local kafka_utils = import 'dashboard/panels/tdg/kafka/utils.libsonnet';
     'tdg_kafka_eos_idemp_stateage',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   txn_stateage(
@@ -40,6 +42,7 @@ local kafka_utils = import 'dashboard/panels/tdg/kafka/utils.libsonnet';
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -53,6 +56,7 @@ local kafka_utils = import 'dashboard/panels/tdg/kafka/utils.libsonnet';
     'tdg_kafka_eos_txn_stateage',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 }

--- a/dashboard/panels/tdg/kafka/topics.libsonnet
+++ b/dashboard/panels/tdg/kafka/topics.libsonnet
@@ -15,10 +15,11 @@ local prometheus = grafana.prometheus;
     job=null,
     policy=null,
     measurement=null,
+    alias=null,
   ) =
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('%s{job=~"%s"}', [metric_name, job]),
+        expr=std.format('%s{job=~"%s",alias=~"%s"}', [metric_name, job, alias]),
         legendFormat='{{name}} ({{topic}}) — {{alias}} ({{type}}, {{connector_name}})',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -35,6 +36,7 @@ local prometheus = grafana.prometheus;
         alias='$tag_label_pairs_name ($tag_label_pairs_topic) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)',
         fill='null',
       ).where('metric_name', '=', metric_name)
+      .where('label_pairs_alias', '=~', alias)
       .selectField('value').addConverter('mean'),
 
   local partitions_target(
@@ -43,10 +45,11 @@ local prometheus = grafana.prometheus;
     job=null,
     policy=null,
     measurement=null,
+    alias=null,
   ) =
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('%s{job=~"%s"}', [metric_name, job]),
+        expr=std.format('%s{job=~"%s",alias=~"%s"}', [metric_name, job, alias]),
         legendFormat='{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -64,6 +67,7 @@ local prometheus = grafana.prometheus;
         alias='$tag_label_pairs_name ($tag_label_pairs_topic, $tag_label_pairs_partition) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)',
         fill='null',
       ).where('metric_name', '=', metric_name)
+      .where('label_pairs_alias', '=~', alias)
       .selectField('value').addConverter('mean'),
 
   local partitions_rps_target(
@@ -72,11 +76,12 @@ local prometheus = grafana.prometheus;
     job=null,
     policy=null,
     measurement=null,
+    alias=null,
   ) =
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('rate(%s{job=~"%s"}[$__rate_interval])',
-                        [metric_name, job]),
+        expr=std.format('rate(%s{job=~"%s",alias=~"%s"}[$__rate_interval])',
+                        [metric_name, job, alias]),
         legendFormat='{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -94,6 +99,7 @@ local prometheus = grafana.prometheus;
         alias='$tag_label_pairs_name ($tag_label_pairs_topic, $tag_label_pairs_partition) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)',
         fill='null',
       ).where('metric_name', '=', metric_name)
+      .where('label_pairs_alias', '=~', alias)
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s']),
 
   local topics_quantile_target(
@@ -102,11 +108,12 @@ local prometheus = grafana.prometheus;
     job=null,
     policy=null,
     measurement=null,
+    alias=null,
   ) =
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('%s{job=~"%s",quantile="0.99"}',
-                        [metric_name, job]),
+        expr=std.format('%s{job=~"%s",alias=~"%s",quantile="0.99"}',
+                        [metric_name, job, alias]),
         legendFormat='{{name}} ({{topic}}) — {{alias}} ({{type}}, {{connector_name}})',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -122,7 +129,9 @@ local prometheus = grafana.prometheus;
         ],
         alias='$tag_label_pairs_name ($tag_label_pairs_topic) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)',
         fill='null',
-      ).where('metric_name', '=', metric_name).where('label_pairs_quantile', '=', '0.99')
+      ).where('metric_name', '=', metric_name)
+      .where('label_pairs_alias', '=~', alias)
+      .where('label_pairs_quantile', '=', '0.99')
       .selectField('value').addConverter('last'),
 
   age(
@@ -135,6 +144,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -146,7 +156,8 @@ local prometheus = grafana.prometheus;
     'tdg_kafka_topic_age',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   metadata_age(
@@ -159,6 +170,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -170,7 +182,8 @@ local prometheus = grafana.prometheus;
     'tdg_kafka_topic_metadata_age',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   topic_batchsize(
@@ -183,6 +196,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -195,7 +209,8 @@ local prometheus = grafana.prometheus;
     'tdg_kafka_topic_batchsize',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   topic_batchcnt(
@@ -208,6 +223,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -219,7 +235,8 @@ local prometheus = grafana.prometheus;
     'tdg_kafka_topic_batchcnt',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   partition_msgq(
@@ -233,6 +250,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -242,7 +260,8 @@ local prometheus = grafana.prometheus;
     'tdg_kafka_topic_partitions_msgq_cnt',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   partition_xmit_msgq(
@@ -256,6 +275,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -265,7 +285,8 @@ local prometheus = grafana.prometheus;
     'tdg_kafka_topic_partitions_xmit_msgq_cnt',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   partition_fetchq_msgq(
@@ -279,6 +300,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -288,7 +310,8 @@ local prometheus = grafana.prometheus;
     'tdg_kafka_topic_partitions_fetchq_cnt',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   partition_msgq_bytes(
@@ -302,6 +325,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -312,7 +336,8 @@ local prometheus = grafana.prometheus;
     'tdg_kafka_topic_partitions_msgq_bytes',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   partition_xmit_msgq_bytes(
@@ -326,6 +351,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -336,7 +362,8 @@ local prometheus = grafana.prometheus;
     'tdg_kafka_topic_partitions_xmit_msgq_bytes',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   partition_fetchq_msgq_bytes(
@@ -350,6 +377,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -360,7 +388,8 @@ local prometheus = grafana.prometheus;
     'tdg_kafka_topic_partitions_fetchq_size',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   partition_messages_sent(
@@ -374,6 +403,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -386,6 +416,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   partition_message_bytes_sent(
@@ -399,6 +430,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -412,6 +444,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   partition_messages_consumed(
@@ -426,6 +459,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -438,6 +472,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   partition_message_bytes_consumed(
@@ -452,6 +487,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -465,6 +501,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   partition_messages_dropped(
@@ -478,6 +515,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -490,6 +528,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   partition_messages_in_flight(
@@ -503,6 +542,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -515,5 +555,6 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 }

--- a/dashboard/panels/tdg/kafka/utils.libsonnet
+++ b/dashboard/panels/tdg/kafka/utils.libsonnet
@@ -12,10 +12,11 @@ local prometheus = grafana.prometheus;
     job=null,
     policy=null,
     measurement=null,
+    alias=null,
   )::
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('%s{job=~"%s"}', [metric_name, job]),
+        expr=std.format('%s{job=~"%s",alias=~"%s"}', [metric_name, job, alias]),
         legendFormat='{{name}} — {{alias}} ({{type}}, {{connector_name}})',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -26,6 +27,7 @@ local prometheus = grafana.prometheus;
         alias='$tag_label_pairs_name — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)',
         fill='null',
       ).where('metric_name', '=', metric_name)
+      .where('label_pairs_alias', '=~', alias)
       .selectField('value').addConverter('mean'),
 
   kafka_rps_target(
@@ -34,11 +36,12 @@ local prometheus = grafana.prometheus;
     job=null,
     policy=null,
     measurement=null,
+    alias=null,
   )::
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('rate(%s{job=~"%s"}[$__rate_interval])',
-                        [metric_name, job]),
+        expr=std.format('rate(%s{job=~"%s",alias=~"%s"}[$__rate_interval])',
+                        [metric_name, job, alias]),
         legendFormat='{{name}} — {{alias}} ({{type}}, {{connector_name}})',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -49,5 +52,6 @@ local prometheus = grafana.prometheus;
         alias='$tag_label_pairs_name — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)',
         fill='null',
       ).where('metric_name', '=', metric_name)
+      .where('label_pairs_alias', '=~', alias)
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s']),
 }

--- a/dashboard/panels/tdg/rest_api.libsonnet
+++ b/dashboard/panels/tdg/rest_api.libsonnet
@@ -20,6 +20,7 @@ local prometheus = grafana.prometheus;
     job=null,
     policy=null,
     measurement=null,
+    alias=null,
   ) = common_utils.default_graph(
     title=title,
     description=description,
@@ -28,9 +29,10 @@ local prometheus = grafana.prometheus;
   ).addTarget(
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('rate(%s{job=~"%s",method%s"GET",status_code=~"%s"}[$__rate_interval])', [
+        expr=std.format('rate(%s{job=~"%s",alias=~"%s",method%s"GET",status_code=~"%s"}[$__rate_interval])', [
           metric_name,
           job,
+          alias,
           get_condition,
           std.strReplace(status_regex, '\\', '\\\\'),
         ]),
@@ -49,6 +51,7 @@ local prometheus = grafana.prometheus;
         alias='$tag_label_pairs_method $tag_label_pairs_type (code $tag_label_pairs_status_code) — $tag_label_pairs_alias',
         fill='null',
       ).where('metric_name', '=', metric_name)
+      .where('label_pairs_alias', '=~', alias)
       .where('label_pairs_method', get_condition, 'GET')
       .where('label_pairs_status_code', '=~', std.format('/%s/', status_regex))
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s']),
@@ -65,6 +68,7 @@ local prometheus = grafana.prometheus;
     job=null,
     policy=null,
     measurement=null,
+    alias=null,
   ) = common_utils.default_graph(
     title=title,
     description=description,
@@ -74,9 +78,10 @@ local prometheus = grafana.prometheus;
   ).addTarget(
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('%s{job=~"%s",method%s"GET",status_code=~"%s",quantile="0.99"}', [
+        expr=std.format('%s{job=~"%s",alias=~"%s",method%s"GET",status_code=~"%s",quantile="0.99"}', [
           metric_name,
           job,
+          alias,
           get_condition,
           std.strReplace(status_regex, '\\', '\\\\'),
         ]),
@@ -95,6 +100,7 @@ local prometheus = grafana.prometheus;
         alias='$tag_label_pairs_method $tag_label_pairs_type (code $tag_label_pairs_status_code) — $tag_label_pairs_alias',
         fill='null',
       ).where('metric_name', '=', metric_name)
+      .where('label_pairs_alias', '=~', alias)
       .where('label_pairs_method', get_condition, 'GET')
       .where('label_pairs_status_code', '=~', std.format('/%s/', status_regex))
       .where('label_pairs_quantile', '=', '0.99')
@@ -112,6 +118,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: rps_panel(
     title=title,
     description=description,
@@ -123,6 +130,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 
   read_error_4xx_rps(
@@ -136,6 +144,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: rps_panel(
     title=title,
     description=description,
@@ -147,6 +156,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 
   read_error_5xx_rps(
@@ -160,6 +170,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: rps_panel(
     title=title,
     description=description,
@@ -171,6 +182,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 
   read_success_latency(
@@ -184,6 +196,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: latency_panel(
     title=title,
     description=description,
@@ -195,6 +208,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 
   read_error_4xx_latency(
@@ -208,6 +222,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: latency_panel(
     title=title,
     description=description,
@@ -219,6 +234,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 
   read_error_5xx_latency(
@@ -232,6 +248,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: latency_panel(
     title=title,
     description=description,
@@ -243,6 +260,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 
   write_success_rps(
@@ -257,6 +275,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: rps_panel(
     title=title,
     description=description,
@@ -268,6 +287,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 
   write_error_4xx_rps(
@@ -282,6 +302,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: rps_panel(
     title=title,
     description=description,
@@ -293,6 +314,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 
   write_error_5xx_rps(
@@ -307,6 +329,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: rps_panel(
     title=title,
     description=description,
@@ -318,6 +341,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 
   write_success_latency(
@@ -332,6 +356,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: latency_panel(
     title=title,
     description=description,
@@ -343,6 +368,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 
   write_error_4xx_latency(
@@ -357,6 +383,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: latency_panel(
     title=title,
     description=description,
@@ -368,6 +395,7 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 
   write_error_5xx_latency(
@@ -382,6 +410,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: latency_panel(
     title=title,
     description=description,
@@ -393,5 +422,6 @@ local prometheus = grafana.prometheus;
     job=job,
     policy=policy,
     measurement=measurement,
+    alias=alias,
   ),
 }

--- a/dashboard/panels/tdg/tuples.libsonnet
+++ b/dashboard/panels/tdg/tuples.libsonnet
@@ -15,6 +15,7 @@ local prometheus = grafana.prometheus;
     job=null,
     policy=null,
     measurement=null,
+    alias=null,
   ) =
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
@@ -63,6 +64,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -75,6 +77,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   tuples_returned_average(
@@ -89,6 +92,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -101,6 +105,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   tuples_scanned_max(
@@ -115,6 +120,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -128,6 +134,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   tuples_returned_max(
@@ -142,6 +149,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common_utils.default_graph(
     title=title,
     description=description,
@@ -155,5 +163,6 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 }

--- a/dashboard/panels/vinyl.libsonnet
+++ b/dashboard/panels/vinyl.libsonnet
@@ -17,6 +17,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
     metric_name=null,
   ) = common.default_graph(
     title=title,
@@ -32,6 +33,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   disk_data(
@@ -46,6 +48,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: disk_size(
     title=title,
     description=description,
@@ -54,6 +57,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_vinyl_disk_data_size',
   ),
 
@@ -69,6 +73,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: disk_size(
     title=title,
     description=description,
@@ -77,6 +82,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_vinyl_disk_index_size',
   ),
 
@@ -92,6 +98,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -104,7 +111,8 @@ local prometheus = grafana.prometheus;
     'tnt_vinyl_memory_tuple_cache',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   index_memory(
@@ -121,6 +129,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -133,7 +142,8 @@ local prometheus = grafana.prometheus;
     'tnt_vinyl_memory_page_index',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   bloom_filter_memory(
@@ -146,6 +156,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -158,7 +169,8 @@ local prometheus = grafana.prometheus;
     'tnt_vinyl_memory_bloom_filter',
     job,
     policy,
-    measurement
+    measurement,
+    alias,
   )),
 
   local regulator_bps(
@@ -169,6 +181,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
     metric_name=null,
   ) = common.default_graph(
     title=title,
@@ -182,6 +195,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   regulator_dump_bandwidth(
@@ -200,6 +214,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: regulator_bps(
     title=title,
     description=description,
@@ -208,6 +223,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_vinyl_regulator_dump_bandwidth',
   ),
 
@@ -225,6 +241,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: regulator_bps(
     title=title,
     description=description,
@@ -233,6 +250,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_vinyl_regulator_write_rate',
   ),
 
@@ -251,6 +269,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: regulator_bps(
     title=title,
     description=description,
@@ -259,6 +278,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_vinyl_regulator_rate_limit',
   ),
 
@@ -280,6 +300,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -293,6 +314,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   regulator_dump_watermark(
@@ -312,6 +334,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -326,6 +349,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   regulator_blocked_writers(
@@ -341,6 +365,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -355,6 +380,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   local tx_rate(
@@ -365,6 +391,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
     metric_name=null,
   ) = common.default_graph(
     title=title,
@@ -379,6 +406,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   tx_commit_rate(
@@ -395,6 +423,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: tx_rate(
     title=title,
     description=description,
@@ -403,6 +432,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_vinyl_tx_commit',
   ),
 
@@ -419,6 +449,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: tx_rate(
     title=title,
     description=description,
@@ -427,6 +458,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_vinyl_tx_rollback',
   ),
 
@@ -444,6 +476,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: tx_rate(
     title=title,
     description=description,
@@ -452,6 +485,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_vinyl_tx_conflict',
   ),
 
@@ -470,6 +504,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -483,6 +518,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
     'last',
   )),
 
@@ -494,6 +530,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
     metric_name=null,
   ) = common.default_graph(
     title=title,
@@ -524,6 +561,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: memory(
     title=title,
     description=description,
@@ -532,6 +570,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_vinyl_memory_page_index',
   ),
 
@@ -548,6 +587,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: memory(
     title=title,
     description=description,
@@ -556,6 +596,7 @@ local prometheus = grafana.prometheus;
     policy=policy,
     measurement=measurement,
     job=job,
+    alias=alias,
     metric_name='tnt_vinyl_memory_bloom_filter',
   ),
 
@@ -571,6 +612,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -581,7 +623,8 @@ local prometheus = grafana.prometheus;
   ).addTarget(
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('tnt_vinyl_scheduler_tasks{job=~"%s", status="inprogress"}', [job]),
+        expr=std.format('tnt_vinyl_scheduler_tasks{job=~"%s", alias=~"%s", status="inprogress"}',
+                        [job, alias]),
         legendFormat='{{alias}}',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -591,7 +634,9 @@ local prometheus = grafana.prometheus;
         group_tags=['label_pairs_alias'],
         alias='$tag_label_pairs_alias',
         fill='null',
-      ).where('metric_name', '=', 'tnt_vinyl_scheduler_tasks').where('label_pairs_status', '=', 'inprogress')
+      ).where('metric_name', '=', 'tnt_vinyl_scheduler_tasks')
+      .where('label_pairs_alias', '=~', alias)
+      .where('label_pairs_status', '=', 'inprogress')
       .selectField('value').addConverter('last')
   ),
 
@@ -608,6 +653,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -619,7 +665,8 @@ local prometheus = grafana.prometheus;
   ).addTarget(
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(
-        expr=std.format('rate(tnt_vinyl_scheduler_tasks{job=~"%s",status="failed"}[$__rate_interval])', [job]),
+        expr=std.format('rate(tnt_vinyl_scheduler_tasks{job=~"%s",alias=~"%s",status="failed"}[$__rate_interval])',
+                        [job, alias]),
         legendFormat='{{alias}}',
       )
     else if datasource_type == variable.datasource_type.influxdb then
@@ -629,7 +676,9 @@ local prometheus = grafana.prometheus;
         group_tags=['label_pairs_alias'],
         alias='$tag_label_pairs_alias',
         fill='null',
-      ).where('metric_name', '=', 'tnt_vinyl_scheduler_tasks').where('label_pairs_status', '=', 'failed')
+      ).where('metric_name', '=', 'tnt_vinyl_scheduler_tasks')
+      .where('label_pairs_alias', '=~', alias)
+      .where('label_pairs_status', '=', 'failed')
       .selectField('value').addConverter('mean').addConverter('non_negative_derivative', ['1s'])
   ),
 
@@ -646,6 +695,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -660,6 +710,7 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 
   scheduler_dump_count_rate(
@@ -674,6 +725,7 @@ local prometheus = grafana.prometheus;
     policy=null,
     measurement=null,
     job=null,
+    alias=null,
   ):: common.default_graph(
     title=title,
     description=description,
@@ -688,5 +740,6 @@ local prometheus = grafana.prometheus;
     job,
     policy,
     measurement,
+    alias,
   )),
 }

--- a/dashboard/section.libsonnet
+++ b/dashboard/section.libsonnet
@@ -25,7 +25,7 @@ local tdg_tasks = import 'dashboard/panels/tdg/tasks.libsonnet';
 local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
 
 {
-  cluster_influxdb(datasource_type, datasource, policy, measurement):: [
+  cluster_influxdb(datasource_type, datasource, policy, measurement, alias):: [
     cluster.row,
 
     cluster.cartridge_warning_issues(
@@ -33,6 +33,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       datasource=datasource,
       policy=policy,
       measurement=measurement,
+      alias=alias,
     ),
 
     cluster.cartridge_critical_issues(
@@ -40,6 +41,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       datasource=datasource,
       policy=policy,
       measurement=measurement,
+      alias=alias,
     ),
 
     cluster.replication_status(
@@ -47,6 +49,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       datasource=datasource,
       policy=policy,
       measurement=measurement,
+      alias=alias,
     ),
 
     cluster.read_only_status(
@@ -54,6 +57,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       datasource=datasource,
       policy=policy,
       measurement=measurement,
+      alias=alias,
     ),
 
     cluster.replication_lag(
@@ -61,6 +65,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       datasource=datasource,
       policy=policy,
       measurement=measurement,
+      alias=alias,
     ),
 
     cluster.clock_delta(
@@ -68,11 +73,12 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       datasource=datasource,
       policy=policy,
       measurement=measurement,
+      alias=alias,
     ),
   ],
 
   // Must be used only in the top of a dashboard, overall stat panels use complicated layout
-  cluster_prometheus(datasource_type, datasource, job):: [
+  cluster_prometheus(datasource_type, datasource, job, alias):: [
     cluster.row,
 
     cluster.health_overview_table(
@@ -121,40 +127,46 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       datasource_type=datasource_type,
       datasource=datasource,
       job=job,
+      alias=alias,
     ),
 
     cluster.cartridge_critical_issues(
       datasource_type=datasource_type,
       datasource=datasource,
       job=job,
+      alias=alias,
     ),
 
     cluster.replication_status(
       datasource_type=datasource_type,
       datasource=datasource,
       job=job,
+      alias=alias,
     ),
 
     cluster.read_only_status(
       datasource_type=datasource_type,
       datasource=datasource,
       job=job,
+      alias=alias,
     ),
 
     cluster.replication_lag(
       datasource_type=datasource_type,
       datasource=datasource,
       job=job,
+      alias=alias,
     ),
 
     cluster.clock_delta(
       datasource_type=datasource_type,
       datasource=datasource,
       job=job,
+      alias=alias,
     ),
   ],
 
-  http(datasource_type, datasource, policy=null, measurement=null, job=null):: [
+  http(datasource_type, datasource, policy=null, measurement=null, job=null, alias=null):: [
     http.row,
 
     http.rps_success(
@@ -163,6 +175,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     http.rps_error_4xx(
@@ -171,6 +184,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     http.rps_error_5xx(
@@ -179,6 +193,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     http.latency_success(
@@ -187,6 +202,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     http.latency_error_4xx(
@@ -195,6 +211,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     http.latency_error_5xx(
@@ -203,10 +220,11 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
   ],
 
-  net(datasource_type, datasource, policy=null, measurement=null, job=null):: [
+  net(datasource_type, datasource, policy=null, measurement=null, job=null, alias=null):: [
     net.row,
 
     net.net_memory(
@@ -215,6 +233,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     net.bytes_received_per_second(
@@ -223,6 +242,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     net.bytes_sent_per_second(
@@ -231,6 +251,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     net.net_rps(
@@ -239,6 +260,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     net.net_pending(
@@ -247,6 +269,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     net.requests_in_progress_per_second(
@@ -255,6 +278,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     net.requests_in_progress_current(
@@ -263,6 +287,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     net.requests_in_queue_per_second(
@@ -271,6 +296,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     net.requests_in_queue_current(
@@ -279,6 +305,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     net.connections_per_second(
@@ -287,6 +314,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     net.current_connections(
@@ -295,10 +323,11 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
   ],
 
-  slab(datasource_type, datasource, policy=null, measurement=null, job=null):: [
+  slab(datasource_type, datasource, policy=null, measurement=null, job=null, alias=null):: [
     slab.row,
 
     slab.monitor_info(),
@@ -309,6 +338,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     slab.arena_used_ratio(
@@ -317,6 +347,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     slab.items_used_ratio(
@@ -325,6 +356,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     slab.quota_used(
@@ -333,6 +365,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     slab.arena_used(
@@ -341,6 +374,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     slab.items_used(
@@ -349,6 +383,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     slab.quota_size(
@@ -357,6 +392,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     slab.arena_size(
@@ -365,6 +401,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     slab.items_size(
@@ -373,10 +410,11 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
   ],
 
-  space(datasource_type, datasource, policy=null, measurement=null, job=null):: [
+  space(datasource_type, datasource, policy=null, measurement=null, job=null, alias=null):: [
     space.row,
 
     space.memtx_len(
@@ -385,6 +423,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     space.vinyl_count(
@@ -393,6 +432,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     space.space_bsize(
@@ -401,6 +441,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     space.space_index_bsize(
@@ -409,6 +450,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     space.space_total_bsize(
@@ -417,10 +459,11 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
   ],
 
-  vinyl(datasource_type, datasource, policy=null, measurement=null, job=null):: [
+  vinyl(datasource_type, datasource, policy=null, measurement=null, job=null, alias=null):: [
     vinyl.row,
 
     vinyl.disk_data(
@@ -429,6 +472,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     vinyl.index_data(
@@ -437,6 +481,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     vinyl.tuples_cache_memory(
@@ -445,6 +490,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     vinyl.index_memory(
@@ -453,6 +499,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     vinyl.bloom_filter_memory(
@@ -461,6 +508,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     vinyl.regulator_dump_bandwidth(
@@ -469,6 +517,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     vinyl.regulator_write_rate(
@@ -477,6 +526,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     vinyl.regulator_rate_limit(
@@ -485,6 +535,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     vinyl.memory_level0(
@@ -493,6 +544,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     vinyl.regulator_dump_watermark(
@@ -501,6 +553,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     vinyl.regulator_blocked_writers(
@@ -509,6 +562,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     vinyl.tx_commit_rate(
@@ -517,6 +571,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     vinyl.tx_rollback_rate(
@@ -525,6 +580,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     vinyl.tx_conflicts_rate(
@@ -533,6 +589,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     vinyl.tx_read_views(
@@ -541,6 +598,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     vinyl.scheduler_tasks_inprogress(
@@ -549,6 +607,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     vinyl.scheduler_tasks_failed_rate(
@@ -557,6 +616,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     vinyl.scheduler_dump_time_rate(
@@ -565,6 +625,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     vinyl.scheduler_dump_count_rate(
@@ -573,10 +634,11 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
   ],
 
-  cpu(datasource_type, datasource, policy=null, measurement=null, job=null):: [
+  cpu(datasource_type, datasource, policy=null, measurement=null, job=null, alias=null):: [
     cpu.row,
 
     cpu.getrusage_cpu_user_time(
@@ -585,6 +647,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     cpu.getrusage_cpu_system_time(
@@ -593,10 +656,11 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
   ],
 
-  cpu_extended(datasource_type, datasource, policy=null, measurement=null, job=null):: [
+  cpu_extended(datasource_type, datasource, policy=null, measurement=null, job=null, alias=null):: [
     cpu.row,
 
     cpu.getrusage_cpu_user_time(
@@ -605,6 +669,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     cpu.getrusage_cpu_system_time(
@@ -613,6 +678,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     cpu.procstat_thread_user_time(
@@ -621,6 +687,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     cpu.procstat_thread_system_time(
@@ -629,10 +696,11 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
   ],
 
-  runtime(datasource_type, datasource, policy=null, measurement=null, job=null):: [
+  runtime(datasource_type, datasource, policy=null, measurement=null, job=null, alias=null):: [
     runtime.row,
 
     runtime.lua_memory(
@@ -641,6 +709,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     runtime.runtime_memory(
@@ -649,6 +718,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     runtime.memory_tx(
@@ -657,6 +727,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     runtime.fiber_csw(
@@ -665,6 +736,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     runtime.event_loop_time(
@@ -673,6 +745,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     runtime.fiber_count(
@@ -681,6 +754,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     runtime.fiber_memused(
@@ -689,6 +763,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     runtime.fiber_memalloc(
@@ -697,10 +772,11 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
   ],
 
-  luajit(datasource_type, datasource, policy=null, measurement=null, job=null):: [
+  luajit(datasource_type, datasource, policy=null, measurement=null, job=null, alias=null):: [
     luajit.row,
 
     luajit.snap_restores(
@@ -709,6 +785,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     luajit.jit_traces(
@@ -717,6 +794,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     luajit.jit_traces_aborts(
@@ -725,6 +803,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     luajit.machine_code_areas(
@@ -733,6 +812,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     luajit.strhash_hit(
@@ -741,6 +821,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     luajit.strhash_miss(
@@ -749,6 +830,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     luajit.gc_steps_atomic(
@@ -757,6 +839,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     luajit.gc_steps_sweepstring(
@@ -765,6 +848,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     luajit.gc_steps_finalize(
@@ -773,6 +857,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     luajit.gc_steps_sweep(
@@ -781,6 +866,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     luajit.gc_steps_propagate(
@@ -789,6 +875,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     luajit.gc_steps_pause(
@@ -797,6 +884,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     luajit.strings_allocated(
@@ -805,6 +893,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     luajit.tables_allocated(
@@ -813,6 +902,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     luajit.cdata_allocated(
@@ -821,6 +911,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     luajit.userdata_allocated(
@@ -829,6 +920,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     luajit.gc_memory_current(
@@ -837,6 +929,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     luajit.gc_memory_freed(
@@ -845,6 +938,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     luajit.gc_memory_allocated(
@@ -853,10 +947,11 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
   ],
 
-  operations(datasource_type, datasource, policy=null, measurement=null, job=null):: [
+  operations(datasource_type, datasource, policy=null, measurement=null, job=null, alias=null):: [
     operations.row,
 
     operations.space_select_rps(
@@ -865,6 +960,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     operations.space_insert_rps(
@@ -873,6 +969,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     operations.space_replace_rps(
@@ -881,6 +978,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     operations.space_upsert_rps(
@@ -889,6 +987,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     operations.space_update_rps(
@@ -897,6 +996,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     operations.space_delete_rps(
@@ -905,6 +1005,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     operations.call_rps(
@@ -913,6 +1014,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     operations.eval_rps(
@@ -921,6 +1023,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     operations.error_rps(
@@ -929,6 +1032,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     operations.auth_rps(
@@ -937,6 +1041,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     operations.SQL_prepare_rps(
@@ -945,6 +1050,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     operations.SQL_execute_rps(
@@ -953,10 +1059,11 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
   ],
 
-  crud(datasource_type, datasource, policy=null, measurement=null, job=null):: [
+  crud(datasource_type, datasource, policy=null, measurement=null, job=null, alias=null):: [
     crud.row,
 
     crud.select_success_rps(
@@ -965,6 +1072,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.select_success_latency(
@@ -973,6 +1081,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.select_error_rps(
@@ -981,6 +1090,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.select_error_latency(
@@ -989,6 +1099,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.tuples_fetched_panel(
@@ -997,6 +1108,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.tuples_lookup_panel(
@@ -1005,6 +1117,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.map_reduces(
@@ -1013,6 +1126,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.insert_success_rps(
@@ -1021,6 +1135,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.insert_success_latency(
@@ -1029,6 +1144,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.insert_error_rps(
@@ -1037,6 +1153,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.insert_error_latency(
@@ -1045,6 +1162,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.insert_many_success_rps(
@@ -1053,6 +1171,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.insert_many_success_latency(
@@ -1061,6 +1180,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.insert_many_error_rps(
@@ -1069,6 +1189,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.insert_many_error_latency(
@@ -1077,6 +1198,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.replace_success_rps(
@@ -1085,6 +1207,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.replace_success_latency(
@@ -1093,6 +1216,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.replace_error_rps(
@@ -1101,6 +1225,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.replace_error_latency(
@@ -1109,6 +1234,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.replace_many_success_rps(
@@ -1117,6 +1243,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.replace_many_success_latency(
@@ -1125,6 +1252,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.replace_many_error_rps(
@@ -1133,6 +1261,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.replace_many_error_latency(
@@ -1141,6 +1270,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.upsert_success_rps(
@@ -1149,6 +1279,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.upsert_success_latency(
@@ -1157,6 +1288,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.upsert_error_rps(
@@ -1165,6 +1297,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.upsert_error_latency(
@@ -1173,6 +1306,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.upsert_many_success_rps(
@@ -1181,6 +1315,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.upsert_many_success_latency(
@@ -1189,6 +1324,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.upsert_many_error_rps(
@@ -1197,6 +1333,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.upsert_many_error_latency(
@@ -1205,6 +1342,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.update_success_rps(
@@ -1213,6 +1351,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.update_success_latency(
@@ -1221,6 +1360,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.update_error_rps(
@@ -1229,6 +1369,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.update_error_latency(
@@ -1237,6 +1378,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.delete_success_rps(
@@ -1245,6 +1387,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.delete_success_latency(
@@ -1253,6 +1396,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.delete_error_rps(
@@ -1261,6 +1405,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.delete_error_latency(
@@ -1269,6 +1414,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.count_success_rps(
@@ -1277,6 +1423,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.count_success_latency(
@@ -1285,6 +1432,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.count_error_rps(
@@ -1293,6 +1441,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.count_error_latency(
@@ -1301,6 +1450,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.get_success_rps(
@@ -1309,6 +1459,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.get_success_latency(
@@ -1317,6 +1468,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.get_error_rps(
@@ -1325,6 +1477,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.get_error_latency(
@@ -1333,6 +1486,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.borders_success_rps(
@@ -1341,6 +1495,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.borders_success_latency(
@@ -1349,6 +1504,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.borders_error_rps(
@@ -1357,6 +1513,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.borders_error_latency(
@@ -1365,6 +1522,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.len_success_rps(
@@ -1373,6 +1531,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.len_success_latency(
@@ -1381,6 +1540,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.len_error_rps(
@@ -1389,6 +1549,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.len_error_latency(
@@ -1397,6 +1558,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.truncate_success_rps(
@@ -1405,6 +1567,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.truncate_success_latency(
@@ -1413,6 +1576,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.truncate_error_rps(
@@ -1421,6 +1585,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     crud.truncate_error_latency(
@@ -1429,10 +1594,11 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
   ],
 
-  expirationd(datasource_type, datasource, policy=null, measurement=null, job=null):: [
+  expirationd(datasource_type, datasource, policy=null, measurement=null, job=null, alias=null):: [
     expirationd.row,
 
     expirationd.tuples_checked(
@@ -1441,6 +1607,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     expirationd.tuples_expired(
@@ -1449,6 +1616,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     expirationd.restarts(
@@ -1457,6 +1625,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     expirationd.operation_time(
@@ -1465,10 +1634,11 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
   ],
 
-  tdg_kafka_common(datasource_type, datasource, policy=null, measurement=null, job=null):: [
+  tdg_kafka_common(datasource_type, datasource, policy=null, measurement=null, job=null, alias=null):: [
     tdg_kafka_common.row,
 
     tdg_kafka_common.queue_operations(
@@ -1477,6 +1647,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_common.message_current(
@@ -1485,6 +1656,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_common.message_size(
@@ -1493,6 +1665,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_common.requests(
@@ -1501,6 +1674,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_common.request_bytes(
@@ -1509,6 +1683,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_common.responses(
@@ -1517,6 +1692,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_common.response_bytes(
@@ -1525,6 +1701,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_common.messages_sent(
@@ -1533,6 +1710,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_common.message_bytes_sent(
@@ -1541,6 +1719,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_common.messages_received(
@@ -1549,6 +1728,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_common.message_bytes_received(
@@ -1557,10 +1737,11 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
   ],
 
-  tdg_kafka_brokers(datasource_type, datasource, policy=null, measurement=null, job=null):: [
+  tdg_kafka_brokers(datasource_type, datasource, policy=null, measurement=null, job=null, alias=null):: [
     tdg_kafka_brokers.row,
 
     tdg_kafka_brokers.stateage(
@@ -1569,6 +1750,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_brokers.connects(
@@ -1577,6 +1759,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_brokers.disconnects(
@@ -1585,6 +1768,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_brokers.poll_wakeups(
@@ -1593,6 +1777,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_brokers.outbuf(
@@ -1601,6 +1786,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_brokers.outbuf_msg(
@@ -1609,6 +1795,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_brokers.waitresp(
@@ -1617,6 +1804,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_brokers.waitresp_msg(
@@ -1625,6 +1813,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_brokers.requests(
@@ -1633,6 +1822,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_brokers.request_bytes(
@@ -1641,6 +1831,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_brokers.request_errors(
@@ -1649,6 +1840,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_brokers.request_retries(
@@ -1657,6 +1849,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_brokers.request_idle(
@@ -1665,6 +1858,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_brokers.request_timeout(
@@ -1673,6 +1867,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_brokers.responses(
@@ -1681,6 +1876,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_brokers.response_bytes(
@@ -1689,6 +1885,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_brokers.response_errors(
@@ -1697,6 +1894,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_brokers.response_corriderrs(
@@ -1705,6 +1903,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_brokers.response_idle(
@@ -1713,6 +1912,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_brokers.response_partial(
@@ -1721,6 +1921,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_brokers.requests_by_type(
@@ -1729,6 +1930,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_brokers.internal_producer_latency(
@@ -1737,6 +1939,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_brokers.internal_request_latency(
@@ -1745,6 +1948,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_brokers.broker_latency(
@@ -1753,6 +1957,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_brokers.broker_throttle(
@@ -1761,10 +1966,11 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
   ],
 
-  tdg_kafka_topics(datasource_type, datasource, policy=null, measurement=null, job=null):: [
+  tdg_kafka_topics(datasource_type, datasource, policy=null, measurement=null, job=null, alias=null):: [
     tdg_kafka_topics.row,
 
     tdg_kafka_topics.age(
@@ -1773,6 +1979,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_topics.metadata_age(
@@ -1781,6 +1988,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_topics.topic_batchsize(
@@ -1789,6 +1997,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_topics.topic_batchcnt(
@@ -1797,6 +2006,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_topics.partition_msgq(
@@ -1805,6 +2015,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_topics.partition_xmit_msgq(
@@ -1813,6 +2024,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_topics.partition_fetchq_msgq(
@@ -1821,6 +2033,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_topics.partition_msgq_bytes(
@@ -1829,6 +2042,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_topics.partition_xmit_msgq_bytes(
@@ -1837,6 +2051,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_topics.partition_fetchq_msgq_bytes(
@@ -1845,6 +2060,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_topics.partition_messages_sent(
@@ -1853,6 +2069,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_topics.partition_message_bytes_sent(
@@ -1861,6 +2078,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_topics.partition_messages_consumed(
@@ -1869,6 +2087,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_topics.partition_message_bytes_consumed(
@@ -1877,6 +2096,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_topics.partition_messages_dropped(
@@ -1885,6 +2105,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_topics.partition_messages_in_flight(
@@ -1893,10 +2114,11 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
   ],
 
-  tdg_kafka_consumer(datasource_type, datasource, policy=null, measurement=null, job=null):: [
+  tdg_kafka_consumer(datasource_type, datasource, policy=null, measurement=null, job=null, alias=null):: [
     tdg_kafka_consumer.row,
 
     tdg_kafka_consumer.stateage(
@@ -1905,6 +2127,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_consumer.rebalance_age(
@@ -1913,6 +2136,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_consumer.rebalances(
@@ -1921,6 +2145,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_consumer.assignment_size(
@@ -1929,10 +2154,11 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
   ],
 
-  tdg_kafka_producer(datasource_type, datasource, policy=null, measurement=null, job=null):: [
+  tdg_kafka_producer(datasource_type, datasource, policy=null, measurement=null, job=null, alias=null):: [
     tdg_kafka_producer.row,
 
     tdg_kafka_producer.idemp_stateage(
@@ -1941,6 +2167,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_kafka_producer.txn_stateage(
@@ -1949,10 +2176,11 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
   ],
 
-  tdg_expirationd(datasource_type, datasource, policy=null, measurement=null, job=null):: [
+  tdg_expirationd(datasource_type, datasource, policy=null, measurement=null, job=null, alias=null):: [
     tdg_expirationd.row,
 
     tdg_expirationd.tuples_checked(
@@ -1961,6 +2189,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_expirationd.tuples_expired(
@@ -1969,6 +2198,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_expirationd.restarts(
@@ -1977,6 +2207,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_expirationd.operation_time(
@@ -1985,10 +2216,11 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
   ],
 
-  tdg_tuples(datasource_type, datasource, policy=null, measurement=null, job=null):: [
+  tdg_tuples(datasource_type, datasource, policy=null, measurement=null, job=null, alias=null):: [
     tdg_tuples.row,
 
     tdg_tuples.tuples_scanned_average(
@@ -1997,6 +2229,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_tuples.tuples_returned_average(
@@ -2005,6 +2238,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_tuples.tuples_scanned_max(
@@ -2013,6 +2247,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_tuples.tuples_returned_max(
@@ -2021,10 +2256,11 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
   ],
 
-  tdg_file_connectors(datasource_type, datasource, policy=null, measurement=null, job=null):: [
+  tdg_file_connectors(datasource_type, datasource, policy=null, measurement=null, job=null, alias=null):: [
     tdg_file_connectors.row,
 
     tdg_file_connectors.files_processed(
@@ -2033,6 +2269,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_file_connectors.objects_processed(
@@ -2041,6 +2278,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_file_connectors.files_process_errors(
@@ -2049,6 +2287,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_file_connectors.file_size(
@@ -2057,6 +2296,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_file_connectors.current_bytes_processed(
@@ -2065,6 +2305,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_file_connectors.current_objects_processed(
@@ -2073,10 +2314,11 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
   ],
 
-  tdg_graphql(datasource_type, datasource, policy=null, measurement=null, job=null):: [
+  tdg_graphql(datasource_type, datasource, policy=null, measurement=null, job=null, alias=null):: [
     tdg_graphql.row,
 
     tdg_graphql.query_success_rps(
@@ -2085,6 +2327,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_graphql.query_success_latency(
@@ -2093,6 +2336,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_graphql.query_error_rps(
@@ -2101,6 +2345,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_graphql.mutation_success_rps(
@@ -2109,6 +2354,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_graphql.mutation_success_latency(
@@ -2117,6 +2363,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_graphql.mutation_error_rps(
@@ -2125,10 +2372,11 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
   ],
 
-  tdg_iproto(datasource_type, datasource, policy=null, measurement=null, job=null):: [
+  tdg_iproto(datasource_type, datasource, policy=null, measurement=null, job=null, alias=null):: [
     tdg_iproto.row,
 
     tdg_iproto.put_rps(
@@ -2137,6 +2385,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_iproto.put_latency(
@@ -2145,6 +2394,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_iproto.put_batch_rps(
@@ -2153,6 +2403,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_iproto.put_batch_latency(
@@ -2161,6 +2412,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_iproto.find_rps(
@@ -2169,6 +2421,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_iproto.find_latency(
@@ -2177,6 +2430,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_iproto.update_rps(
@@ -2185,6 +2439,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_iproto.update_latency(
@@ -2193,6 +2448,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_iproto.get_rps(
@@ -2201,6 +2457,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_iproto.get_latency(
@@ -2209,6 +2466,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_iproto.delete_rps(
@@ -2217,6 +2475,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_iproto.delete_latency(
@@ -2225,6 +2484,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_iproto.count_rps(
@@ -2233,6 +2493,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_iproto.count_latency(
@@ -2241,6 +2502,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_iproto.map_reduce_rps(
@@ -2249,6 +2511,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_iproto.map_reduce_latency(
@@ -2257,6 +2520,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_iproto.call_on_storage_rps(
@@ -2265,6 +2529,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_iproto.call_on_storage_latency(
@@ -2273,10 +2538,11 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
   ],
 
-  tdg_rest_api(datasource_type, datasource, policy=null, measurement=null, job=null):: [
+  tdg_rest_api(datasource_type, datasource, policy=null, measurement=null, job=null, alias=null):: [
     tdg_rest_api.row,
 
     tdg_rest_api.read_success_rps(
@@ -2285,6 +2551,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_rest_api.read_error_4xx_rps(
@@ -2293,6 +2560,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_rest_api.read_error_5xx_rps(
@@ -2301,6 +2569,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_rest_api.read_success_latency(
@@ -2309,6 +2578,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_rest_api.read_error_4xx_latency(
@@ -2317,6 +2587,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_rest_api.read_error_5xx_latency(
@@ -2325,6 +2596,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_rest_api.write_success_rps(
@@ -2333,6 +2605,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_rest_api.write_error_4xx_rps(
@@ -2341,6 +2614,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_rest_api.write_error_5xx_rps(
@@ -2349,6 +2623,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_rest_api.write_success_latency(
@@ -2357,6 +2632,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_rest_api.write_error_4xx_latency(
@@ -2365,6 +2641,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_rest_api.write_error_5xx_latency(
@@ -2373,10 +2650,11 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
   ],
 
-  tdg_tasks(datasource_type, datasource, policy=null, measurement=null, job=null):: [
+  tdg_tasks(datasource_type, datasource, policy=null, measurement=null, job=null, alias=null):: [
     tdg_tasks.row,
 
     tdg_tasks.jobs_started(
@@ -2385,6 +2663,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_tasks.jobs_failed(
@@ -2393,6 +2672,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_tasks.jobs_succeeded(
@@ -2401,6 +2681,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_tasks.jobs_running(
@@ -2409,6 +2690,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_tasks.jobs_time(
@@ -2417,6 +2699,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_tasks.tasks_started(
@@ -2425,6 +2708,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_tasks.tasks_failed(
@@ -2433,6 +2717,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_tasks.tasks_succeeded(
@@ -2441,6 +2726,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_tasks.tasks_stopped(
@@ -2449,6 +2735,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_tasks.tasks_running(
@@ -2457,6 +2744,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_tasks.tasks_time(
@@ -2465,6 +2753,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_tasks.system_tasks_started(
@@ -2473,6 +2762,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_tasks.system_tasks_failed(
@@ -2481,6 +2771,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_tasks.system_tasks_succeeded(
@@ -2489,6 +2780,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_tasks.system_tasks_running(
@@ -2497,6 +2789,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
 
     tdg_tasks.system_tasks_time(
@@ -2505,6 +2798,7 @@ local tdg_tuples = import 'dashboard/panels/tdg/tuples.libsonnet';
       policy=policy,
       measurement=measurement,
       job=job,
+      alias=alias,
     ),
   ],
 }

--- a/dashboard/variable.libsonnet
+++ b/dashboard/variable.libsonnet
@@ -9,9 +9,11 @@
   },
   prometheus: {
     job: '$job',
+    alias: '$alias',
   },
   influxdb: {
     policy: '${INFLUXDB_POLICY}',
     measurement: '${INFLUXDB_MEASUREMENT}',
+    alias: '/^$alias$/',
   },
 }

--- a/tests/InfluxDB/dashboard_compiled.json
+++ b/tests/InfluxDB/dashboard_compiled.json
@@ -169,6 +169,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_level",
                            "operator": "=",
                            "value": "warning"
@@ -303,6 +309,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_cartridge_issues"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -506,6 +518,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_replication_status"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -656,6 +674,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_read_only"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -757,6 +781,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_replication_lag"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -891,6 +921,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_clock_delta"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -1067,6 +1103,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_status",
                            "operator": "=~",
                            "value": "/^2\\d{2}$/"
@@ -1225,6 +1267,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "http_server_request_latency_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -1389,6 +1437,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_status",
                            "operator": "=~",
                            "value": "/^5\\d{2}$/"
@@ -1541,6 +1595,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "http_server_request_latency"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -1705,6 +1765,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_quantile",
                            "operator": "=",
                            "value": "0.99"
@@ -1863,6 +1929,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "http_server_request_latency"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -2026,6 +2098,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_info_memory_net"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -2163,6 +2241,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_received_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -2300,6 +2384,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_sent_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -2437,6 +2527,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -2568,6 +2664,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -2705,6 +2807,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_in_progress_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -2836,6 +2944,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_in_progress_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -2973,6 +3087,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_in_stream_queue_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -3104,6 +3224,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_in_stream_queue_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -3241,6 +3367,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_connections_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -3372,6 +3504,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_connections_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -3537,6 +3675,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_quota_used_ratio"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -3668,6 +3812,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_arena_used_ratio"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -3799,6 +3949,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_items_used_ratio"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -3930,6 +4086,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_quota_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -4061,6 +4223,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_arena_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -4192,6 +4360,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_items_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -4323,6 +4497,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_quota_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -4454,6 +4634,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_arena_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -4585,6 +4771,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_items_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -4745,6 +4937,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_engine",
                            "operator": "=",
                            "value": "memtx"
@@ -4888,6 +5086,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_engine",
                            "operator": "=",
                            "value": "vinyl"
@@ -5028,6 +5232,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_space_bsize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -5177,6 +5387,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_space_index_bsize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -5314,6 +5530,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_space_total_bsize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -5471,6 +5693,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_disk_data_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -5602,6 +5830,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_disk_index_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -5733,6 +5967,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_memory_tuple_cache"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -5864,6 +6104,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_memory_page_index"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -5995,6 +6241,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_memory_bloom_filter"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -6126,6 +6378,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_regulator_dump_bandwidth"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -6257,6 +6515,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_regulator_write_rate"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -6388,6 +6652,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_regulator_rate_limit"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -6519,6 +6789,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_memory_level0"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -6650,6 +6926,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_regulator_dump_watermark"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -6781,6 +7063,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_regulator_blocked_writers"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -6918,6 +7206,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_tx_commit"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -7055,6 +7349,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_tx_rollback"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -7192,6 +7492,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_tx_conflict"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -7323,6 +7629,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_tx_read_views"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -7454,6 +7766,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_scheduler_tasks"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -7600,6 +7918,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_status",
                            "operator": "=",
                            "value": "failed"
@@ -7740,6 +8064,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_scheduler_dump_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -7877,6 +8207,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_scheduler_dump_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -8034,6 +8370,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_cpu_user_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -8171,6 +8513,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_cpu_system_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -8322,6 +8670,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_info_memory_lua"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -8453,6 +8807,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_runtime_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -8584,6 +8944,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_info_memory_tx"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -8715,6 +9081,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_fiber_csw"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -8846,6 +9218,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_ev_loop_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -8977,6 +9355,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_fiber_amount"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -9108,6 +9492,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_fiber_memused"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -9239,6 +9629,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_fiber_memalloc"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -9396,6 +9792,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_jit_snap_restore"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -9533,6 +9935,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_jit_trace_num"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -9670,6 +10078,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_jit_trace_abort"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -9801,6 +10215,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_jit_mcode_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -9938,6 +10358,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_strhash_hit"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -10075,6 +10501,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_strhash_miss"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -10212,6 +10644,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_atomic"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -10349,6 +10787,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_sweepstring"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -10486,6 +10930,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_finalize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -10623,6 +11073,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_sweep"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -10760,6 +11216,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_propagate"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -10897,6 +11359,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_pause"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -11028,6 +11496,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_strnum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -11159,6 +11633,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_tabnum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -11290,6 +11770,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_cdatanum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -11421,6 +11907,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_udatanum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -11552,6 +12044,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_memory"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -11689,6 +12187,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_freed"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -11826,6 +12330,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_allocated"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -11986,6 +12496,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "select"
@@ -12126,6 +12642,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -12272,6 +12794,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "replace"
@@ -12412,6 +12940,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -12558,6 +13092,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "update"
@@ -12698,6 +13238,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -12844,6 +13390,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "call"
@@ -12984,6 +13536,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -13130,6 +13688,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "error"
@@ -13270,6 +13834,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -13416,6 +13986,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "prepare"
@@ -13556,6 +14132,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -13728,6 +14310,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "select"
@@ -13874,6 +14462,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -14038,6 +14632,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "select"
@@ -14187,6 +14787,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "select"
@@ -14305,7 +14911,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tnt_crud_tuples_fetched\") / (mean(\"tnt_crud_stats_count_ok\") + mean(\"tnt_crud_stats_count_error\"))\nas \"tnt_crud_tuples_per_request\" FROM\n(SELECT \"value\" as \"tnt_crud_tuples_fetched\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tnt_crud_tuples_fetched' AND \"label_pairs_operation\" = 'select') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_error\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_operation\" = 'select'\nAND \"label_pairs_status\" = 'error') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_ok\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_operation\" = 'select'\nAND \"label_pairs_status\" = 'ok') AND $timeFilter)\nGROUP BY time($__interval * 2), \"label_pairs_alias\", \"label_pairs_name\" fill(0)\n",
+                     "query": "SELECT mean(\"tnt_crud_tuples_fetched\") / (mean(\"tnt_crud_stats_count_ok\") + mean(\"tnt_crud_stats_count_error\"))\nas \"tnt_crud_tuples_per_request\" FROM\n(SELECT \"value\" as \"tnt_crud_tuples_fetched\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tnt_crud_tuples_fetched' AND \"label_pairs_alias\" =~ /^$alias$/\nAND \"label_pairs_operation\" = 'select') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_error\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_alias\" =~ /^$alias$/\nAND \"label_pairs_operation\" = 'select' AND \"label_pairs_status\" = 'error') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_ok\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_alias\" =~ /^$alias$/\nAND \"label_pairs_operation\" = 'select' AND \"label_pairs_status\" = 'ok') AND $timeFilter)\nGROUP BY time($__interval * 2), \"label_pairs_alias\", \"label_pairs_name\" fill(0)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -14412,7 +15018,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tnt_crud_tuples_lookup\") / (mean(\"tnt_crud_stats_count_ok\") + mean(\"tnt_crud_stats_count_error\"))\nas \"tnt_crud_tuples_per_request\" FROM\n(SELECT \"value\" as \"tnt_crud_tuples_lookup\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tnt_crud_tuples_lookup' AND \"label_pairs_operation\" = 'select') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_error\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_operation\" = 'select'\nAND \"label_pairs_status\" = 'error') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_ok\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_operation\" = 'select'\nAND \"label_pairs_status\" = 'ok') AND $timeFilter)\nGROUP BY time($__interval * 2), \"label_pairs_alias\", \"label_pairs_name\" fill(0)\n",
+                     "query": "SELECT mean(\"tnt_crud_tuples_lookup\") / (mean(\"tnt_crud_stats_count_ok\") + mean(\"tnt_crud_stats_count_error\"))\nas \"tnt_crud_tuples_per_request\" FROM\n(SELECT \"value\" as \"tnt_crud_tuples_lookup\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tnt_crud_tuples_lookup' AND \"label_pairs_alias\" =~ /^$alias$/\nAND \"label_pairs_operation\" = 'select') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_error\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_alias\" =~ /^$alias$/\nAND \"label_pairs_operation\" = 'select' AND \"label_pairs_status\" = 'error') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_ok\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_alias\" =~ /^$alias$/\nAND \"label_pairs_operation\" = 'select' AND \"label_pairs_status\" = 'ok') AND $timeFilter)\nGROUP BY time($__interval * 2), \"label_pairs_alias\", \"label_pairs_name\" fill(0)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -14559,6 +15165,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_map_reduces"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -14711,6 +15323,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "insert"
@@ -14857,6 +15475,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -15021,6 +15645,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "insert"
@@ -15167,6 +15797,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -15331,6 +15967,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "insert_many"
@@ -15477,6 +16119,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -15641,6 +16289,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "insert_many"
@@ -15787,6 +16441,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -15951,6 +16611,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "replace"
@@ -16097,6 +16763,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -16261,6 +16933,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "replace"
@@ -16407,6 +17085,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -16571,6 +17255,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "replace_many"
@@ -16717,6 +17407,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -16881,6 +17577,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "replace_many"
@@ -17027,6 +17729,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -17191,6 +17899,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "upsert"
@@ -17337,6 +18051,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -17501,6 +18221,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "upsert"
@@ -17647,6 +18373,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -17811,6 +18543,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "upsert_many"
@@ -17957,6 +18695,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -18121,6 +18865,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "upsert_many"
@@ -18267,6 +19017,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -18431,6 +19187,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "update"
@@ -18577,6 +19339,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -18741,6 +19509,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "update"
@@ -18887,6 +19661,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -19051,6 +19831,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "delete"
@@ -19197,6 +19983,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -19361,6 +20153,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "delete"
@@ -19507,6 +20305,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -19671,6 +20475,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "count"
@@ -19817,6 +20627,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -19981,6 +20797,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "count"
@@ -20127,6 +20949,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -20291,6 +21119,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "get"
@@ -20437,6 +21271,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -20601,6 +21441,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "get"
@@ -20747,6 +21593,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -20911,6 +21763,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "borders"
@@ -21057,6 +21915,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -21221,6 +22085,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "borders"
@@ -21367,6 +22237,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -21531,6 +22407,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "len"
@@ -21677,6 +22559,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -21841,6 +22729,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "len"
@@ -21987,6 +22881,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -22151,6 +23051,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "truncate"
@@ -22297,6 +23203,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -22461,6 +23373,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "truncate"
@@ -22607,6 +23525,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -22788,6 +23712,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "expirationd_checked_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -22931,6 +23861,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "expirationd_expired_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -23068,6 +24004,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "expirationd_restarts"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -23205,6 +24147,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "expirationd_working_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -23265,7 +24213,31 @@
       "tarantool"
    ],
    "templating": {
-      "list": [ ]
+      "list": [
+         {
+            "allValue": null,
+            "current": {
+               "text": "all",
+               "value": "$__all"
+            },
+            "datasource": "${DS_INFLUXDB}",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Instances",
+            "multi": true,
+            "name": "alias",
+            "options": [ ],
+            "query": "SHOW TAG VALUES FROM \"${INFLUXDB_MEASUREMENT}\" WITH KEY=\"label_pairs_alias\"",
+            "refresh": 2,
+            "regex": "",
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         }
+      ]
    },
    "time": {
       "from": "now-3h",

--- a/tests/InfluxDB/dashboard_static_compiled.json
+++ b/tests/InfluxDB/dashboard_static_compiled.json
@@ -146,6 +146,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_level",
                            "operator": "=",
                            "value": "warning"
@@ -280,6 +286,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_cartridge_issues"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -483,6 +495,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_replication_status"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -633,6 +651,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_read_only"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -734,6 +758,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_replication_lag"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -868,6 +898,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_clock_delta"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -1044,6 +1080,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_status",
                            "operator": "=~",
                            "value": "/^2\\d{2}$/"
@@ -1202,6 +1244,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "http_server_request_latency_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -1366,6 +1414,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_status",
                            "operator": "=~",
                            "value": "/^5\\d{2}$/"
@@ -1518,6 +1572,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "http_server_request_latency"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -1682,6 +1742,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_quantile",
                            "operator": "=",
                            "value": "0.99"
@@ -1840,6 +1906,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "http_server_request_latency"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -2003,6 +2075,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_info_memory_net"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -2140,6 +2218,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_received_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -2277,6 +2361,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_sent_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -2414,6 +2504,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -2545,6 +2641,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -2682,6 +2784,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_in_progress_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -2813,6 +2921,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_in_progress_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -2950,6 +3064,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_in_stream_queue_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -3081,6 +3201,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_in_stream_queue_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -3218,6 +3344,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_connections_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -3349,6 +3481,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_connections_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -3514,6 +3652,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_quota_used_ratio"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -3645,6 +3789,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_arena_used_ratio"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -3776,6 +3926,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_items_used_ratio"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -3907,6 +4063,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_quota_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -4038,6 +4200,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_arena_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -4169,6 +4337,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_items_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -4300,6 +4474,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_quota_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -4431,6 +4611,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_arena_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -4562,6 +4748,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_items_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -4722,6 +4914,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_engine",
                            "operator": "=",
                            "value": "memtx"
@@ -4865,6 +5063,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_engine",
                            "operator": "=",
                            "value": "vinyl"
@@ -5005,6 +5209,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_space_bsize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -5154,6 +5364,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_space_index_bsize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -5291,6 +5507,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_space_total_bsize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -5448,6 +5670,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_disk_data_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -5579,6 +5807,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_disk_index_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -5710,6 +5944,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_memory_tuple_cache"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -5841,6 +6081,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_memory_page_index"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -5972,6 +6218,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_memory_bloom_filter"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -6103,6 +6355,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_regulator_dump_bandwidth"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -6234,6 +6492,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_regulator_write_rate"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -6365,6 +6629,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_regulator_rate_limit"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -6496,6 +6766,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_memory_level0"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -6627,6 +6903,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_regulator_dump_watermark"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -6758,6 +7040,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_regulator_blocked_writers"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -6895,6 +7183,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_tx_commit"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -7032,6 +7326,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_tx_rollback"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -7169,6 +7469,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_tx_conflict"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -7300,6 +7606,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_tx_read_views"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -7431,6 +7743,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_scheduler_tasks"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -7577,6 +7895,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_status",
                            "operator": "=",
                            "value": "failed"
@@ -7717,6 +8041,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_scheduler_dump_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -7854,6 +8184,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_scheduler_dump_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -8011,6 +8347,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_cpu_user_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -8148,6 +8490,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_cpu_system_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -8299,6 +8647,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_info_memory_lua"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -8430,6 +8784,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_runtime_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -8561,6 +8921,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_info_memory_tx"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -8692,6 +9058,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_fiber_csw"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -8823,6 +9195,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_ev_loop_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -8954,6 +9332,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_fiber_amount"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -9085,6 +9469,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_fiber_memused"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -9216,6 +9606,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_fiber_memalloc"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -9373,6 +9769,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_jit_snap_restore"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -9510,6 +9912,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_jit_trace_num"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -9647,6 +10055,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_jit_trace_abort"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -9778,6 +10192,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_jit_mcode_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -9915,6 +10335,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_strhash_hit"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -10052,6 +10478,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_strhash_miss"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -10189,6 +10621,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_atomic"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -10326,6 +10764,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_sweepstring"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -10463,6 +10907,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_finalize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -10600,6 +11050,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_sweep"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -10737,6 +11193,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_propagate"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -10874,6 +11336,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_pause"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -11005,6 +11473,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_strnum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -11136,6 +11610,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_tabnum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -11267,6 +11747,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_cdatanum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -11398,6 +11884,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_udatanum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -11529,6 +12021,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_memory"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -11666,6 +12164,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_freed"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -11803,6 +12307,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_allocated"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -11963,6 +12473,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "select"
@@ -12103,6 +12619,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -12249,6 +12771,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "replace"
@@ -12389,6 +12917,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -12535,6 +13069,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "update"
@@ -12675,6 +13215,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -12821,6 +13367,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "call"
@@ -12961,6 +13513,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -13107,6 +13665,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "error"
@@ -13247,6 +13811,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -13393,6 +13963,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "prepare"
@@ -13533,6 +14109,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -13705,6 +14287,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "select"
@@ -13851,6 +14439,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -14015,6 +14609,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "select"
@@ -14164,6 +14764,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "select"
@@ -14282,7 +14888,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tnt_crud_tuples_fetched\") / (mean(\"tnt_crud_stats_count_ok\") + mean(\"tnt_crud_stats_count_error\"))\nas \"tnt_crud_tuples_per_request\" FROM\n(SELECT \"value\" as \"tnt_crud_tuples_fetched\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tnt_crud_tuples_fetched' AND \"label_pairs_operation\" = 'select') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_error\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_operation\" = 'select'\nAND \"label_pairs_status\" = 'error') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_ok\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_operation\" = 'select'\nAND \"label_pairs_status\" = 'ok') AND $timeFilter)\nGROUP BY time($__interval * 2), \"label_pairs_alias\", \"label_pairs_name\" fill(0)\n",
+                     "query": "SELECT mean(\"tnt_crud_tuples_fetched\") / (mean(\"tnt_crud_stats_count_ok\") + mean(\"tnt_crud_stats_count_error\"))\nas \"tnt_crud_tuples_per_request\" FROM\n(SELECT \"value\" as \"tnt_crud_tuples_fetched\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tnt_crud_tuples_fetched' AND \"label_pairs_alias\" =~ /^.*$/\nAND \"label_pairs_operation\" = 'select') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_error\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_alias\" =~ /^.*$/\nAND \"label_pairs_operation\" = 'select' AND \"label_pairs_status\" = 'error') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_ok\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_alias\" =~ /^.*$/\nAND \"label_pairs_operation\" = 'select' AND \"label_pairs_status\" = 'ok') AND $timeFilter)\nGROUP BY time($__interval * 2), \"label_pairs_alias\", \"label_pairs_name\" fill(0)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -14389,7 +14995,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tnt_crud_tuples_lookup\") / (mean(\"tnt_crud_stats_count_ok\") + mean(\"tnt_crud_stats_count_error\"))\nas \"tnt_crud_tuples_per_request\" FROM\n(SELECT \"value\" as \"tnt_crud_tuples_lookup\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tnt_crud_tuples_lookup' AND \"label_pairs_operation\" = 'select') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_error\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_operation\" = 'select'\nAND \"label_pairs_status\" = 'error') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_ok\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_operation\" = 'select'\nAND \"label_pairs_status\" = 'ok') AND $timeFilter)\nGROUP BY time($__interval * 2), \"label_pairs_alias\", \"label_pairs_name\" fill(0)\n",
+                     "query": "SELECT mean(\"tnt_crud_tuples_lookup\") / (mean(\"tnt_crud_stats_count_ok\") + mean(\"tnt_crud_stats_count_error\"))\nas \"tnt_crud_tuples_per_request\" FROM\n(SELECT \"value\" as \"tnt_crud_tuples_lookup\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tnt_crud_tuples_lookup' AND \"label_pairs_alias\" =~ /^.*$/\nAND \"label_pairs_operation\" = 'select') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_error\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_alias\" =~ /^.*$/\nAND \"label_pairs_operation\" = 'select' AND \"label_pairs_status\" = 'error') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_ok\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_alias\" =~ /^.*$/\nAND \"label_pairs_operation\" = 'select' AND \"label_pairs_status\" = 'ok') AND $timeFilter)\nGROUP BY time($__interval * 2), \"label_pairs_alias\", \"label_pairs_name\" fill(0)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -14536,6 +15142,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_map_reduces"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -14688,6 +15300,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "insert"
@@ -14834,6 +15452,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -14998,6 +15622,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "insert"
@@ -15144,6 +15774,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -15308,6 +15944,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "insert_many"
@@ -15454,6 +16096,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -15618,6 +16266,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "insert_many"
@@ -15764,6 +16418,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -15928,6 +16588,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "replace"
@@ -16074,6 +16740,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -16238,6 +16910,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "replace"
@@ -16384,6 +17062,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -16548,6 +17232,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "replace_many"
@@ -16694,6 +17384,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -16858,6 +17554,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "replace_many"
@@ -17004,6 +17706,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -17168,6 +17876,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "upsert"
@@ -17314,6 +18028,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -17478,6 +18198,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "upsert"
@@ -17624,6 +18350,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -17788,6 +18520,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "upsert_many"
@@ -17934,6 +18672,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -18098,6 +18842,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "upsert_many"
@@ -18244,6 +18994,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -18408,6 +19164,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "update"
@@ -18554,6 +19316,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -18718,6 +19486,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "update"
@@ -18864,6 +19638,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -19028,6 +19808,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "delete"
@@ -19174,6 +19960,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -19338,6 +20130,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "delete"
@@ -19484,6 +20282,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -19648,6 +20452,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "count"
@@ -19794,6 +20604,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -19958,6 +20774,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "count"
@@ -20104,6 +20926,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -20268,6 +21096,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "get"
@@ -20414,6 +21248,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -20578,6 +21418,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "get"
@@ -20724,6 +21570,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -20888,6 +21740,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "borders"
@@ -21034,6 +21892,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -21198,6 +22062,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "borders"
@@ -21344,6 +22214,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -21508,6 +22384,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "len"
@@ -21654,6 +22536,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -21818,6 +22706,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "len"
@@ -21964,6 +22858,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -22128,6 +23028,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "truncate"
@@ -22274,6 +23180,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -22438,6 +23350,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "truncate"
@@ -22584,6 +23502,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -22765,6 +23689,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "expirationd_checked_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -22908,6 +23838,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "expirationd_expired_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -23045,6 +23981,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "expirationd_restarts"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -23182,6 +24124,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "expirationd_working_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }

--- a/tests/InfluxDB/dashboard_static_with_instance_variable.sh
+++ b/tests/InfluxDB/dashboard_static_with_instance_variable.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+make DATASOURCE=influxdb \
+     POLICY=autogen \
+     MEASUREMENT=tarantool_http \
+     WITH_INSTANCE_VARIABLE=TRUE \
+     build-static-influxdb

--- a/tests/InfluxDB/dashboard_static_with_instance_variable_compiled.json
+++ b/tests/InfluxDB/dashboard_static_with_instance_variable_compiled.json
@@ -1,21 +1,5 @@
 {
-   "__inputs": [
-      {
-         "description": "Prometheus Tarantool metrics bank",
-         "label": "Prometheus",
-         "name": "DS_PROMETHEUS",
-         "pluginId": "prometheus",
-         "pluginName": "Prometheus",
-         "type": "datasource"
-      },
-      {
-         "description": "Prometheus Tarantool metrics job",
-         "label": "Job",
-         "name": "PROMETHEUS_JOB",
-         "type": "constant",
-         "value": "tarantool"
-      }
-   ],
+   "__inputs": [ ],
    "__requires": [
       {
          "id": "grafana",
@@ -42,20 +26,8 @@
          "version": ""
       },
       {
-         "id": "stat",
-         "name": "Stat",
-         "type": "panel",
-         "version": ""
-      },
-      {
-         "id": "table",
-         "name": "Table",
-         "type": "panel",
-         "version": ""
-      },
-      {
-         "id": "prometheus",
-         "name": "Prometheus",
+         "id": "influxdb",
+         "name": "InfluxDB",
          "type": "datasource",
          "version": "1.0.0"
       }
@@ -83,416 +55,11 @@
          "id": 2,
          "panels": [
             {
-               "columns": [ ],
-               "datasource": "${DS_PROMETHEUS}",
-               "description": "Overview of Tarantool instances observed by Prometheus job.\n\nIf instance row is *red*, it means Prometheus can't reach\nURI specified in targets or ran into error.\nIf instance row is *green*, it means instance is up and running and\nPrometheus is successfully extracting metrics from it.\n\"Uptime\" column shows time since instant start.\n",
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 0,
-                  "y": 1
-               },
-               "id": 3,
-               "links": [ ],
-               "sort": {
-                  "col": 2,
-                  "desc": false
-               },
-               "styles": [
-                  {
-                     "alias": "Instance alias",
-                     "mappingType": 1,
-                     "pattern": "alias",
-                     "thresholds": [ ],
-                     "type": "string"
-                  },
-                  {
-                     "alias": "Instance URI",
-                     "mappingType": 1,
-                     "pattern": "instance",
-                     "thresholds": [ ],
-                     "type": "string"
-                  },
-                  {
-                     "alias": "Uptime",
-                     "colorMode": "row",
-                     "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                     ],
-                     "decimals": 0,
-                     "mappingType": 1,
-                     "pattern": "Value",
-                     "thresholds": [
-                        "0.1",
-                        "0.1"
-                     ],
-                     "type": "number",
-                     "unit": "s"
-                  },
-                  {
-                     "alias": "job",
-                     "pattern": "job",
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "__name__",
-                     "pattern": "__name__",
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "Time",
-                     "pattern": "Time",
-                     "type": "hidden"
-                  }
-               ],
-               "targets": [
-                  {
-                     "expr": "up{job=~\"$job\"} * on(instance) group_left(alias) tnt_info_uptime{job=~\"$job\"} or\non(instance) label_replace(up{job=~\"$job\"}, \"alias\", \"Not available\", \"instance\", \".*\")\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  }
-               ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Cluster status overview",
-               "transform": "table",
-               "type": "table"
-            },
-            {
-               "datasource": "${DS_PROMETHEUS}",
-               "description": "Count of running Tarantool instances observed by Prometheus job.\nIf Prometheus can't reach URI specified in targets\nor ran into error, instance is not counted.\n",
-               "gridPos": {
-                  "h": 3,
-                  "w": 6,
-                  "x": 12,
-                  "y": 1
-               },
-               "id": 4,
-               "links": [ ],
-               "options": {
-                  "colorMode": "value",
-                  "fieldOptions": {
-                     "calcs": [
-                        "last"
-                     ],
-                     "defaults": {
-                        "decimals": 0,
-                        "links": [ ],
-                        "mappings": [ ],
-                        "thresholds": {
-                           "mode": "absolute",
-                           "steps": [
-                              {
-                                 "color": "green",
-                                 "value": null
-                              }
-                           ]
-                        },
-                        "title": "Total instances running:",
-                        "unit": "none"
-                     },
-                     "fields": "",
-                     "values": false
-                  },
-                  "graphMode": "area",
-                  "justifyMode": "auto",
-                  "orientation": "auto"
-               },
-               "pluginVersion": "6.6.0",
-               "targets": [
-                  {
-                     "expr": "sum(up{job=~\"$job\"})",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  }
-               ],
-               "title": "",
-               "transparent": false,
-               "type": "stat"
-            },
-            {
-               "datasource": "${DS_PROMETHEUS}",
-               "description": "Overall value of memory used by Tarantool\nitems and indexes (*arena_used* value).\nIf Tarantool instance is not available\nfor Prometheus metrics extraction now,\nits contribution is not counted.\n",
-               "gridPos": {
-                  "h": 3,
-                  "w": 3,
-                  "x": 18,
-                  "y": 1
-               },
-               "id": 5,
-               "links": [ ],
-               "options": {
-                  "colorMode": "value",
-                  "fieldOptions": {
-                     "calcs": [
-                        "last"
-                     ],
-                     "defaults": {
-                        "decimals": 2,
-                        "links": [ ],
-                        "mappings": [ ],
-                        "thresholds": {
-                           "mode": "absolute",
-                           "steps": [
-                              {
-                                 "color": "green",
-                                 "value": null
-                              }
-                           ]
-                        },
-                        "title": "Overall memory used:",
-                        "unit": "bytes"
-                     },
-                     "fields": "",
-                     "values": false
-                  },
-                  "graphMode": "area",
-                  "justifyMode": "auto",
-                  "orientation": "auto"
-               },
-               "pluginVersion": "6.6.0",
-               "targets": [
-                  {
-                     "expr": "sum(tnt_slab_arena_used{job=~\"$job\"})",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  }
-               ],
-               "title": "",
-               "transparent": false,
-               "type": "stat"
-            },
-            {
-               "datasource": "${DS_PROMETHEUS}",
-               "description": "Overall value of memory available for Tarantool items\nand indexes allocation (*memtx_memory* or *quota_size* values).\nIf Tarantool instance is not available for Prometheus metrics\nextraction now, its contribution is not counted.\n",
-               "gridPos": {
-                  "h": 3,
-                  "w": 3,
-                  "x": 21,
-                  "y": 1
-               },
-               "id": 6,
-               "links": [ ],
-               "options": {
-                  "colorMode": "value",
-                  "fieldOptions": {
-                     "calcs": [
-                        "last"
-                     ],
-                     "defaults": {
-                        "decimals": 2,
-                        "links": [ ],
-                        "mappings": [ ],
-                        "thresholds": {
-                           "mode": "absolute",
-                           "steps": [
-                              {
-                                 "color": "green",
-                                 "value": null
-                              }
-                           ]
-                        },
-                        "title": "Overall memory reserved:",
-                        "unit": "bytes"
-                     },
-                     "fields": "",
-                     "values": false
-                  },
-                  "graphMode": "area",
-                  "justifyMode": "auto",
-                  "orientation": "auto"
-               },
-               "pluginVersion": "6.6.0",
-               "targets": [
-                  {
-                     "expr": "sum(tnt_slab_quota_size{job=~\"$job\"})",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  }
-               ],
-               "title": "",
-               "transparent": false,
-               "type": "stat"
-            },
-            {
-               "datasource": "${DS_PROMETHEUS}",
-               "description": "Overall rate of HTTP requests processed\non Tarantool instances (all methods and response codes).\nIf Tarantool instance is not available for Prometheus metrics\nextraction now, its contribution is not counted.\n",
-               "gridPos": {
-                  "h": 5,
-                  "w": 4,
-                  "x": 12,
-                  "y": 4
-               },
-               "id": 7,
-               "links": [ ],
-               "options": {
-                  "colorMode": "value",
-                  "fieldOptions": {
-                     "calcs": [
-                        "last"
-                     ],
-                     "defaults": {
-                        "decimals": 3,
-                        "links": [ ],
-                        "mappings": [ ],
-                        "thresholds": {
-                           "mode": "absolute",
-                           "steps": [
-                              {
-                                 "color": "green",
-                                 "value": null
-                              }
-                           ]
-                        },
-                        "title": "Overall HTTP load:",
-                        "unit": "reqps"
-                     },
-                     "fields": "",
-                     "values": false
-                  },
-                  "graphMode": "area",
-                  "justifyMode": "auto",
-                  "orientation": "auto"
-               },
-               "pluginVersion": "6.6.0",
-               "targets": [
-                  {
-                     "expr": "sum(rate(http_server_request_latency_count{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  }
-               ],
-               "title": "",
-               "transparent": false,
-               "type": "stat"
-            },
-            {
-               "datasource": "${DS_PROMETHEUS}",
-               "description": "Overall rate of network requests processed on Tarantool instances.\nIf Tarantool instance is not available for Prometheus metrics\nextraction now, its contribution is not counted.\n",
-               "gridPos": {
-                  "h": 5,
-                  "w": 4,
-                  "x": 16,
-                  "y": 4
-               },
-               "id": 8,
-               "links": [ ],
-               "options": {
-                  "colorMode": "value",
-                  "fieldOptions": {
-                     "calcs": [
-                        "last"
-                     ],
-                     "defaults": {
-                        "decimals": 3,
-                        "links": [ ],
-                        "mappings": [ ],
-                        "thresholds": {
-                           "mode": "absolute",
-                           "steps": [
-                              {
-                                 "color": "green",
-                                 "value": null
-                              }
-                           ]
-                        },
-                        "title": "Overall net load:",
-                        "unit": "reqps"
-                     },
-                     "fields": "",
-                     "values": false
-                  },
-                  "graphMode": "area",
-                  "justifyMode": "auto",
-                  "orientation": "auto"
-               },
-               "pluginVersion": "6.6.0",
-               "targets": [
-                  {
-                     "expr": "sum(rate(tnt_net_requests_total{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  }
-               ],
-               "title": "",
-               "transparent": false,
-               "type": "stat"
-            },
-            {
-               "datasource": "${DS_PROMETHEUS}",
-               "description": "Overall rate of operations performed on Tarantool spaces\n(*select*, *insert*, *update* etc.).\nIf Tarantool instance is not available for Prometheus metrics\nextraction now, its contribution is not counted.\n",
-               "gridPos": {
-                  "h": 5,
-                  "w": 4,
-                  "x": 20,
-                  "y": 4
-               },
-               "id": 9,
-               "links": [ ],
-               "options": {
-                  "colorMode": "value",
-                  "fieldOptions": {
-                     "calcs": [
-                        "last"
-                     ],
-                     "defaults": {
-                        "decimals": 3,
-                        "links": [ ],
-                        "mappings": [ ],
-                        "thresholds": {
-                           "mode": "absolute",
-                           "steps": [
-                              {
-                                 "color": "green",
-                                 "value": null
-                              }
-                           ]
-                        },
-                        "title": "Overall space load:",
-                        "unit": "ops"
-                     },
-                     "fields": "",
-                     "values": false
-                  },
-                  "graphMode": "area",
-                  "justifyMode": "auto",
-                  "orientation": "auto"
-               },
-               "pluginVersion": "6.6.0",
-               "targets": [
-                  {
-                     "expr": "sum(rate(tnt_stats_op_total{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  }
-               ],
-               "title": "",
-               "transparent": false,
-               "type": "stat"
-            },
-            {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Number of \"warning\" issues on each cluster instance.\n\"warning\" issues includes high replication lag, replication long idle,\nfailover and switchover issues, clock issues, memory fragmentation,\nconfiguration issues and alien members warnings.\n\nPanel works with `cartridge >= 2.0.2`, `metrics >= 0.6.0`,\nwhile `metrics >= 0.9.0` is recommended for per instance display.\n",
                "fill": 0,
@@ -500,9 +67,9 @@
                   "h": 6,
                   "w": 12,
                   "x": 0,
-                  "y": 9
+                  "y": 1
                },
-               "id": 10,
+               "id": 3,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -532,11 +99,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_cartridge_issues{job=~\"$job\",alias=~\"$alias\",level=\"warning\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_cartridge_issues"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_level",
+                           "operator": "=",
+                           "value": "warning"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -582,7 +202,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Number of \"critical\" issues on each cluster instance.\n\"critical\" issues includes replication process critical fails and\nrunning out of available memory.\n\nPanel works with `cartridge >= 2.0.2`, `metrics >= 0.6.0`,\nwhile `metrics >= 0.9.0` is recommended for per instance display.\n",
                "fill": 0,
@@ -590,9 +210,9 @@
                   "h": 6,
                   "w": 12,
                   "x": 12,
-                  "y": 9
+                  "y": 1
                },
-               "id": 11,
+               "id": 4,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -622,11 +242,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_cartridge_issues{job=~\"$job\",alias=~\"$alias\",level=\"critical\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_cartridge_issues"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_level",
+                           "operator": "=",
+                           "value": "critical"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -668,7 +341,7 @@
                ]
             },
             {
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "description": "`follows` status means replication is running.\nOtherwise, `not running` is displayed.\n\nPanel works with `metrics >= 0.13.0` and Grafana 8.x.\n",
                "fieldConfig": {
                   "defaults": {
@@ -749,9 +422,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 15
+                  "y": 7
                },
-               "id": 12,
+               "id": 5,
                "options": {
                   "legend": {
                      "calcs": [
@@ -766,18 +439,77 @@
                },
                "targets": [
                   {
-                     "expr": "tnt_replication_status{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} {{stream}} ({{id}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias $tag_label_pairs_stream ($tag_label_pairs_id)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_stream"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_id"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_replication_status"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "title": "Tarantool replication status",
                "type": "timeseries"
             },
             {
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "description": "`master` status means instance is available for read and\nwrite operations. `replica` status means instance is\navailable only for read operations.\n\nPanel works with `metrics >= 0.11.0` and Grafana 8.x.\n",
                "fieldConfig": {
                   "defaults": {
@@ -858,9 +590,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 15
+                  "y": 7
                },
-               "id": 13,
+               "id": 6,
                "options": {
                   "legend": {
                      "calcs": [
@@ -875,11 +607,58 @@
                },
                "targets": [
                   {
-                     "expr": "tnt_read_only{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_read_only"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "title": "Tarantool instance status",
@@ -890,16 +669,16 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "description": "Replication lag value for Tarantool instance.\n\nPanel works with `metrics >= 0.13.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 23
+                  "y": 15
                },
-               "id": 14,
+               "id": 7,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -929,11 +708,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_replication_lag{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} ({{id}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias ($tag_label_pairs_id)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_id"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_replication_lag"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -977,16 +809,16 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "description": "Clock drift across the cluster.\nmax shows difference with the fastest clock (always positive),\nmin shows difference with the slowest clock (always negative).\n\nPanel works with `metrics >= 0.10.0`.\n",
                "fill": 1,
                "gridPos": {
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 23
+                  "y": 15
                },
-               "id": 15,
+               "id": 8,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -1016,11 +848,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_clock_delta{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} ({{delta}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias ($tag_label_pairs_delta)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_delta"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_clock_delta"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -1075,16 +960,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 31
+            "y": 23
          },
-         "id": 16,
+         "id": 9,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Requests, processed with success (code 2xx) on Tarantool's side.\nGraph shows mean count per second.\n",
                "fill": 0,
@@ -1092,9 +977,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 32
+                  "y": 24
                },
-               "id": 17,
+               "id": 10,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1124,11 +1009,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(http_server_request_latency_count{job=~\"$job\",alias=~\"$alias\",status=~\"^2\\\\d{2}$\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_method $tag_label_pairs_path (code $tag_label_pairs_status)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_path"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_method"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_status"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "http_server_request_latency_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=~",
+                           "value": "/^2\\d{2}$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -1174,7 +1136,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Requests, processed with 4xx error on Tarantool's side.\nGraph shows mean count per second.\n",
                "fill": 0,
@@ -1182,9 +1144,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 32
+                  "y": 24
                },
-               "id": 18,
+               "id": 11,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1214,11 +1176,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(http_server_request_latency_count{job=~\"$job\",alias=~\"$alias\",status=~\"^4\\\\d{2}$\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_method $tag_label_pairs_path (code $tag_label_pairs_status)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_path"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_method"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_status"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "http_server_request_latency_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=~",
+                           "value": "/^4\\d{2}$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -1264,7 +1303,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Requests, processed with 5xx error on Tarantool's side.\nGraph shows mean count per second.\n",
                "fill": 0,
@@ -1272,9 +1311,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 32
+                  "y": 24
                },
-               "id": 19,
+               "id": 12,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1304,11 +1343,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(http_server_request_latency_count{job=~\"$job\",alias=~\"$alias\",status=~\"^5\\\\d{2}$\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_method $tag_label_pairs_path (code $tag_label_pairs_status)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_path"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_method"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_status"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "http_server_request_latency_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=~",
+                           "value": "/^5\\d{2}$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -1354,7 +1470,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "99th percentile of requests latency.\nIncludes only requests processed with success\n(code 2xx) on Tarantool's side.\n",
                "fill": 0,
@@ -1362,9 +1478,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 40
+                  "y": 32
                },
-               "id": 20,
+               "id": 13,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1394,11 +1510,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "http_server_request_latency{job=~\"$job\",alias=~\"$alias\",quantile=\"0.99\",status=~\"^2\\\\d{2}$\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_method $tag_label_pairs_path (code $tag_label_pairs_status)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_path"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_method"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_status"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "http_server_request_latency"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=~",
+                           "value": "/^2\\d{2}$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -1444,7 +1637,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "99th percentile of requests latency.\nIncludes only requests processed with\n4xx error on Tarantool's side.\n",
                "fill": 0,
@@ -1452,9 +1645,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 40
+                  "y": 32
                },
-               "id": 21,
+               "id": 14,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1484,11 +1677,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "http_server_request_latency{job=~\"$job\",alias=~\"$alias\",quantile=\"0.99\",status=~\"^4\\\\d{2}$\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_method $tag_label_pairs_path (code $tag_label_pairs_status)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_path"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_method"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_status"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "http_server_request_latency"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=~",
+                           "value": "/^4\\d{2}$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -1534,7 +1804,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "99th percentile of requests latency.\nIncludes only requests processed with\n5xx error on Tarantool's side.\n",
                "fill": 0,
@@ -1542,9 +1812,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 40
+                  "y": 32
                },
-               "id": 22,
+               "id": 15,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1574,11 +1844,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "http_server_request_latency{job=~\"$job\",alias=~\"$alias\",quantile=\"0.99\",status=~\"^5\\\\d{2}$\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_method $tag_label_pairs_path (code $tag_label_pairs_status)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_path"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_method"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_status"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "http_server_request_latency"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=~",
+                           "value": "/^5\\d{2}$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -1635,16 +1982,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 48
+            "y": 40
          },
-         "id": 23,
+         "id": 16,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Memory used for network input/output buffers.\n",
                "fill": 0,
@@ -1652,9 +1999,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 49
+                  "y": 41
                },
-               "id": 24,
+               "id": 17,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1684,11 +2031,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_info_memory_net{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_info_memory_net"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -1734,7 +2128,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Data received by instance from binary protocol connections.\nGraph shows average bytes per second.\n",
                "fill": 0,
@@ -1742,9 +2136,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 49
+                  "y": 41
                },
-               "id": 25,
+               "id": 18,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1774,11 +2168,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_received_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_net_received_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -1824,7 +2271,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Data sent by instance with binary protocol connections.\nGraph shows average bytes per second.\n",
                "fill": 0,
@@ -1832,9 +2279,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 49
+                  "y": 41
                },
-               "id": 26,
+               "id": 19,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1864,11 +2311,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_sent_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_net_sent_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -1914,7 +2414,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of network requests this instance has handled.\nGraph shows mean rps.\n\nPanel will be removed in favor of \"Processed requests\"\nand \"Requests in queue (overall)\" panels.\n",
                "fill": 0,
@@ -1922,9 +2422,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 57
+                  "y": 49
                },
-               "id": 27,
+               "id": 20,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1954,11 +2454,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_net_requests_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -2004,7 +2557,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Number of pending network requests.\n\nPanel will be removed in favor of \"Requests in progress\"\nand \"Requests in queue (current)\" panels.\n",
                "fill": 0,
@@ -2012,9 +2565,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 57
+                  "y": 49
                },
-               "id": 28,
+               "id": 21,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -2044,11 +2597,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_current{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_net_requests_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -2094,7 +2694,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average number of requests processed by tx thread per second.\n\nPanel works with `metrics >= 0.13.0` and `Tarantool >= 2.10-beta2`.\n",
                "fill": 0,
@@ -2102,9 +2702,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 65
+                  "y": 57
                },
-               "id": 29,
+               "id": 22,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -2134,11 +2734,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_in_progress_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_net_requests_in_progress_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -2184,7 +2837,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Number of requests currently being processed in the tx thread.\n\nPanel works with `metrics >= 0.13.0` and `Tarantool >= 2.10-beta2`.\n",
                "fill": 0,
@@ -2192,9 +2845,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 65
+                  "y": 57
                },
-               "id": 30,
+               "id": 23,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -2224,11 +2877,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_in_progress_current{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_net_requests_in_progress_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -2274,7 +2974,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average number of requests which was placed in queues\nof streams per second.\n\nPanel works with `metrics >= 0.13.0` and `Tarantool >= 2.10-beta2`.\n",
                "fill": 0,
@@ -2282,9 +2982,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 65
+                  "y": 57
                },
-               "id": 31,
+               "id": 24,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -2314,11 +3014,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_in_stream_queue_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_net_requests_in_stream_queue_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -2364,7 +3117,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Number of requests currently waiting in queues of streams.\n\nPanel works with `metrics >= 0.13.0` and `Tarantool >= 2.10-beta2`.\n",
                "fill": 0,
@@ -2372,9 +3125,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 65
+                  "y": 57
                },
-               "id": 32,
+               "id": 25,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -2404,11 +3157,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_in_stream_queue_current{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_net_requests_in_stream_queue_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -2454,7 +3254,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average number of new binary protocol connections per second.\n",
                "fill": 0,
@@ -2462,9 +3262,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 73
+                  "y": 65
                },
-               "id": 33,
+               "id": 26,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -2494,11 +3294,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_connections_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_net_connections_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -2544,7 +3397,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Number of current active binary protocol connections.\n",
                "fill": 0,
@@ -2552,9 +3405,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 73
+                  "y": 65
                },
-               "id": 34,
+               "id": 27,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -2584,11 +3437,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_connections_current{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_net_connections_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -2645,9 +3545,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 81
+            "y": 73
          },
-         "id": 35,
+         "id": 28,
          "panels": [
             {
                "content": "`quota_used_ratio` > 90%, `arena_used_ratio` > 90%, 50% < `items_used_ratio` < 90% – your memory is highly fragmented. See [docs](https://www.tarantool.io/en/doc/1.10/reference/reference_lua/box_slab/#lua-function.box.slab.info) for more info.\n\n`quota_used_ratio` > 90%, `arena_used_ratio` > 90%, `items_used_ratio` > 90% – you are running out of memory. You should consider increasing Tarantool’s memory limit (*box.cfg.memtx_memory*).\n",
@@ -2656,9 +3556,9 @@
                   "h": 3,
                   "w": 24,
                   "x": 0,
-                  "y": 82
+                  "y": 74
                },
-               "id": 36,
+               "id": 29,
                "mode": "markdown",
                "title": "Slab allocator monitoring information",
                "type": "text"
@@ -2668,7 +3568,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "`quota_used_ratio` = `quota_used` / `quota_size`.\n\n`quota_used` – used by slab allocator (for both tuple and index slabs).\n\n`quota_size` – memory limit for slab allocator (as configured in the *memtx_memory* parameter).\n",
                "fill": 0,
@@ -2676,9 +3576,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 85
+                  "y": 77
                },
-               "id": 37,
+               "id": 30,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2708,11 +3608,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_used_ratio{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_slab_quota_used_ratio"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -2758,7 +3705,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "`arena_used_ratio` = `arena_used` / `arena_size`.\n\n`arena_used` – used for both tuples and indexes.\n\n`arena_size` – allocated for both tuples and indexes.\n",
                "fill": 0,
@@ -2766,9 +3713,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 85
+                  "y": 77
                },
-               "id": 38,
+               "id": 31,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2798,11 +3745,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_used_ratio{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_slab_arena_used_ratio"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -2848,7 +3842,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "`items_used_ratio` = `items_used` / `items_size`.\n\n`items_used` – used only for tuples.\n\n`items_size` – allocated only for tuples.\n",
                "fill": 0,
@@ -2856,9 +3850,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 85
+                  "y": 77
                },
-               "id": 39,
+               "id": 32,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2888,11 +3882,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_used_ratio{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_slab_items_used_ratio"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -2938,7 +3979,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Memory used by slab allocator (for both tuple and index slabs).\n",
                "fill": 0,
@@ -2946,9 +3987,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 93
+                  "y": 85
                },
-               "id": 40,
+               "id": 33,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2978,11 +4019,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_used{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_slab_quota_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -3028,7 +4116,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Memory used for both tuples and indexes.\n",
                "fill": 0,
@@ -3036,9 +4124,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 93
+                  "y": 85
                },
-               "id": 41,
+               "id": 34,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3068,11 +4156,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_used{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_slab_arena_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -3118,7 +4253,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Memory used for only tuples.\n",
                "fill": 0,
@@ -3126,9 +4261,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 93
+                  "y": 85
                },
-               "id": 42,
+               "id": 35,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3158,11 +4293,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_used{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_slab_items_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -3208,7 +4390,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Memory limit for slab allocator (as configured in the *memtx_memory* parameter).\n",
                "fill": 0,
@@ -3216,9 +4398,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 101
+                  "y": 93
                },
-               "id": 43,
+               "id": 36,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3248,11 +4430,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_size{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_slab_quota_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -3298,7 +4527,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Memory allocated for both tuples and indexes by slab allocator.\n",
                "fill": 0,
@@ -3306,9 +4535,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 101
+                  "y": 93
                },
-               "id": 44,
+               "id": 37,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3338,11 +4567,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_size{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_slab_arena_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -3388,7 +4664,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Memory allocated for only tuples by slab allocator.\n",
                "fill": 0,
@@ -3396,9 +4672,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 101
+                  "y": 93
                },
-               "id": 45,
+               "id": 38,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3428,11 +4704,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_size{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_slab_items_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -3489,16 +4812,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 109
+            "y": 101
          },
-         "id": 46,
+         "id": 39,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Number of records in the space (memtx engine).\nName of space is specified after dash.\n",
                "fill": 0,
@@ -3506,9 +4829,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 110
+                  "y": 102
                },
-               "id": 47,
+               "id": 40,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3538,11 +4861,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_len{job=~\"$job\", alias=~\"$alias\", engine=\"memtx\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_space_len"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_engine",
+                           "operator": "=",
+                           "value": "memtx"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -3588,7 +4970,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Number of records in the space (vinyl engine).\nName of space is specified after dash.\nBy default this metrics is disabled,\nto enable it you must set global variable\ninclude_vinyl_count to true. Beware that\ncount() operation scans the space and may\nslow down your app. \n\nPanel works with `metrics >= 0.13.0`.\n",
                "fill": 0,
@@ -3596,9 +4978,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 110
+                  "y": 102
                },
-               "id": 48,
+               "id": 41,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3628,11 +5010,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_tuples{job=~\"$job\", alias=~\"$alias\", engine=\"vinyl\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_tuples"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_engine",
+                           "operator": "=",
+                           "value": "vinyl"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -3678,17 +5119,17 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
-               "description": "Total number of bytes in all tuples of the space (memtx engine).\nName of space is specified after dash.\n",
+               "description": "Total number of bytes in all tuples of the space (memtx engine).\nName of space is specified after dash.\n\n`No data` may be displayed because of tarantool/metrics issue #321,\nuse `metrics >= 0.12.0` to fix.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 118
+                  "y": 110
                },
-               "id": 49,
+               "id": 42,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3718,11 +5159,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_bsize{job=~\"$job\", alias=~\"$alias\", engine=\"memtx\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_space_bsize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_engine",
+                           "operator": "=",
+                           "value": "memtx"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -3768,7 +5268,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Total number of bytes taken by the index.\nName of space is specified after dash,\nindex name specified in parentheses.\nIncludes both memtx and vinyl spaces.\n",
                "fill": 0,
@@ -3776,9 +5276,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 118
+                  "y": 110
                },
-               "id": 50,
+               "id": 43,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3808,11 +5308,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_index_bsize{job=~\"$job\", alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}} ({{index_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name ($tag_label_pairs_index_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_index_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_space_index_bsize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -3858,17 +5417,17 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
-               "description": "Total size of tuples and all indexes in the space (memtx engine).\nName of space is specified after dash.\n",
+               "description": "Total size of tuples and all indexes in the space (memtx engine).\nName of space is specified after dash.\n\n`No data` may be displayed because of tarantool/metrics issue #321,\nuse `metrics >= 0.12.0` to fix.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 118
+                  "y": 110
                },
-               "id": 51,
+               "id": 44,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3898,11 +5457,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_total_bsize{job=~\"$job\", alias=~\"$alias\", engine=\"memtx\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_space_total_bsize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_engine",
+                           "operator": "=",
+                           "value": "memtx"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -3959,16 +5577,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 126
+            "y": 118
          },
-         "id": 52,
+         "id": 45,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "The amount of data stored in the `.run` files located in the `vinyl_dir` directory.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -3976,9 +5594,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 127
+                  "y": 119
                },
-               "id": 53,
+               "id": 46,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4008,11 +5626,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_disk_data_size{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_disk_data_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -4058,7 +5723,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "The amount of data stored in the `.index` files located in the `vinyl_dir` directory.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4066,9 +5731,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 127
+                  "y": 119
                },
-               "id": 54,
+               "id": 47,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4098,11 +5763,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_disk_index_size{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_disk_index_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -4148,7 +5860,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Amount of memory in bytes currently used to store tuples (data).\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4156,9 +5868,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 135
+                  "y": 127
                },
-               "id": 55,
+               "id": 48,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4188,11 +5900,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_tuple_cache{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_memory_tuple_cache"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -4238,7 +5997,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4246,9 +6005,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 135
+                  "y": 127
                },
-               "id": 56,
+               "id": 49,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4278,11 +6037,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_page_index{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_memory_page_index"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -4328,7 +6134,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Amount of memory in bytes used by bloom filters.\n",
                "fill": 0,
@@ -4336,9 +6142,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 135
+                  "y": 127
                },
-               "id": 57,
+               "id": 50,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4368,11 +6174,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_bloom_filter{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_memory_bloom_filter"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -4418,7 +6271,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "The estimated average rate of taking dumps, bytes per second.\nInitially, the rate value is 10 megabytes per second\nand being recalculated depending on the the actual rate.\nOnly significant dumps that are larger than one megabyte\nare used for the estimate.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4426,9 +6279,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 143
+                  "y": 135
                },
-               "id": 58,
+               "id": 51,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4458,11 +6311,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_dump_bandwidth{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_regulator_dump_bandwidth"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -4508,7 +6408,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "The actual average rate of performing the write operations, bytes per second.\nThe rate is calculated as a 5-second moving average.\nIf the metric value is gradually going down, this can indicate some disk issues.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4516,9 +6416,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 143
+                  "y": 135
                },
-               "id": 59,
+               "id": 52,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4548,11 +6448,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_write_rate{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_regulator_write_rate"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -4598,7 +6545,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "The write rate limit, bytes per second.\nThe regulator imposes the limit on transactions based on the observed dump/compaction performance.\nIf the metric value is down to approximately 100 Kbps,\nthis indicates issues with the disk or the scheduler.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4606,9 +6553,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 143
+                  "y": 135
                },
-               "id": 60,
+               "id": 53,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4638,11 +6585,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_rate_limit{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_regulator_rate_limit"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -4688,7 +6682,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "«Level 0» (L0) memory area in bytes. L0 is the area that\nvinyl can use for in-memory storage of an LSM tree.\nBy monitoring this metric, you can see when L0 is getting\nclose to its maximum (tnt_vinyl_regulator_dump_watermark),\nat which time a dump will occur. You can expect L0 = 0\nimmediately after the dump operation is completed.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4696,9 +6690,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 151
+                  "y": 143
                },
-               "id": 61,
+               "id": 54,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4728,11 +6722,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_level0{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_memory_level0"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -4778,7 +6819,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "The maximum amount of memory used for in-memory storing of a vinyl LSM tree.\nWhen accessing this maximum, the dumping must occur.\nFor details, see https://www.tarantool.io/en/doc/latest/book/box/engines/#engines-algorithm-filling-lsm.\nThe value is slightly smaller than the amount of memory allocated for vinyl trees,\nwhich is the `vinyl_memory` parameter.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4786,9 +6827,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 151
+                  "y": 143
                },
-               "id": 62,
+               "id": 55,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4818,11 +6859,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_dump_watermark{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_regulator_dump_watermark"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -4868,7 +6956,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "The number of fibers that are blocked waiting for Vinyl level0 memory quota.\n\nPanel works with `metrics >= 0.13.0` and `Tarantool >= 2.8.3`.\n",
                "fill": 0,
@@ -4876,9 +6964,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 151
+                  "y": 143
                },
-               "id": 63,
+               "id": 56,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4908,11 +6996,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_blocked_writers{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_regulator_blocked_writers"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -4958,7 +7093,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average per second rate of commits (successful transaction ends).\nIt includes implicit commits: for example, any insert operation causes a commit\nunless it is within a `box.begin()`–`box.commit()` block.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4966,9 +7101,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 159
+                  "y": 151
                },
-               "id": 64,
+               "id": 57,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4998,11 +7133,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_commit{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_tx_commit"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -5048,7 +7236,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average per second rate of rollbacks (unsuccessful transaction ends).\nThis is not merely a count of explicit `box.rollback()` requests — it includes requests\nthat ended with errors.\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -5056,9 +7244,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 159
+                  "y": 151
                },
-               "id": 65,
+               "id": 58,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5088,11 +7276,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_rollback{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_tx_rollback"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -5138,7 +7379,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average per second rate of conflicts that caused transactions to roll back.\nThe ratio `tx conflicts` / `tx commits` above 5% indicates that vinyl is not healthy.\nAt this moment you’ll probably see a lot of other problems with vinyl.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -5146,9 +7387,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 159
+                  "y": 151
                },
-               "id": 66,
+               "id": 59,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5178,11 +7419,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_conflict{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_tx_conflict"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -5228,7 +7522,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Number of current read views, that is, transactions entered a read-only state\nto avoid conflict temporarily.\nIf the value stays non-zero for a long time, it indicates of a memory leak.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -5236,9 +7530,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 159
+                  "y": 151
                },
-               "id": 67,
+               "id": 60,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5268,11 +7562,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_tx_read_views{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_tx_read_views"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -5318,7 +7659,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "The number of the scheduler dump/compaction tasks in progress now.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -5326,9 +7667,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 167
+                  "y": 159
                },
-               "id": 68,
+               "id": 61,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5358,11 +7699,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_scheduler_tasks{job=~\"$job\", alias=~\"$alias\", status=\"inprogress\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_scheduler_tasks"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "inprogress"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -5408,7 +7802,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Scheduler dump/compaction tasks failed.\nAverage per second rate is shown.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -5416,9 +7810,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 167
+                  "y": 159
                },
-               "id": 69,
+               "id": 62,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5448,11 +7842,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_tasks{job=~\"$job\",alias=~\"$alias\",status=\"failed\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_scheduler_tasks"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "failed"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -5498,7 +7951,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Time spent by all worker threads performing dumps.\nAverage per second rate is shown.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -5506,9 +7959,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 167
+                  "y": 159
                },
-               "id": 70,
+               "id": 63,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5538,11 +7991,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_dump_time{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_scheduler_dump_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -5588,7 +8094,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Scheduler dumps completed average per second rate.\n\nPanel works with `metrics >= 0.13.0`.\n",
                "fill": 0,
@@ -5596,9 +8102,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 167
+                  "y": 159
                },
-               "id": 71,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5628,11 +8134,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_dump_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_scheduler_dump_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -5689,16 +8248,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 175
+            "y": 167
          },
-         "id": 72,
+         "id": 65,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "This is the average share of time\nspent by instance process executing in user mode.\nMetrics obtained using `getrusage()` call.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -5706,9 +8265,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 176
+                  "y": 168
                },
-               "id": 73,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5738,11 +8297,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_cpu_user_time{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_cpu_user_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -5788,7 +8400,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "This is the average share of time\nspent by instance process executing in kernel mode.\nMetrics obtained using `getrusage()` call.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -5796,9 +8408,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 176
+                  "y": 168
                },
-               "id": 74,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5828,11 +8440,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_cpu_system_time{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_cpu_system_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -5889,16 +8554,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 184
+            "y": 176
          },
-         "id": 75,
+         "id": 68,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance. \n",
                "fill": 0,
@@ -5906,9 +8571,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 185
+                  "y": 177
                },
-               "id": 76,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5938,11 +8603,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_info_memory_lua{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_info_memory_lua"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -5988,7 +8700,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Memory used by runtime arena.\nRuntime arena stores network buffers, tuples\ncreated with box.tuple.new and other objects\nallocated by application not covered by basic\nLua mechanisms (spaces data and indexes\nare not included here, see memtx/vinyl arena).\n",
                "fill": 0,
@@ -5996,9 +8708,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 185
+                  "y": 177
                },
-               "id": 77,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6028,11 +8740,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_runtime_used{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_runtime_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -6078,7 +8837,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Memory in use by active transactions.\nFor the vinyl storage engine, this is the total size of\nall allocated objects (struct txv, struct vy_tx, struct vy_read_interval)\nand tuples pinned for those objects. \n",
                "fill": 0,
@@ -6086,9 +8845,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 185
+                  "y": 177
                },
-               "id": 78,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6118,11 +8877,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_info_memory_tx{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_info_memory_tx"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -6168,7 +8974,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of fiber context switches.\nContext switches are counted over all current fibers.\n",
                "fill": 0,
@@ -6176,9 +8982,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 193
+                  "y": 185
                },
-               "id": 79,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6208,11 +9014,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_csw{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_fiber_csw"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -6258,7 +9111,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Duration of last event loop iteration (tx thread).\nHigh duration results in longer responses,\npossible bad health signals and may be the\nreason of \"Too long WAL write\" errors.\n\nPanel works with `metrics >= 0.13.0`.\n",
                "fill": 0,
@@ -6266,9 +9119,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 193
+                  "y": 185
                },
-               "id": 80,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6298,11 +9151,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_ev_loop_time{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_ev_loop_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -6348,7 +9248,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Current number of fibers in tx thread. \n\nPanel works with `metrics >= 0.13.0`.\n",
                "fill": 0,
@@ -6356,9 +9256,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 201
+                  "y": 193
                },
-               "id": 81,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6388,11 +9288,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_amount{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_fiber_amount"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -6438,7 +9385,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Amount of memory used by current fibers.\n",
                "fill": 0,
@@ -6446,9 +9393,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 201
+                  "y": 193
                },
-               "id": 82,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6478,11 +9425,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_memused{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_fiber_memused"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -6528,7 +9522,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Amount of memory reserved for current fibers.\n",
                "fill": 0,
@@ -6536,9 +9530,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 201
+                  "y": 193
                },
-               "id": 83,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6568,11 +9562,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_memalloc{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_fiber_memalloc"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -6629,16 +9670,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 209
+            "y": 201
          },
-         "id": 84,
+         "id": 77,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average number of snap restores (guard assertions\nleading to stopping trace executions) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -6646,9 +9687,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 210
+                  "y": 202
                },
-               "id": 85,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6678,11 +9719,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_snap_restore{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_jit_snap_restore"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -6728,7 +9822,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average number of new JIT traces per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -6736,9 +9830,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 210
+                  "y": 202
                },
-               "id": 86,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6768,11 +9862,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_trace_num{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_jit_trace_num"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -6818,7 +9965,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average number of JIT trace aborts per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -6826,9 +9973,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 210
+                  "y": 202
                },
-               "id": 87,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6858,11 +10005,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_trace_abort{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_jit_trace_abort"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -6908,7 +10108,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Total size of allocated machine code areas.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -6916,9 +10116,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 210
+                  "y": 202
                },
-               "id": 88,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6948,11 +10148,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_jit_mcode_size{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_jit_mcode_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -6998,7 +10245,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average number of strings being extracted from hash instead of allocating per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7006,9 +10253,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 218
+                  "y": 210
                },
-               "id": 89,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7038,11 +10285,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_strhash_hit{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_strhash_hit"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -7088,7 +10388,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average number of strings being allocated due to hash miss per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7096,9 +10396,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 218
+                  "y": 210
                },
-               "id": 90,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7128,11 +10428,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_strhash_miss{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_strhash_miss"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -7178,7 +10531,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average count of incremental GC steps (atomic state) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7186,9 +10539,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 226
+                  "y": 218
                },
-               "id": 91,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7218,11 +10571,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_atomic{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_gc_steps_atomic"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -7268,7 +10674,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average count of incremental GC steps (sweepstring state) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7276,9 +10682,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 226
+                  "y": 218
                },
-               "id": 92,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7308,11 +10714,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_sweepstring{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_gc_steps_sweepstring"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -7358,7 +10817,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average count of incremental GC steps (finalize state) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7366,9 +10825,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 226
+                  "y": 218
                },
-               "id": 93,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7398,11 +10857,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_finalize{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_gc_steps_finalize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -7448,7 +10960,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average count of incremental GC steps (sweep state) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7456,9 +10968,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 234
+                  "y": 226
                },
-               "id": 94,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7488,11 +11000,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_sweep{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_gc_steps_sweep"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -7538,7 +11103,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average count of incremental GC steps (propagate state) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7546,9 +11111,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 234
+                  "y": 226
                },
-               "id": 95,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7578,11 +11143,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_propagate{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_gc_steps_propagate"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -7628,7 +11246,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average count of incremental GC steps (pause state) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7636,9 +11254,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 234
+                  "y": 226
                },
-               "id": 96,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7668,11 +11286,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_pause{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_gc_steps_pause"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -7718,7 +11389,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Number of allocated string objects.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7726,9 +11397,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 242
+                  "y": 234
                },
-               "id": 97,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7758,11 +11429,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_strnum{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_gc_strnum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -7808,7 +11526,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Number of allocated table objects.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7816,9 +11534,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 242
+                  "y": 234
                },
-               "id": 98,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7848,11 +11566,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_tabnum{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_gc_tabnum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -7898,7 +11663,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Number of allocated cdata objects.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7906,9 +11671,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 242
+                  "y": 234
                },
-               "id": 99,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7938,11 +11703,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_cdatanum{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_gc_cdatanum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -7988,7 +11800,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Number of allocated userdata objects.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7996,9 +11808,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 242
+                  "y": 234
                },
-               "id": 100,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8028,11 +11840,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_udatanum{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_gc_udatanum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -8078,7 +11937,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Current allocated Lua memory.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -8086,9 +11945,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 250
+                  "y": 242
                },
-               "id": 101,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8118,11 +11977,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_memory{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_gc_memory"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -8168,7 +12074,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average amount of freed Lua memory per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -8176,9 +12082,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 250
+                  "y": 242
                },
-               "id": 102,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8208,11 +12114,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_freed{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_gc_freed"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -8258,7 +12217,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average amount of allocated Lua memory per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -8266,9 +12225,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 250
+                  "y": 242
                },
-               "id": 103,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8298,11 +12257,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_allocated{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_gc_allocated"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -8359,16 +12371,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 258
+            "y": 250
          },
-         "id": 104,
+         "id": 97,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Total count of SELECT requests to all instance spaces.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8376,9 +12388,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 259
+                  "y": 251
                },
-               "id": 105,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8408,11 +12420,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"select\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "select"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -8458,7 +12529,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Total count of INSERT requests to all instance spaces.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8466,9 +12537,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 259
+                  "y": 251
                },
-               "id": 106,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8498,11 +12569,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"insert\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "insert"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -8548,7 +12678,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Total count of REPLACE requests to all instance spaces.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8556,9 +12686,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 259
+                  "y": 251
                },
-               "id": 107,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8588,11 +12718,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"replace\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "replace"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -8638,7 +12827,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Total count of UPSERT requests to all instance spaces.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8646,9 +12835,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 267
+                  "y": 259
                },
-               "id": 108,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8678,11 +12867,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"upsert\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "upsert"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -8728,7 +12976,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Total count of UPDATE requests to all instance spaces.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8736,9 +12984,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 267
+                  "y": 259
                },
-               "id": 109,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8768,11 +13016,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"update\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "update"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -8818,7 +13125,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Total count of DELETE requests to all instance spaces.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8826,9 +13133,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 267
+                  "y": 259
                },
-               "id": 110,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8858,11 +13165,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"delete\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "delete"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -8908,7 +13274,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Requests to execute stored procedures.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8916,9 +13282,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 275
+                  "y": 267
                },
-               "id": 111,
+               "id": 104,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8948,11 +13314,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"call\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "call"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -8998,7 +13423,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Calls to evaluate Lua code.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -9006,9 +13431,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 275
+                  "y": 267
                },
-               "id": 112,
+               "id": 105,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9038,11 +13463,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"eval\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "eval"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -9088,7 +13572,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Requests resulted in error.\nGraph shows average errors per second.\n",
                "fill": 0,
@@ -9096,9 +13580,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 275
+                  "y": 267
                },
-               "id": 113,
+               "id": 106,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9128,11 +13612,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"error\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "error"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -9178,7 +13721,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Authentication requests.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -9186,9 +13729,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 283
+                  "y": 275
                },
-               "id": 114,
+               "id": 107,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9218,11 +13761,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"auth\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "auth"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -9268,7 +13870,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "SQL prepare calls.\nGraph shows average calls per second.\n\nPanel works with Tarantool 2.x.\n",
                "fill": 0,
@@ -9276,9 +13878,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 283
+                  "y": 275
                },
-               "id": 115,
+               "id": 108,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9308,11 +13910,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"prepare\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "prepare"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -9358,7 +14019,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "SQL execute calls.\nGraph shows average calls per second.\n\nPanel works with Tarantool 2.x.\n",
                "fill": 0,
@@ -9366,9 +14027,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 283
+                  "y": 275
                },
-               "id": 116,
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9398,11 +14059,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"execute\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "execute"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -9459,16 +14179,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 291
+            "y": 283
          },
-         "id": 117,
+         "id": 110,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of success SELECT and PAIRS requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -9476,9 +14196,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 292
+                  "y": 284
                },
-               "id": 118,
+               "id": 111,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9508,11 +14228,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"select\",status=\"ok\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "select"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -9558,7 +14349,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of success SELECT and PAIRS CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -9566,9 +14357,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 292
+                  "y": 284
                },
-               "id": 119,
+               "id": 112,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9598,11 +14389,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"select\",status=\"ok\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "select"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -9648,7 +14510,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of error SELECT and PAIRS requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -9656,9 +14518,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 292
+                  "y": 284
                },
-               "id": 120,
+               "id": 113,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9688,11 +14550,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"select\",status=\"error\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "select"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -9738,7 +14671,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of error SELECT and PAIRS CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -9746,9 +14679,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 292
+                  "y": 284
                },
-               "id": 121,
+               "id": 114,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9778,11 +14711,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"select\",status=\"error\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "select"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -9828,17 +14832,17 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
-               "description": "Average number of tuples fetched during SELECT/PAIRS request for a space.\nBoth success and error requests are taken into consideration.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "description": "Average number of tuples fetched during SELECT/PAIRS request for a space.\nBoth success and error requests are taken into consideration.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n\nCurrent value may be 0 from time to time due to fill(0)\nand GROUP BY including partial intervals.\nRefer to https://github.com/influxdata/influxdb/issues/8244\nfor updates.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 300
+                  "y": 292
                },
-               "id": 122,
+               "id": 115,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9868,11 +14872,28 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_tuples_fetched{job=~\"$job\",alias=~\"$alias\", operation=\"select\"}[$__rate_interval]) /\n(sum without (status) (rate(tnt_crud_stats_count{job=~\"$job\",operation=\"select\"}[$__rate_interval])))\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT mean(\"tnt_crud_tuples_fetched\") / (mean(\"tnt_crud_stats_count_ok\") + mean(\"tnt_crud_stats_count_error\"))\nas \"tnt_crud_tuples_per_request\" FROM\n(SELECT \"value\" as \"tnt_crud_tuples_fetched\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tnt_crud_tuples_fetched' AND \"label_pairs_alias\" =~ /^$alias$/\nAND \"label_pairs_operation\" = 'select') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_error\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_alias\" =~ /^$alias$/\nAND \"label_pairs_operation\" = 'select' AND \"label_pairs_status\" = 'error') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_ok\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_alias\" =~ /^$alias$/\nAND \"label_pairs_operation\" = 'select' AND \"label_pairs_status\" = 'ok') AND $timeFilter)\nGROUP BY time($__interval * 2), \"label_pairs_alias\", \"label_pairs_name\" fill(0)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
                   }
                ],
                "thresholds": [ ],
@@ -9918,17 +14939,17 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
-               "description": "Average number of tuples looked up on storages while collecting responses\nfor SELECT/PAIRS requests (including scrolls for multibatch requests)\nfor a space. Both success and error requests are taken into consideration.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "description": "Average number of tuples looked up on storages while collecting responses\nfor SELECT/PAIRS requests (including scrolls for multibatch requests)\nfor a space. Both success and error requests are taken into consideration.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n\nCurrent value may be 0 from time to time due to fill(0)\nand GROUP BY including partial intervals.\nRefer to https://github.com/influxdata/influxdb/issues/8244\nfor updates.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 300
+                  "y": 292
                },
-               "id": 123,
+               "id": 116,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9958,11 +14979,28 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_tuples_lookup{job=~\"$job\",alias=~\"$alias\", operation=\"select\"}[$__rate_interval]) /\n(sum without (status) (rate(tnt_crud_stats_count{job=~\"$job\",operation=\"select\"}[$__rate_interval])))\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT mean(\"tnt_crud_tuples_lookup\") / (mean(\"tnt_crud_stats_count_ok\") + mean(\"tnt_crud_stats_count_error\"))\nas \"tnt_crud_tuples_per_request\" FROM\n(SELECT \"value\" as \"tnt_crud_tuples_lookup\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tnt_crud_tuples_lookup' AND \"label_pairs_alias\" =~ /^$alias$/\nAND \"label_pairs_operation\" = 'select') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_error\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_alias\" =~ /^$alias$/\nAND \"label_pairs_operation\" = 'select' AND \"label_pairs_status\" = 'error') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_ok\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_alias\" =~ /^$alias$/\nAND \"label_pairs_operation\" = 'select' AND \"label_pairs_status\" = 'ok') AND $timeFilter)\nGROUP BY time($__interval * 2), \"label_pairs_alias\", \"label_pairs_name\" fill(0)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
                   }
                ],
                "thresholds": [ ],
@@ -10008,7 +15046,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of SELECT and PAIRS requests that resulted in map reduce.\nGraph shows average requests per second.\nBoth success and error requests are taken into consideration.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -10016,9 +15054,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 300
+                  "y": 292
                },
-               "id": 124,
+               "id": 117,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10048,11 +15086,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_map_reduces{job=~\"$job\",alias=~\"$alias\",operation=\"select\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_map_reduces"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "select"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -10098,7 +15201,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of success insert and insert_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -10106,9 +15209,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 308
+                  "y": 300
                },
-               "id": 125,
+               "id": 118,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10138,11 +15241,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"insert\",status=\"ok\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "insert"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -10188,7 +15362,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of success insert and insert_object CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -10196,9 +15370,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 308
+                  "y": 300
                },
-               "id": 126,
+               "id": 119,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10228,11 +15402,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"insert\",status=\"ok\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "insert"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -10278,7 +15523,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of error insert and insert_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -10286,9 +15531,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 308
+                  "y": 300
                },
-               "id": 127,
+               "id": 120,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10318,11 +15563,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"insert\",status=\"error\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "insert"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -10368,7 +15684,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of error insert and insert_object CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -10376,9 +15692,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 308
+                  "y": 300
                },
-               "id": 128,
+               "id": 121,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10408,11 +15724,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"insert\",status=\"error\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "insert"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -10458,7 +15845,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of success insert_many and insert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -10466,9 +15853,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 316
+                  "y": 308
                },
-               "id": 129,
+               "id": 122,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10498,11 +15885,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"insert_many\",status=\"ok\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "insert_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -10548,7 +16006,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of success insert_many and insert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -10556,9 +16014,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 316
+                  "y": 308
                },
-               "id": 130,
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10588,11 +16046,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"insert_many\",status=\"ok\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "insert_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -10638,7 +16167,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of error insert_many and insert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -10646,9 +16175,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 316
+                  "y": 308
                },
-               "id": 131,
+               "id": 124,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10678,11 +16207,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"insert_many\",status=\"error\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "insert_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -10728,7 +16328,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of error insert_many and insert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -10736,9 +16336,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 316
+                  "y": 308
                },
-               "id": 132,
+               "id": 125,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10768,11 +16368,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"insert_many\",status=\"error\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "insert_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -10818,7 +16489,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of success replace and replace_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -10826,9 +16497,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 324
+                  "y": 316
                },
-               "id": 133,
+               "id": 126,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10858,11 +16529,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"replace\",status=\"ok\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "replace"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -10908,7 +16650,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of success replace and replace_object CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -10916,9 +16658,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 324
+                  "y": 316
                },
-               "id": 134,
+               "id": 127,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10948,11 +16690,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"replace\",status=\"ok\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "replace"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -10998,7 +16811,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of error replace and replace_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -11006,9 +16819,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 324
+                  "y": 316
                },
-               "id": 135,
+               "id": 128,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11038,11 +16851,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"replace\",status=\"error\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "replace"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -11088,7 +16972,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of error replace and replace_object CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -11096,9 +16980,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 324
+                  "y": 316
                },
-               "id": 136,
+               "id": 129,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11128,11 +17012,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"replace\",status=\"error\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "replace"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -11178,7 +17133,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of success replace_many and replace_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -11186,9 +17141,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 332
+                  "y": 324
                },
-               "id": 137,
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11218,11 +17173,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"replace_many\",status=\"ok\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "replace_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -11268,7 +17294,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of success replace_many and replace_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -11276,9 +17302,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 332
+                  "y": 324
                },
-               "id": 138,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11308,11 +17334,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"replace_many\",status=\"ok\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "replace_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -11358,7 +17455,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of error replace_many and replace_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -11366,9 +17463,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 332
+                  "y": 324
                },
-               "id": 139,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11398,11 +17495,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"replace_many\",status=\"error\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "replace_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -11448,7 +17616,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of error replace_many and replace_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -11456,9 +17624,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 332
+                  "y": 324
                },
-               "id": 140,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11488,11 +17656,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"replace_many\",status=\"error\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "replace_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -11538,7 +17777,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of success upsert and upsert_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -11546,9 +17785,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 340
+                  "y": 332
                },
-               "id": 141,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11578,11 +17817,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"upsert\",status=\"ok\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "upsert"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -11628,7 +17938,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of success upsert and upsert_object CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -11636,9 +17946,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 340
+                  "y": 332
                },
-               "id": 142,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11668,11 +17978,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"upsert\",status=\"ok\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "upsert"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -11718,7 +18099,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of error upsert and upsert_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -11726,9 +18107,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 340
+                  "y": 332
                },
-               "id": 143,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11758,11 +18139,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"upsert\",status=\"error\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "upsert"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -11808,7 +18260,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of error upsert and upsert_object CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -11816,9 +18268,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 340
+                  "y": 332
                },
-               "id": 144,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11848,11 +18300,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"upsert\",status=\"error\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "upsert"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -11898,7 +18421,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of success upsert_many and upsert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -11906,9 +18429,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 348
+                  "y": 340
                },
-               "id": 145,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11938,11 +18461,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"upsert_many\",status=\"ok\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "upsert_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -11988,7 +18582,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of success upsert_many and upsert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -11996,9 +18590,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 348
+                  "y": 340
                },
-               "id": 146,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12028,11 +18622,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"upsert_many\",status=\"ok\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "upsert_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -12078,7 +18743,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of error upsert_many and upsert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -12086,9 +18751,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 348
+                  "y": 340
                },
-               "id": 147,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12118,11 +18783,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"upsert_many\",status=\"error\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "upsert_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -12168,7 +18904,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of error upsert_many and upsert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -12176,9 +18912,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 348
+                  "y": 340
                },
-               "id": 148,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12208,11 +18944,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"upsert_many\",status=\"error\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "upsert_many"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -12258,7 +19065,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of success update requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -12266,9 +19073,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 356
+                  "y": 348
                },
-               "id": 149,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12298,11 +19105,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"update\",status=\"ok\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "update"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -12348,7 +19226,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of success update CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -12356,9 +19234,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 356
+                  "y": 348
                },
-               "id": 150,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12388,11 +19266,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"update\",status=\"ok\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "update"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -12438,7 +19387,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of error update requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -12446,9 +19395,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 356
+                  "y": 348
                },
-               "id": 151,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12478,11 +19427,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"update\",status=\"error\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "update"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -12528,7 +19548,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of error update CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -12536,9 +19556,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 356
+                  "y": 348
                },
-               "id": 152,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12568,11 +19588,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"update\",status=\"error\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "update"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -12618,7 +19709,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of success delete requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -12626,9 +19717,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 364
+                  "y": 356
                },
-               "id": 153,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12658,11 +19749,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"delete\",status=\"ok\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "delete"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -12708,7 +19870,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of success delete CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -12716,9 +19878,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 364
+                  "y": 356
                },
-               "id": 154,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12748,11 +19910,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"delete\",status=\"ok\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "delete"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -12798,7 +20031,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of error delete requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -12806,9 +20039,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 364
+                  "y": 356
                },
-               "id": 155,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12838,11 +20071,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"delete\",status=\"error\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "delete"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -12888,7 +20192,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of error delete CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -12896,9 +20200,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 364
+                  "y": 356
                },
-               "id": 156,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12928,11 +20232,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"delete\",status=\"error\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "delete"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -12978,7 +20353,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of success count requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -12986,9 +20361,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 372
+                  "y": 364
                },
-               "id": 157,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13018,11 +20393,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"count\",status=\"ok\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -13068,7 +20514,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of success count CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -13076,9 +20522,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 372
+                  "y": 364
                },
-               "id": 158,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13108,11 +20554,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"count\",status=\"ok\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -13158,7 +20675,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of error count requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -13166,9 +20683,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 372
+                  "y": 364
                },
-               "id": 159,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13198,11 +20715,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"count\",status=\"error\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -13248,7 +20836,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of error count CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -13256,9 +20844,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 372
+                  "y": 364
                },
-               "id": 160,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13288,11 +20876,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"count\",status=\"error\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -13338,7 +20997,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of success get requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -13346,9 +21005,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 380
+                  "y": 372
                },
-               "id": 161,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13378,11 +21037,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"get\",status=\"ok\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "get"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -13428,7 +21158,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of success get CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -13436,9 +21166,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 380
+                  "y": 372
                },
-               "id": 162,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13468,11 +21198,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"get\",status=\"ok\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "get"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -13518,7 +21319,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of error get requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -13526,9 +21327,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 380
+                  "y": 372
                },
-               "id": 163,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13558,11 +21359,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"get\",status=\"error\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "get"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -13608,7 +21480,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of error get CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -13616,9 +21488,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 380
+                  "y": 372
                },
-               "id": 164,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13648,11 +21520,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"get\",status=\"error\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "get"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -13698,7 +21641,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of success MIN and MAX requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -13706,9 +21649,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 388
+                  "y": 380
                },
-               "id": 165,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13738,11 +21681,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"borders\",status=\"ok\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "borders"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -13788,7 +21802,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of success MIN and MAX CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -13796,9 +21810,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 388
+                  "y": 380
                },
-               "id": 166,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13828,11 +21842,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"borders\",status=\"ok\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "borders"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -13878,7 +21963,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of error MIN and MAX requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -13886,9 +21971,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 388
+                  "y": 380
                },
-               "id": 167,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13918,11 +22003,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"borders\",status=\"error\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "borders"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -13968,7 +22124,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of error MIN and MAX CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -13976,9 +22132,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 388
+                  "y": 380
                },
-               "id": 168,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14008,11 +22164,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"borders\",status=\"error\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "borders"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -14058,7 +22285,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of success len requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -14066,9 +22293,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 396
+                  "y": 388
                },
-               "id": 169,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14098,11 +22325,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"len\",status=\"ok\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "len"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -14148,7 +22446,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of success len CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -14156,9 +22454,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 396
+                  "y": 388
                },
-               "id": 170,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14188,11 +22486,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"len\",status=\"ok\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "len"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -14238,7 +22607,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of error len requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -14246,9 +22615,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 396
+                  "y": 388
                },
-               "id": 171,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14278,11 +22647,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"len\",status=\"error\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "len"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -14328,7 +22768,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of error len CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -14336,9 +22776,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 396
+                  "y": 388
                },
-               "id": 172,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14368,11 +22808,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"len\",status=\"error\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "len"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -14418,7 +22929,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of success truncate requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -14426,9 +22937,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 404
+                  "y": 396
                },
-               "id": 173,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14458,11 +22969,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"truncate\",status=\"ok\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "truncate"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -14508,7 +23090,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of success truncate CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -14516,9 +23098,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 404
+                  "y": 396
                },
-               "id": 174,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14548,11 +23130,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"truncate\",status=\"ok\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "truncate"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "ok"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -14598,7 +23251,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "Total count of error truncate requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -14606,9 +23259,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 404
+                  "y": 396
                },
-               "id": 175,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14638,11 +23291,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"truncate\",status=\"error\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "truncate"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -14688,7 +23412,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 2,
                "description": "99th percentile of error truncate CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -14696,9 +23420,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 404
+                  "y": 396
                },
-               "id": 176,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14728,11 +23452,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"truncate\",status=\"error\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "truncate"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "error"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -14789,16 +23584,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 412
+            "y": 404
          },
-         "id": 177,
+         "id": 170,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "A number of task tuples checked for expiration (expired + skipped).\nGraph shows mean tuples per second.\n",
                "fill": 0,
@@ -14806,9 +23601,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 413
+                  "y": 405
                },
-               "id": 178,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14838,11 +23633,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(expirationd_checked_count{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "expirationd_checked_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -14888,7 +23742,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "A number of task expired tuples.\nGraph shows mean tuples per second.\n",
                "fill": 0,
@@ -14896,9 +23750,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 413
+                  "y": 405
                },
-               "id": 179,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14928,11 +23782,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(expirationd_expired_count{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "expirationd_expired_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -14978,7 +23891,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "A number of task restarts since start.\nFrom the start is equal to 1.\n",
                "fill": 0,
@@ -14986,9 +23899,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 421
+                  "y": 413
                },
-               "id": 180,
+               "id": 173,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15018,11 +23931,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "expirationd_restarts{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "expirationd_restarts"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -15068,7 +24034,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "A task's operation time.\n",
                "fill": 0,
@@ -15076,9 +24042,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 421
+                  "y": 413
                },
-               "id": 181,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15108,11 +24074,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "expirationd_working_time{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "expirationd_working_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -15161,296 +24180,6 @@
          "title": "expirationd module statistics",
          "titleSize": "h6",
          "type": "row"
-      },
-      {
-         "collapse": true,
-         "collapsed": true,
-         "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 429
-         },
-         "id": 182,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 3,
-               "description": "My custom component could have 3 statuses:\ncode 2 is OK, code 1 is suspended process, code 0 means issues in component.\n",
-               "fill": 0,
-               "gridPos": {
-                  "h": 6,
-                  "w": 24,
-                  "x": 0,
-                  "y": 430
-               },
-               "id": 183,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "my_component_status{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "My custom component status",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "decimals": 0,
-                     "format": "none",
-                     "label": "requests per second",
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "decimals": 3,
-                     "format": "none",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 3,
-               "description": "My custom component processes requests\nand collects info on process to summary collector\n'my_component_load_metric'.\n",
-               "fill": 0,
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 0,
-                  "y": 436
-               },
-               "id": 184,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "rate(my_component_load_metric_count{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "My custom component load",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "decimals": 0,
-                     "format": "none",
-                     "label": "requests per second",
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "decimals": 3,
-                     "format": "none",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 3,
-               "description": "My custom component processes requests\nand collects info on process to summary collector\n'my_component_load_metric'.\n",
-               "fill": 0,
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 12,
-                  "y": 436
-               },
-               "id": 185,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "my_component_load_metric{job=~\"$job\",alias=~\"$alias\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "My custom component process",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "decimals": 0,
-                     "format": "s",
-                     "label": "process time",
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Tarantool network activity",
-         "titleSize": "h6",
-         "type": "row"
       }
    ],
    "refresh": "30s",
@@ -15465,38 +24194,17 @@
          {
             "allValue": null,
             "current": {
-               "text": "${PROMETHEUS_JOB}",
-               "value": "${PROMETHEUS_JOB}"
-            },
-            "hide": 2,
-            "includeAll": false,
-            "label": "Prometheus job",
-            "multi": false,
-            "name": "job",
-            "options": [
-               {
-                  "text": "${PROMETHEUS_JOB}",
-                  "value": "${PROMETHEUS_JOB}"
-               }
-            ],
-            "query": "${PROMETHEUS_JOB}",
-            "refresh": 0,
-            "type": "custom"
-         },
-         {
-            "allValue": null,
-            "current": {
                "text": "all",
                "value": "$__all"
             },
-            "datasource": "${DS_PROMETHEUS}",
+            "datasource": "influxdb",
             "hide": 0,
             "includeAll": true,
             "label": "Instances",
             "multi": true,
             "name": "alias",
             "options": [ ],
-            "query": "label_values(tnt_info_uptime{job=~\"$job\"},alias)",
+            "query": "SHOW TAG VALUES FROM \"autogen\".\"tarantool_http\" WITH KEY=\"label_pairs_alias\"",
             "refresh": 2,
             "regex": "",
             "sort": 0,

--- a/tests/InfluxDB/dashboard_tdg_compiled.json
+++ b/tests/InfluxDB/dashboard_tdg_compiled.json
@@ -169,6 +169,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_level",
                            "operator": "=",
                            "value": "warning"
@@ -303,6 +309,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_cartridge_issues"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -506,6 +518,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_replication_status"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -656,6 +674,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_read_only"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -757,6 +781,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_replication_lag"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -891,6 +921,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_clock_delta"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -1040,6 +1076,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_info_memory_net"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -1177,6 +1219,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_received_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -1314,6 +1362,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_sent_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -1451,6 +1505,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -1582,6 +1642,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -1719,6 +1785,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_in_progress_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -1850,6 +1922,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_in_progress_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -1987,6 +2065,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_in_stream_queue_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -2118,6 +2202,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_in_stream_queue_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -2255,6 +2345,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_connections_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -2386,6 +2482,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_connections_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -2551,6 +2653,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_quota_used_ratio"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -2682,6 +2790,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_arena_used_ratio"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -2813,6 +2927,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_items_used_ratio"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -2944,6 +3064,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_quota_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -3075,6 +3201,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_arena_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -3206,6 +3338,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_items_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -3337,6 +3475,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_quota_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -3468,6 +3612,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_arena_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -3599,6 +3749,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_items_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -3759,6 +3915,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_engine",
                            "operator": "=",
                            "value": "memtx"
@@ -3902,6 +4064,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_engine",
                            "operator": "=",
                            "value": "vinyl"
@@ -4042,6 +4210,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_space_bsize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -4191,6 +4365,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_space_index_bsize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -4328,6 +4508,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_space_total_bsize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -4485,6 +4671,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_disk_data_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -4616,6 +4808,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_disk_index_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -4747,6 +4945,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_memory_tuple_cache"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -4878,6 +5082,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_memory_page_index"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -5009,6 +5219,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_memory_bloom_filter"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -5140,6 +5356,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_regulator_dump_bandwidth"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -5271,6 +5493,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_regulator_write_rate"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -5402,6 +5630,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_regulator_rate_limit"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -5533,6 +5767,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_memory_level0"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -5664,6 +5904,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_regulator_dump_watermark"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -5795,6 +6041,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_regulator_blocked_writers"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -5932,6 +6184,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_tx_commit"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -6069,6 +6327,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_tx_rollback"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -6206,6 +6470,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_tx_conflict"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -6337,6 +6607,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_tx_read_views"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -6468,6 +6744,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_scheduler_tasks"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -6614,6 +6896,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_status",
                            "operator": "=",
                            "value": "failed"
@@ -6754,6 +7042,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_scheduler_dump_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -6891,6 +7185,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_scheduler_dump_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -7048,6 +7348,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_cpu_user_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -7185,6 +7491,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_cpu_system_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -7328,6 +7640,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_cpu_thread"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -7477,6 +7795,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_cpu_thread"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -7634,6 +7958,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_info_memory_lua"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -7765,6 +8095,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_runtime_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -7896,6 +8232,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_info_memory_tx"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -8027,6 +8369,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_fiber_csw"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -8158,6 +8506,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_ev_loop_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -8289,6 +8643,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_fiber_amount"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -8420,6 +8780,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_fiber_memused"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -8551,6 +8917,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_fiber_memalloc"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -8708,6 +9080,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_jit_snap_restore"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -8845,6 +9223,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_jit_trace_num"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -8982,6 +9366,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_jit_trace_abort"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -9113,6 +9503,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_jit_mcode_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -9250,6 +9646,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_strhash_hit"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -9387,6 +9789,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_strhash_miss"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -9524,6 +9932,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_atomic"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -9661,6 +10075,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_sweepstring"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -9798,6 +10218,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_finalize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -9935,6 +10361,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_sweep"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -10072,6 +10504,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_propagate"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -10209,6 +10647,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_pause"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -10340,6 +10784,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_strnum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -10471,6 +10921,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_tabnum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -10602,6 +11058,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_cdatanum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -10733,6 +11195,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_udatanum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -10864,6 +11332,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_memory"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -11001,6 +11475,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_freed"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -11138,6 +11618,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_allocated"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -11298,6 +11784,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "select"
@@ -11438,6 +11930,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -11584,6 +12082,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "replace"
@@ -11724,6 +12228,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -11870,6 +12380,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "update"
@@ -12010,6 +12526,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -12156,6 +12678,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "call"
@@ -12296,6 +12824,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -12442,6 +12976,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "error"
@@ -12582,6 +13122,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -12728,6 +13274,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "prepare"
@@ -12868,6 +13420,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -13043,6 +13601,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_replyq"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -13192,6 +13756,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_msg_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -13341,6 +13911,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_msg_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -13496,6 +14072,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_tx"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -13651,6 +14233,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_tx_bytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -13806,6 +14394,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_rx"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -13961,6 +14555,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_rx_bytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -14116,6 +14716,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_txmsgs"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -14271,6 +14877,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_txmsg_bytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -14426,6 +15038,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_rxmsgs"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -14581,6 +15199,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_rxmsg_bytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -14756,6 +15380,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_stateage"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -14917,6 +15547,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_connects"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -15078,6 +15714,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_disconnects"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -15239,6 +15881,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_wakeups"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -15394,6 +16042,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_outbuf_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -15549,6 +16203,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_outbuf_msg_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -15704,6 +16364,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_waitresp_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -15859,6 +16525,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_waitresp_msg_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -16020,6 +16692,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_tx"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -16181,6 +16859,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_txbytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -16342,6 +17026,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_txerrs"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -16503,6 +17193,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_txretries"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -16658,6 +17354,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_txidle"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -16819,6 +17521,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_req_timeouts"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -16980,6 +17688,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_rx"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -17141,6 +17855,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_rxbytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -17302,6 +18022,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_rxerrs"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -17463,6 +18189,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_rxcorriderrs"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -17618,6 +18350,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_rxidle"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -17779,6 +18517,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_rxpartial"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -17946,6 +18690,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_req"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -18101,6 +18851,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_int_latency"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -18265,6 +19021,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_quantile",
                            "operator": "=",
                            "value": "0.99"
@@ -18426,6 +19188,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_quantile",
                            "operator": "=",
                            "value": "0.99"
@@ -18584,6 +19352,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_throttle"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -18765,6 +19539,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_age"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -18920,6 +19700,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_metadata_age"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -19075,6 +19861,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_batchsize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -19236,6 +20028,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_batchcnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -19403,6 +20201,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_partitions_msgq_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -19564,6 +20368,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_partitions_xmit_msgq_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -19725,6 +20535,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_partitions_fetchq_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -19886,6 +20702,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_partitions_msgq_bytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -20047,6 +20869,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_partitions_xmit_msgq_bytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -20208,6 +21036,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_partitions_fetchq_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -20375,6 +21209,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_partitions_txmsgs"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -20542,6 +21382,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_partitions_txbytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -20709,6 +21555,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_partitions_rxmsgs"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -20876,6 +21728,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_partitions_rxbytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -21043,6 +21901,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_partitions_rx_ver_drops"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -21204,6 +22068,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_partitions_msgs_inflight"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -21373,6 +22243,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_cgrp_stateage"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -21522,6 +22398,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_cgrp_rebalance_age"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -21677,6 +22559,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_cgrp_rebalance_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -21826,6 +22714,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_cgrp_assignment_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -21995,6 +22889,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_eos_idemp_stateage"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -22144,6 +23044,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_eos_txn_stateage"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -22307,6 +23213,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_expiration_checked_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -22450,6 +23362,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_expiration_expired_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -22587,6 +23505,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_expiration_restarts"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -22724,6 +23648,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_expiration_working_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -23089,6 +24019,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_scanned_tuples_max"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -23220,6 +24156,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_returned_tuples_max"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -23377,6 +24319,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_connector_input_file_processed_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -23514,6 +24462,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_connector_input_file_processed_objects_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -23651,6 +24605,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_connector_input_file_failed_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -23788,6 +24748,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_connector_input_file_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -23925,6 +24891,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_connector_input_file_current_bytes_processed"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -24062,6 +25034,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_connector_input_file_current_processed_objects"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -24340,7 +25318,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_graphql_query_time_sum\") / mean(\"tdg_graphql_query_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_graphql_query_time_sum\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_graphql_query_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_graphql_query_time_count\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_graphql_query_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_operation_name\",\n\"label_pairs_schema\", \"label_pairs_entity\" fill(null)\n",
+                     "query": "SELECT mean(\"tdg_graphql_query_time_sum\") / mean(\"tdg_graphql_query_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_graphql_query_time_sum\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_graphql_query_time_sum' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter),\n(SELECT \"value\" as \"tdg_graphql_query_time_count\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_graphql_query_time_count' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_operation_name\",\n\"label_pairs_schema\", \"label_pairs_entity\" fill(null)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -24757,7 +25735,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_graphql_mutation_time_sum\") / mean(\"tdg_graphql_mutation_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_graphql_mutation_time_sum\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_graphql_mutation_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_graphql_mutation_time_count\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_graphql_mutation_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_operation_name\",\n\"label_pairs_schema\", \"label_pairs_entity\" fill(null)\n",
+                     "query": "SELECT mean(\"tdg_graphql_mutation_time_sum\") / mean(\"tdg_graphql_mutation_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_graphql_mutation_time_sum\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_graphql_mutation_time_sum' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter),\n(SELECT \"value\" as \"tdg_graphql_mutation_time_count\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_graphql_mutation_time_count' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_operation_name\",\n\"label_pairs_schema\", \"label_pairs_entity\" fill(null)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -25082,6 +26060,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "=",
                            "value": "repository.put"
@@ -25222,6 +26206,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -25380,6 +26370,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "=",
                            "value": "repository.put_batch"
@@ -25520,6 +26516,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -25678,6 +26680,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "=",
                            "value": "repository.find"
@@ -25818,6 +26826,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -25976,6 +26990,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "=",
                            "value": "repository.update"
@@ -26116,6 +27136,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -26274,6 +27300,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "=",
                            "value": "repository.get"
@@ -26414,6 +27446,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -26572,6 +27610,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "=",
                            "value": "repository.delete"
@@ -26712,6 +27756,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -26870,6 +27920,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "=",
                            "value": "repository.count"
@@ -27010,6 +28066,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -27168,6 +28230,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "=",
                            "value": "repository.map_reduce"
@@ -27308,6 +28376,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -27466,6 +28540,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "=",
                            "value": "repository.call_on_storage"
@@ -27606,6 +28686,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -27796,6 +28882,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "=",
                            "value": "GET"
@@ -27960,6 +29052,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_rest_exec_time_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -28130,6 +29228,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "=",
                            "value": "GET"
@@ -28288,6 +29392,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_rest_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -28458,6 +29568,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "=",
                            "value": "GET"
@@ -28622,6 +29738,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_rest_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -28798,6 +29920,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "!=",
                            "value": "GET"
@@ -28962,6 +30090,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_rest_exec_time_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -29132,6 +30266,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "!=",
                            "value": "GET"
@@ -29290,6 +30430,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_rest_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -29460,6 +30606,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "!=",
                            "value": "GET"
@@ -29624,6 +30776,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_rest_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -29811,6 +30969,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_jobs_started"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -29960,6 +31124,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_jobs_failed"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -30109,6 +31279,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_jobs_succeeded"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -30252,6 +31428,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_jobs_running"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -30355,7 +31537,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_jobs_execution_time_sum\") / mean(\"tdg_jobs_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_jobs_execution_time_sum\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_jobs_execution_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_jobs_execution_time_count\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_jobs_execution_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\" fill(null)\n",
+                     "query": "SELECT mean(\"tdg_jobs_execution_time_sum\") / mean(\"tdg_jobs_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_jobs_execution_time_sum\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_jobs_execution_time_sum' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter),\n(SELECT \"value\" as \"tdg_jobs_execution_time_count\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_jobs_execution_time_count' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\" fill(null)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -30508,6 +31690,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_tasks_started"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -30657,6 +31845,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_tasks_failed"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -30806,6 +32000,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_tasks_succeeded"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -30955,6 +32155,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_tasks_stopped"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -31098,6 +32304,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_tasks_running"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -31201,7 +32413,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_tasks_execution_time_sum\") / mean(\"tdg_tasks_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_tasks_execution_time_sum\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_tasks_execution_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_tasks_execution_time_count\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_tasks_execution_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\",\n\"label_pairs_kind\" fill(null)\n",
+                     "query": "SELECT mean(\"tdg_tasks_execution_time_sum\") / mean(\"tdg_tasks_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_tasks_execution_time_sum\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_tasks_execution_time_sum' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter),\n(SELECT \"value\" as \"tdg_tasks_execution_time_count\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_tasks_execution_time_count' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\",\n\"label_pairs_kind\" fill(null)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -31354,6 +32566,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_system_tasks_started"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -31503,6 +32721,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_system_tasks_failed"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -31652,6 +32876,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_system_tasks_succeeded"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -31795,6 +33025,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_system_tasks_running"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -31898,7 +33134,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_system_tasks_execution_time_sum\") / mean(\"tdg_system_tasks_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_system_tasks_execution_time_sum\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_system_tasks_execution_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_system_tasks_execution_time_count\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_system_tasks_execution_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\",\n\"label_pairs_kind\" fill(null)\n",
+                     "query": "SELECT mean(\"tdg_system_tasks_execution_time_sum\") / mean(\"tdg_system_tasks_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_system_tasks_execution_time_sum\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_system_tasks_execution_time_sum' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter),\n(SELECT \"value\" as \"tdg_system_tasks_execution_time_count\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tdg_system_tasks_execution_time_count' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\",\n\"label_pairs_kind\" fill(null)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -31962,7 +33198,31 @@
       "tarantool"
    ],
    "templating": {
-      "list": [ ]
+      "list": [
+         {
+            "allValue": null,
+            "current": {
+               "text": "all",
+               "value": "$__all"
+            },
+            "datasource": "${DS_INFLUXDB}",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Instances",
+            "multi": true,
+            "name": "alias",
+            "options": [ ],
+            "query": "SHOW TAG VALUES FROM \"${INFLUXDB_MEASUREMENT}\" WITH KEY=\"label_pairs_alias\"",
+            "refresh": 2,
+            "regex": "",
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         }
+      ]
    },
    "time": {
       "from": "now-3h",

--- a/tests/InfluxDB/dashboard_tdg_static_compiled.json
+++ b/tests/InfluxDB/dashboard_tdg_static_compiled.json
@@ -146,6 +146,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_level",
                            "operator": "=",
                            "value": "warning"
@@ -280,6 +286,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_cartridge_issues"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -483,6 +495,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_replication_status"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -633,6 +651,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_read_only"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -734,6 +758,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_replication_lag"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -868,6 +898,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_clock_delta"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -1017,6 +1053,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_info_memory_net"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -1154,6 +1196,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_received_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -1291,6 +1339,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_sent_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -1428,6 +1482,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -1559,6 +1619,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -1696,6 +1762,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_in_progress_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -1827,6 +1899,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_in_progress_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -1964,6 +2042,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_in_stream_queue_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -2095,6 +2179,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_in_stream_queue_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -2232,6 +2322,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_connections_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -2363,6 +2459,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_connections_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -2528,6 +2630,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_quota_used_ratio"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -2659,6 +2767,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_arena_used_ratio"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -2790,6 +2904,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_items_used_ratio"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -2921,6 +3041,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_quota_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -3052,6 +3178,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_arena_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -3183,6 +3315,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_items_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -3314,6 +3452,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_quota_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -3445,6 +3589,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_arena_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -3576,6 +3726,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_items_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -3736,6 +3892,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_engine",
                            "operator": "=",
                            "value": "memtx"
@@ -3879,6 +4041,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_engine",
                            "operator": "=",
                            "value": "vinyl"
@@ -4019,6 +4187,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_space_bsize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -4168,6 +4342,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_space_index_bsize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -4305,6 +4485,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_space_total_bsize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -4462,6 +4648,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_disk_data_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -4593,6 +4785,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_disk_index_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -4724,6 +4922,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_memory_tuple_cache"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -4855,6 +5059,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_memory_page_index"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -4986,6 +5196,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_memory_bloom_filter"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -5117,6 +5333,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_regulator_dump_bandwidth"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -5248,6 +5470,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_regulator_write_rate"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -5379,6 +5607,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_regulator_rate_limit"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -5510,6 +5744,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_memory_level0"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -5641,6 +5881,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_regulator_dump_watermark"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -5772,6 +6018,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_regulator_blocked_writers"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -5909,6 +6161,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_tx_commit"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -6046,6 +6304,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_tx_rollback"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -6183,6 +6447,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_tx_conflict"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -6314,6 +6584,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_tx_read_views"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -6445,6 +6721,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_scheduler_tasks"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -6591,6 +6873,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_status",
                            "operator": "=",
                            "value": "failed"
@@ -6731,6 +7019,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_scheduler_dump_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -6868,6 +7162,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_scheduler_dump_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -7025,6 +7325,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_cpu_user_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -7162,6 +7468,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_cpu_system_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -7305,6 +7617,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_cpu_thread"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -7454,6 +7772,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_cpu_thread"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -7611,6 +7935,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_info_memory_lua"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -7742,6 +8072,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_runtime_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -7873,6 +8209,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_info_memory_tx"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -8004,6 +8346,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_fiber_csw"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -8135,6 +8483,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_ev_loop_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -8266,6 +8620,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_fiber_amount"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -8397,6 +8757,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_fiber_memused"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -8528,6 +8894,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_fiber_memalloc"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -8685,6 +9057,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_jit_snap_restore"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -8822,6 +9200,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_jit_trace_num"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -8959,6 +9343,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_jit_trace_abort"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -9090,6 +9480,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_jit_mcode_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -9227,6 +9623,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_strhash_hit"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -9364,6 +9766,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_strhash_miss"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -9501,6 +9909,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_atomic"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -9638,6 +10052,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_sweepstring"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -9775,6 +10195,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_finalize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -9912,6 +10338,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_sweep"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -10049,6 +10481,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_propagate"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -10186,6 +10624,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_pause"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -10317,6 +10761,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_strnum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -10448,6 +10898,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_tabnum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -10579,6 +11035,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_cdatanum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -10710,6 +11172,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_udatanum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -10841,6 +11309,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_memory"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -10978,6 +11452,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_freed"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -11115,6 +11595,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_allocated"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -11275,6 +11761,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "select"
@@ -11415,6 +11907,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -11561,6 +12059,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "replace"
@@ -11701,6 +12205,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -11847,6 +12357,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "update"
@@ -11987,6 +12503,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -12133,6 +12655,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "call"
@@ -12273,6 +12801,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -12419,6 +12953,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "error"
@@ -12559,6 +13099,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -12705,6 +13251,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "prepare"
@@ -12845,6 +13397,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -13020,6 +13578,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_replyq"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -13169,6 +13733,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_msg_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -13318,6 +13888,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_msg_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -13473,6 +14049,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_tx"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -13628,6 +14210,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_tx_bytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -13783,6 +14371,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_rx"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -13938,6 +14532,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_rx_bytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -14093,6 +14693,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_txmsgs"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -14248,6 +14854,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_txmsg_bytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -14403,6 +15015,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_rxmsgs"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -14558,6 +15176,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_rxmsg_bytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -14733,6 +15357,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_stateage"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -14894,6 +15524,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_connects"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -15055,6 +15691,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_disconnects"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -15216,6 +15858,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_wakeups"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -15371,6 +16019,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_outbuf_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -15526,6 +16180,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_outbuf_msg_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -15681,6 +16341,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_waitresp_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -15836,6 +16502,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_waitresp_msg_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -15997,6 +16669,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_tx"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -16158,6 +16836,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_txbytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -16319,6 +17003,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_txerrs"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -16480,6 +17170,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_txretries"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -16635,6 +17331,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_txidle"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -16796,6 +17498,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_req_timeouts"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -16957,6 +17665,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_rx"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -17118,6 +17832,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_rxbytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -17279,6 +17999,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_rxerrs"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -17440,6 +18166,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_rxcorriderrs"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -17595,6 +18327,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_rxidle"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -17756,6 +18494,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_rxpartial"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -17923,6 +18667,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_req"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -18078,6 +18828,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_int_latency"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -18242,6 +18998,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_quantile",
                            "operator": "=",
                            "value": "0.99"
@@ -18403,6 +19165,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_quantile",
                            "operator": "=",
                            "value": "0.99"
@@ -18561,6 +19329,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_broker_throttle"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -18742,6 +19516,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_age"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -18897,6 +19677,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_metadata_age"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -19052,6 +19838,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_batchsize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -19213,6 +20005,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_batchcnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -19380,6 +20178,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_partitions_msgq_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -19541,6 +20345,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_partitions_xmit_msgq_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -19702,6 +20512,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_partitions_fetchq_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -19863,6 +20679,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_partitions_msgq_bytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -20024,6 +20846,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_partitions_xmit_msgq_bytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -20185,6 +21013,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_partitions_fetchq_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -20352,6 +21186,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_partitions_txmsgs"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -20519,6 +21359,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_partitions_txbytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -20686,6 +21532,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_partitions_rxmsgs"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -20853,6 +21705,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_partitions_rxbytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -21020,6 +21878,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_partitions_rx_ver_drops"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -21181,6 +22045,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_topic_partitions_msgs_inflight"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -21350,6 +22220,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_cgrp_stateage"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -21499,6 +22375,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_cgrp_rebalance_age"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -21654,6 +22536,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_cgrp_rebalance_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -21803,6 +22691,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_cgrp_assignment_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -21972,6 +22866,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_eos_idemp_stateage"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -22121,6 +23021,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_kafka_eos_txn_stateage"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -22284,6 +23190,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_expiration_checked_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -22427,6 +23339,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_expiration_expired_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -22564,6 +23482,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_expiration_restarts"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -22701,6 +23625,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_expiration_working_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -23066,6 +23996,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_scanned_tuples_max"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -23197,6 +24133,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_returned_tuples_max"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -23354,6 +24296,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_connector_input_file_processed_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -23491,6 +24439,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_connector_input_file_processed_objects_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -23628,6 +24582,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_connector_input_file_failed_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -23765,6 +24725,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_connector_input_file_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -23902,6 +24868,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_connector_input_file_current_bytes_processed"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -24039,6 +25011,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_connector_input_file_current_processed_objects"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -24317,7 +25295,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_graphql_query_time_sum\") / mean(\"tdg_graphql_query_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_graphql_query_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_query_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_graphql_query_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_query_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_operation_name\",\n\"label_pairs_schema\", \"label_pairs_entity\" fill(null)\n",
+                     "query": "SELECT mean(\"tdg_graphql_query_time_sum\") / mean(\"tdg_graphql_query_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_graphql_query_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_query_time_sum' AND \"label_pairs_alias\" =~ /^.*$/)\nAND $timeFilter),\n(SELECT \"value\" as \"tdg_graphql_query_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_query_time_count' AND \"label_pairs_alias\" =~ /^.*$/)\nAND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_operation_name\",\n\"label_pairs_schema\", \"label_pairs_entity\" fill(null)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -24734,7 +25712,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_graphql_mutation_time_sum\") / mean(\"tdg_graphql_mutation_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_graphql_mutation_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_mutation_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_graphql_mutation_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_mutation_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_operation_name\",\n\"label_pairs_schema\", \"label_pairs_entity\" fill(null)\n",
+                     "query": "SELECT mean(\"tdg_graphql_mutation_time_sum\") / mean(\"tdg_graphql_mutation_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_graphql_mutation_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_mutation_time_sum' AND \"label_pairs_alias\" =~ /^.*$/)\nAND $timeFilter),\n(SELECT \"value\" as \"tdg_graphql_mutation_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_mutation_time_count' AND \"label_pairs_alias\" =~ /^.*$/)\nAND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_operation_name\",\n\"label_pairs_schema\", \"label_pairs_entity\" fill(null)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -25059,6 +26037,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "=",
                            "value": "repository.put"
@@ -25199,6 +26183,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -25357,6 +26347,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "=",
                            "value": "repository.put_batch"
@@ -25497,6 +26493,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -25655,6 +26657,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "=",
                            "value": "repository.find"
@@ -25795,6 +26803,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -25953,6 +26967,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "=",
                            "value": "repository.update"
@@ -26093,6 +27113,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -26251,6 +27277,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "=",
                            "value": "repository.get"
@@ -26391,6 +27423,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -26549,6 +27587,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "=",
                            "value": "repository.delete"
@@ -26689,6 +27733,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -26847,6 +27897,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "=",
                            "value": "repository.count"
@@ -26987,6 +28043,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -27145,6 +28207,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "=",
                            "value": "repository.map_reduce"
@@ -27285,6 +28353,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -27443,6 +28517,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "=",
                            "value": "repository.call_on_storage"
@@ -27583,6 +28663,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -27773,6 +28859,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "=",
                            "value": "GET"
@@ -27937,6 +29029,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_rest_exec_time_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -28107,6 +29205,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "=",
                            "value": "GET"
@@ -28265,6 +29369,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_rest_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -28435,6 +29545,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "=",
                            "value": "GET"
@@ -28599,6 +29715,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_rest_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -28775,6 +29897,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "!=",
                            "value": "GET"
@@ -28939,6 +30067,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_rest_exec_time_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -29109,6 +30243,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "!=",
                            "value": "GET"
@@ -29267,6 +30407,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_rest_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -29437,6 +30583,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_method",
                            "operator": "!=",
                            "value": "GET"
@@ -29601,6 +30753,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_rest_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         },
                         {
                            "condition": "AND",
@@ -29788,6 +30946,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_jobs_started"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -29937,6 +31101,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_jobs_failed"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -30086,6 +31256,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_jobs_succeeded"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -30229,6 +31405,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_jobs_running"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -30332,7 +31514,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_jobs_execution_time_sum\") / mean(\"tdg_jobs_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_jobs_execution_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_jobs_execution_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_jobs_execution_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_jobs_execution_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\" fill(null)\n",
+                     "query": "SELECT mean(\"tdg_jobs_execution_time_sum\") / mean(\"tdg_jobs_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_jobs_execution_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_jobs_execution_time_sum' AND \"label_pairs_alias\" =~ /^.*$/)\nAND $timeFilter),\n(SELECT \"value\" as \"tdg_jobs_execution_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_jobs_execution_time_count' AND \"label_pairs_alias\" =~ /^.*$/)\nAND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\" fill(null)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -30485,6 +31667,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_tasks_started"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -30634,6 +31822,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_tasks_failed"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -30783,6 +31977,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_tasks_succeeded"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -30932,6 +32132,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_tasks_stopped"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -31075,6 +32281,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_tasks_running"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -31178,7 +32390,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_tasks_execution_time_sum\") / mean(\"tdg_tasks_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_tasks_execution_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_tasks_execution_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_tasks_execution_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_tasks_execution_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\",\n\"label_pairs_kind\" fill(null)\n",
+                     "query": "SELECT mean(\"tdg_tasks_execution_time_sum\") / mean(\"tdg_tasks_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_tasks_execution_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_tasks_execution_time_sum' AND \"label_pairs_alias\" =~ /^.*$/)\nAND $timeFilter),\n(SELECT \"value\" as \"tdg_tasks_execution_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_tasks_execution_time_count' AND \"label_pairs_alias\" =~ /^.*$/)\nAND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\",\n\"label_pairs_kind\" fill(null)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -31331,6 +32543,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_system_tasks_started"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -31480,6 +32698,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_system_tasks_failed"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -31629,6 +32853,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_system_tasks_succeeded"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -31772,6 +33002,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tdg_system_tasks_running"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^.*$/"
                         }
                      ]
                   }
@@ -31875,7 +33111,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_system_tasks_execution_time_sum\") / mean(\"tdg_system_tasks_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_system_tasks_execution_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_system_tasks_execution_time_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_system_tasks_execution_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_system_tasks_execution_time_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\",\n\"label_pairs_kind\" fill(null)\n",
+                     "query": "SELECT mean(\"tdg_system_tasks_execution_time_sum\") / mean(\"tdg_system_tasks_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_system_tasks_execution_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_system_tasks_execution_time_sum' AND \"label_pairs_alias\" =~ /^.*$/)\nAND $timeFilter),\n(SELECT \"value\" as \"tdg_system_tasks_execution_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_system_tasks_execution_time_count' AND \"label_pairs_alias\" =~ /^.*$/)\nAND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\",\n\"label_pairs_kind\" fill(null)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",

--- a/tests/InfluxDB/dashboard_tdg_static_with_instance_variable.sh
+++ b/tests/InfluxDB/dashboard_tdg_static_with_instance_variable.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+make DATASOURCE=influxdb \
+     POLICY=autogen \
+     MEASUREMENT=tarantool_http \
+     WITH_INSTANCE_VARIABLE=TRUE \
+     build-static-tdg-influxdb

--- a/tests/InfluxDB/dashboard_tdg_static_with_instance_variable_compiled.json
+++ b/tests/InfluxDB/dashboard_tdg_static_with_instance_variable_compiled.json
@@ -1,21 +1,5 @@
 {
-   "__inputs": [
-      {
-         "description": "Prometheus Tarantool metrics bank",
-         "label": "Prometheus",
-         "name": "DS_PROMETHEUS",
-         "pluginId": "prometheus",
-         "pluginName": "Prometheus",
-         "type": "datasource"
-      },
-      {
-         "description": "Prometheus Tarantool metrics job",
-         "label": "Job",
-         "name": "PROMETHEUS_JOB",
-         "type": "constant",
-         "value": "tarantool"
-      }
-   ],
+   "__inputs": [ ],
    "__requires": [
       {
          "id": "grafana",
@@ -42,20 +26,8 @@
          "version": ""
       },
       {
-         "id": "stat",
-         "name": "Stat",
-         "type": "panel",
-         "version": ""
-      },
-      {
-         "id": "table",
-         "name": "Table",
-         "type": "panel",
-         "version": ""
-      },
-      {
-         "id": "prometheus",
-         "name": "Prometheus",
+         "id": "influxdb",
+         "name": "InfluxDB",
          "type": "datasource",
          "version": "1.0.0"
       }
@@ -83,416 +55,11 @@
          "id": 2,
          "panels": [
             {
-               "columns": [ ],
-               "datasource": "${DS_PROMETHEUS}",
-               "description": "Overview of Tarantool instances observed by Prometheus job.\n\nIf instance row is *red*, it means Prometheus can't reach\nURI specified in targets or ran into error.\nIf instance row is *green*, it means instance is up and running and\nPrometheus is successfully extracting metrics from it.\n\"Uptime\" column shows time since instant start.\n",
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 0,
-                  "y": 1
-               },
-               "id": 3,
-               "links": [ ],
-               "sort": {
-                  "col": 2,
-                  "desc": false
-               },
-               "styles": [
-                  {
-                     "alias": "Instance alias",
-                     "mappingType": 1,
-                     "pattern": "alias",
-                     "thresholds": [ ],
-                     "type": "string"
-                  },
-                  {
-                     "alias": "Instance URI",
-                     "mappingType": 1,
-                     "pattern": "instance",
-                     "thresholds": [ ],
-                     "type": "string"
-                  },
-                  {
-                     "alias": "Uptime",
-                     "colorMode": "row",
-                     "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                     ],
-                     "decimals": 0,
-                     "mappingType": 1,
-                     "pattern": "Value",
-                     "thresholds": [
-                        "0.1",
-                        "0.1"
-                     ],
-                     "type": "number",
-                     "unit": "s"
-                  },
-                  {
-                     "alias": "job",
-                     "pattern": "job",
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "__name__",
-                     "pattern": "__name__",
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "Time",
-                     "pattern": "Time",
-                     "type": "hidden"
-                  }
-               ],
-               "targets": [
-                  {
-                     "expr": "up{job=~\"$job\"} * on(instance) group_left(alias) tnt_info_uptime{job=~\"$job\"} or\non(instance) label_replace(up{job=~\"$job\"}, \"alias\", \"Not available\", \"instance\", \".*\")\n",
-                     "format": "table",
-                     "instant": true,
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  }
-               ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Cluster status overview",
-               "transform": "table",
-               "type": "table"
-            },
-            {
-               "datasource": "${DS_PROMETHEUS}",
-               "description": "Count of running Tarantool instances observed by Prometheus job.\nIf Prometheus can't reach URI specified in targets\nor ran into error, instance is not counted.\n",
-               "gridPos": {
-                  "h": 3,
-                  "w": 6,
-                  "x": 12,
-                  "y": 1
-               },
-               "id": 4,
-               "links": [ ],
-               "options": {
-                  "colorMode": "value",
-                  "fieldOptions": {
-                     "calcs": [
-                        "last"
-                     ],
-                     "defaults": {
-                        "decimals": 0,
-                        "links": [ ],
-                        "mappings": [ ],
-                        "thresholds": {
-                           "mode": "absolute",
-                           "steps": [
-                              {
-                                 "color": "green",
-                                 "value": null
-                              }
-                           ]
-                        },
-                        "title": "Total instances running:",
-                        "unit": "none"
-                     },
-                     "fields": "",
-                     "values": false
-                  },
-                  "graphMode": "area",
-                  "justifyMode": "auto",
-                  "orientation": "auto"
-               },
-               "pluginVersion": "6.6.0",
-               "targets": [
-                  {
-                     "expr": "sum(up{job=~\"$job\"})",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  }
-               ],
-               "title": "",
-               "transparent": false,
-               "type": "stat"
-            },
-            {
-               "datasource": "${DS_PROMETHEUS}",
-               "description": "Overall value of memory used by Tarantool\nitems and indexes (*arena_used* value).\nIf Tarantool instance is not available\nfor Prometheus metrics extraction now,\nits contribution is not counted.\n",
-               "gridPos": {
-                  "h": 3,
-                  "w": 3,
-                  "x": 18,
-                  "y": 1
-               },
-               "id": 5,
-               "links": [ ],
-               "options": {
-                  "colorMode": "value",
-                  "fieldOptions": {
-                     "calcs": [
-                        "last"
-                     ],
-                     "defaults": {
-                        "decimals": 2,
-                        "links": [ ],
-                        "mappings": [ ],
-                        "thresholds": {
-                           "mode": "absolute",
-                           "steps": [
-                              {
-                                 "color": "green",
-                                 "value": null
-                              }
-                           ]
-                        },
-                        "title": "Overall memory used:",
-                        "unit": "bytes"
-                     },
-                     "fields": "",
-                     "values": false
-                  },
-                  "graphMode": "area",
-                  "justifyMode": "auto",
-                  "orientation": "auto"
-               },
-               "pluginVersion": "6.6.0",
-               "targets": [
-                  {
-                     "expr": "sum(tnt_slab_arena_used{job=~\"$job\"})",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  }
-               ],
-               "title": "",
-               "transparent": false,
-               "type": "stat"
-            },
-            {
-               "datasource": "${DS_PROMETHEUS}",
-               "description": "Overall value of memory available for Tarantool items\nand indexes allocation (*memtx_memory* or *quota_size* values).\nIf Tarantool instance is not available for Prometheus metrics\nextraction now, its contribution is not counted.\n",
-               "gridPos": {
-                  "h": 3,
-                  "w": 3,
-                  "x": 21,
-                  "y": 1
-               },
-               "id": 6,
-               "links": [ ],
-               "options": {
-                  "colorMode": "value",
-                  "fieldOptions": {
-                     "calcs": [
-                        "last"
-                     ],
-                     "defaults": {
-                        "decimals": 2,
-                        "links": [ ],
-                        "mappings": [ ],
-                        "thresholds": {
-                           "mode": "absolute",
-                           "steps": [
-                              {
-                                 "color": "green",
-                                 "value": null
-                              }
-                           ]
-                        },
-                        "title": "Overall memory reserved:",
-                        "unit": "bytes"
-                     },
-                     "fields": "",
-                     "values": false
-                  },
-                  "graphMode": "area",
-                  "justifyMode": "auto",
-                  "orientation": "auto"
-               },
-               "pluginVersion": "6.6.0",
-               "targets": [
-                  {
-                     "expr": "sum(tnt_slab_quota_size{job=~\"$job\"})",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  }
-               ],
-               "title": "",
-               "transparent": false,
-               "type": "stat"
-            },
-            {
-               "datasource": "${DS_PROMETHEUS}",
-               "description": "Overall rate of HTTP requests processed\non Tarantool instances (all methods and response codes).\nIf Tarantool instance is not available for Prometheus metrics\nextraction now, its contribution is not counted.\n",
-               "gridPos": {
-                  "h": 5,
-                  "w": 4,
-                  "x": 12,
-                  "y": 4
-               },
-               "id": 7,
-               "links": [ ],
-               "options": {
-                  "colorMode": "value",
-                  "fieldOptions": {
-                     "calcs": [
-                        "last"
-                     ],
-                     "defaults": {
-                        "decimals": 3,
-                        "links": [ ],
-                        "mappings": [ ],
-                        "thresholds": {
-                           "mode": "absolute",
-                           "steps": [
-                              {
-                                 "color": "green",
-                                 "value": null
-                              }
-                           ]
-                        },
-                        "title": "Overall HTTP load:",
-                        "unit": "reqps"
-                     },
-                     "fields": "",
-                     "values": false
-                  },
-                  "graphMode": "area",
-                  "justifyMode": "auto",
-                  "orientation": "auto"
-               },
-               "pluginVersion": "6.6.0",
-               "targets": [
-                  {
-                     "expr": "sum(rate(http_server_request_latency_count{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  }
-               ],
-               "title": "",
-               "transparent": false,
-               "type": "stat"
-            },
-            {
-               "datasource": "${DS_PROMETHEUS}",
-               "description": "Overall rate of network requests processed on Tarantool instances.\nIf Tarantool instance is not available for Prometheus metrics\nextraction now, its contribution is not counted.\n",
-               "gridPos": {
-                  "h": 5,
-                  "w": 4,
-                  "x": 16,
-                  "y": 4
-               },
-               "id": 8,
-               "links": [ ],
-               "options": {
-                  "colorMode": "value",
-                  "fieldOptions": {
-                     "calcs": [
-                        "last"
-                     ],
-                     "defaults": {
-                        "decimals": 3,
-                        "links": [ ],
-                        "mappings": [ ],
-                        "thresholds": {
-                           "mode": "absolute",
-                           "steps": [
-                              {
-                                 "color": "green",
-                                 "value": null
-                              }
-                           ]
-                        },
-                        "title": "Overall net load:",
-                        "unit": "reqps"
-                     },
-                     "fields": "",
-                     "values": false
-                  },
-                  "graphMode": "area",
-                  "justifyMode": "auto",
-                  "orientation": "auto"
-               },
-               "pluginVersion": "6.6.0",
-               "targets": [
-                  {
-                     "expr": "sum(rate(tnt_net_requests_total{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  }
-               ],
-               "title": "",
-               "transparent": false,
-               "type": "stat"
-            },
-            {
-               "datasource": "${DS_PROMETHEUS}",
-               "description": "Overall rate of operations performed on Tarantool spaces\n(*select*, *insert*, *update* etc.).\nIf Tarantool instance is not available for Prometheus metrics\nextraction now, its contribution is not counted.\n",
-               "gridPos": {
-                  "h": 5,
-                  "w": 4,
-                  "x": 20,
-                  "y": 4
-               },
-               "id": 9,
-               "links": [ ],
-               "options": {
-                  "colorMode": "value",
-                  "fieldOptions": {
-                     "calcs": [
-                        "last"
-                     ],
-                     "defaults": {
-                        "decimals": 3,
-                        "links": [ ],
-                        "mappings": [ ],
-                        "thresholds": {
-                           "mode": "absolute",
-                           "steps": [
-                              {
-                                 "color": "green",
-                                 "value": null
-                              }
-                           ]
-                        },
-                        "title": "Overall space load:",
-                        "unit": "ops"
-                     },
-                     "fields": "",
-                     "values": false
-                  },
-                  "graphMode": "area",
-                  "justifyMode": "auto",
-                  "orientation": "auto"
-               },
-               "pluginVersion": "6.6.0",
-               "targets": [
-                  {
-                     "expr": "sum(rate(tnt_stats_op_total{job=~\"$job\"}[$__rate_interval]))",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "",
-                     "refId": "A"
-                  }
-               ],
-               "title": "",
-               "transparent": false,
-               "type": "stat"
-            },
-            {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Number of \"warning\" issues on each cluster instance.\n\"warning\" issues includes high replication lag, replication long idle,\nfailover and switchover issues, clock issues, memory fragmentation,\nconfiguration issues and alien members warnings.\n\nPanel works with `cartridge >= 2.0.2`, `metrics >= 0.6.0`,\nwhile `metrics >= 0.9.0` is recommended for per instance display.\n",
                "fill": 0,
@@ -500,9 +67,9 @@
                   "h": 6,
                   "w": 12,
                   "x": 0,
-                  "y": 9
+                  "y": 1
                },
-               "id": 10,
+               "id": 3,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -532,11 +99,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_cartridge_issues{job=~\"$job\",alias=~\"$alias\",level=\"warning\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_cartridge_issues"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_level",
+                           "operator": "=",
+                           "value": "warning"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -582,7 +202,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Number of \"critical\" issues on each cluster instance.\n\"critical\" issues includes replication process critical fails and\nrunning out of available memory.\n\nPanel works with `cartridge >= 2.0.2`, `metrics >= 0.6.0`,\nwhile `metrics >= 0.9.0` is recommended for per instance display.\n",
                "fill": 0,
@@ -590,9 +210,9 @@
                   "h": 6,
                   "w": 12,
                   "x": 12,
-                  "y": 9
+                  "y": 1
                },
-               "id": 11,
+               "id": 4,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -622,11 +242,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_cartridge_issues{job=~\"$job\",alias=~\"$alias\",level=\"critical\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_cartridge_issues"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_level",
+                           "operator": "=",
+                           "value": "critical"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -668,7 +341,7 @@
                ]
             },
             {
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "description": "`follows` status means replication is running.\nOtherwise, `not running` is displayed.\n\nPanel works with `metrics >= 0.13.0` and Grafana 8.x.\n",
                "fieldConfig": {
                   "defaults": {
@@ -749,9 +422,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 15
+                  "y": 7
                },
-               "id": 12,
+               "id": 5,
                "options": {
                   "legend": {
                      "calcs": [
@@ -766,18 +439,77 @@
                },
                "targets": [
                   {
-                     "expr": "tnt_replication_status{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} {{stream}} ({{id}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias $tag_label_pairs_stream ($tag_label_pairs_id)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_stream"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_id"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_replication_status"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "title": "Tarantool replication status",
                "type": "timeseries"
             },
             {
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "description": "`master` status means instance is available for read and\nwrite operations. `replica` status means instance is\navailable only for read operations.\n\nPanel works with `metrics >= 0.11.0` and Grafana 8.x.\n",
                "fieldConfig": {
                   "defaults": {
@@ -858,9 +590,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 15
+                  "y": 7
                },
-               "id": 13,
+               "id": 6,
                "options": {
                   "legend": {
                      "calcs": [
@@ -875,11 +607,58 @@
                },
                "targets": [
                   {
-                     "expr": "tnt_read_only{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_read_only"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "title": "Tarantool instance status",
@@ -890,16 +669,16 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "description": "Replication lag value for Tarantool instance.\n\nPanel works with `metrics >= 0.13.0`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 23
+                  "y": 15
                },
-               "id": 14,
+               "id": 7,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -929,11 +708,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_replication_lag{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} ({{id}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias ($tag_label_pairs_id)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_id"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_replication_lag"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -977,16 +809,16 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "description": "Clock drift across the cluster.\nmax shows difference with the fastest clock (always positive),\nmin shows difference with the slowest clock (always negative).\n\nPanel works with `metrics >= 0.10.0`.\n",
                "fill": 1,
                "gridPos": {
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 23
+                  "y": 15
                },
-               "id": 15,
+               "id": 8,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -1016,11 +848,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_clock_delta{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} ({{delta}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias ($tag_label_pairs_delta)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_delta"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_clock_delta"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -1075,16 +960,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 31
+            "y": 23
          },
-         "id": 16,
+         "id": 9,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Memory used for network input/output buffers.\n",
                "fill": 0,
@@ -1092,9 +977,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 32
+                  "y": 24
                },
-               "id": 17,
+               "id": 10,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1124,11 +1009,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_info_memory_net{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_info_memory_net"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -1174,7 +1106,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Data received by instance from binary protocol connections.\nGraph shows average bytes per second.\n",
                "fill": 0,
@@ -1182,9 +1114,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 32
+                  "y": 24
                },
-               "id": 18,
+               "id": 11,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1214,11 +1146,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_received_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_net_received_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -1264,7 +1249,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Data sent by instance with binary protocol connections.\nGraph shows average bytes per second.\n",
                "fill": 0,
@@ -1272,9 +1257,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 32
+                  "y": 24
                },
-               "id": 19,
+               "id": 12,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1304,11 +1289,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_sent_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_net_sent_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -1354,7 +1392,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of network requests this instance has handled.\nGraph shows mean rps.\n\nPanel will be removed in favor of \"Processed requests\"\nand \"Requests in queue (overall)\" panels.\n",
                "fill": 0,
@@ -1362,9 +1400,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 40
+                  "y": 32
                },
-               "id": 20,
+               "id": 13,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1394,11 +1432,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_net_requests_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -1444,7 +1535,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Number of pending network requests.\n\nPanel will be removed in favor of \"Requests in progress\"\nand \"Requests in queue (current)\" panels.\n",
                "fill": 0,
@@ -1452,9 +1543,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 40
+                  "y": 32
                },
-               "id": 21,
+               "id": 14,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1484,11 +1575,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_current{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_net_requests_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -1534,7 +1672,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average number of requests processed by tx thread per second.\n\nPanel works with `metrics >= 0.13.0` and `Tarantool >= 2.10-beta2`.\n",
                "fill": 0,
@@ -1542,9 +1680,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 48
+                  "y": 40
                },
-               "id": 22,
+               "id": 15,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1574,11 +1712,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_in_progress_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_net_requests_in_progress_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -1624,7 +1815,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Number of requests currently being processed in the tx thread.\n\nPanel works with `metrics >= 0.13.0` and `Tarantool >= 2.10-beta2`.\n",
                "fill": 0,
@@ -1632,9 +1823,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 48
+                  "y": 40
                },
-               "id": 23,
+               "id": 16,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1664,11 +1855,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_in_progress_current{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_net_requests_in_progress_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -1714,7 +1952,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average number of requests which was placed in queues\nof streams per second.\n\nPanel works with `metrics >= 0.13.0` and `Tarantool >= 2.10-beta2`.\n",
                "fill": 0,
@@ -1722,9 +1960,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 48
+                  "y": 40
                },
-               "id": 24,
+               "id": 17,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1754,11 +1992,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_in_stream_queue_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_net_requests_in_stream_queue_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -1804,7 +2095,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Number of requests currently waiting in queues of streams.\n\nPanel works with `metrics >= 0.13.0` and `Tarantool >= 2.10-beta2`.\n",
                "fill": 0,
@@ -1812,9 +2103,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 48
+                  "y": 40
                },
-               "id": 25,
+               "id": 18,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1844,11 +2135,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_in_stream_queue_current{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_net_requests_in_stream_queue_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -1894,7 +2232,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average number of new binary protocol connections per second.\n",
                "fill": 0,
@@ -1902,9 +2240,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 56
+                  "y": 48
                },
-               "id": 26,
+               "id": 19,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1934,11 +2272,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_connections_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_net_connections_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -1984,7 +2375,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Number of current active binary protocol connections.\n",
                "fill": 0,
@@ -1992,9 +2383,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 56
+                  "y": 48
                },
-               "id": 27,
+               "id": 20,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -2024,11 +2415,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_connections_current{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_net_connections_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -2085,9 +2523,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 64
+            "y": 56
          },
-         "id": 28,
+         "id": 21,
          "panels": [
             {
                "content": "`quota_used_ratio` > 90%, `arena_used_ratio` > 90%, 50% < `items_used_ratio` < 90% – your memory is highly fragmented. See [docs](https://www.tarantool.io/en/doc/1.10/reference/reference_lua/box_slab/#lua-function.box.slab.info) for more info.\n\n`quota_used_ratio` > 90%, `arena_used_ratio` > 90%, `items_used_ratio` > 90% – you are running out of memory. You should consider increasing Tarantool’s memory limit (*box.cfg.memtx_memory*).\n",
@@ -2096,9 +2534,9 @@
                   "h": 3,
                   "w": 24,
                   "x": 0,
-                  "y": 65
+                  "y": 57
                },
-               "id": 29,
+               "id": 22,
                "mode": "markdown",
                "title": "Slab allocator monitoring information",
                "type": "text"
@@ -2108,7 +2546,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "`quota_used_ratio` = `quota_used` / `quota_size`.\n\n`quota_used` – used by slab allocator (for both tuple and index slabs).\n\n`quota_size` – memory limit for slab allocator (as configured in the *memtx_memory* parameter).\n",
                "fill": 0,
@@ -2116,9 +2554,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 68
+                  "y": 60
                },
-               "id": 30,
+               "id": 23,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2148,11 +2586,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_used_ratio{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_slab_quota_used_ratio"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -2198,7 +2683,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "`arena_used_ratio` = `arena_used` / `arena_size`.\n\n`arena_used` – used for both tuples and indexes.\n\n`arena_size` – allocated for both tuples and indexes.\n",
                "fill": 0,
@@ -2206,9 +2691,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 68
+                  "y": 60
                },
-               "id": 31,
+               "id": 24,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2238,11 +2723,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_used_ratio{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_slab_arena_used_ratio"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -2288,7 +2820,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "`items_used_ratio` = `items_used` / `items_size`.\n\n`items_used` – used only for tuples.\n\n`items_size` – allocated only for tuples.\n",
                "fill": 0,
@@ -2296,9 +2828,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 68
+                  "y": 60
                },
-               "id": 32,
+               "id": 25,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2328,11 +2860,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_used_ratio{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_slab_items_used_ratio"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -2378,7 +2957,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Memory used by slab allocator (for both tuple and index slabs).\n",
                "fill": 0,
@@ -2386,9 +2965,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 76
+                  "y": 68
                },
-               "id": 33,
+               "id": 26,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2418,11 +2997,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_used{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_slab_quota_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -2468,7 +3094,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Memory used for both tuples and indexes.\n",
                "fill": 0,
@@ -2476,9 +3102,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 76
+                  "y": 68
                },
-               "id": 34,
+               "id": 27,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2508,11 +3134,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_used{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_slab_arena_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -2558,7 +3231,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Memory used for only tuples.\n",
                "fill": 0,
@@ -2566,9 +3239,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 76
+                  "y": 68
                },
-               "id": 35,
+               "id": 28,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2598,11 +3271,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_used{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_slab_items_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -2648,7 +3368,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Memory limit for slab allocator (as configured in the *memtx_memory* parameter).\n",
                "fill": 0,
@@ -2656,9 +3376,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 84
+                  "y": 76
                },
-               "id": 36,
+               "id": 29,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2688,11 +3408,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_size{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_slab_quota_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -2738,7 +3505,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Memory allocated for both tuples and indexes by slab allocator.\n",
                "fill": 0,
@@ -2746,9 +3513,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 84
+                  "y": 76
                },
-               "id": 37,
+               "id": 30,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2778,11 +3545,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_size{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_slab_arena_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -2828,7 +3642,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Memory allocated for only tuples by slab allocator.\n",
                "fill": 0,
@@ -2836,9 +3650,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 84
+                  "y": 76
                },
-               "id": 38,
+               "id": 31,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2868,11 +3682,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_size{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_slab_items_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -2929,16 +3790,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 92
+            "y": 84
          },
-         "id": 39,
+         "id": 32,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Number of records in the space (memtx engine).\nName of space is specified after dash.\n",
                "fill": 0,
@@ -2946,9 +3807,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 93
+                  "y": 85
                },
-               "id": 40,
+               "id": 33,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2978,11 +3839,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_len{job=~\"$job\", alias=~\"$alias\", engine=\"memtx\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_space_len"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_engine",
+                           "operator": "=",
+                           "value": "memtx"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -3028,7 +3948,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Number of records in the space (vinyl engine).\nName of space is specified after dash.\nBy default this metrics is disabled,\nto enable it you must set global variable\ninclude_vinyl_count to true. Beware that\ncount() operation scans the space and may\nslow down your app. \n\nPanel works with `metrics >= 0.13.0`.\n",
                "fill": 0,
@@ -3036,9 +3956,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 93
+                  "y": 85
                },
-               "id": 41,
+               "id": 34,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3068,11 +3988,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_tuples{job=~\"$job\", alias=~\"$alias\", engine=\"vinyl\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_tuples"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_engine",
+                           "operator": "=",
+                           "value": "vinyl"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -3118,17 +4097,17 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
-               "description": "Total number of bytes in all tuples of the space (memtx engine).\nName of space is specified after dash.\n",
+               "description": "Total number of bytes in all tuples of the space (memtx engine).\nName of space is specified after dash.\n\n`No data` may be displayed because of tarantool/metrics issue #321,\nuse `metrics >= 0.12.0` to fix.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 101
+                  "y": 93
                },
-               "id": 42,
+               "id": 35,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3158,11 +4137,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_bsize{job=~\"$job\", alias=~\"$alias\", engine=\"memtx\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_space_bsize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_engine",
+                           "operator": "=",
+                           "value": "memtx"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -3208,7 +4246,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Total number of bytes taken by the index.\nName of space is specified after dash,\nindex name specified in parentheses.\nIncludes both memtx and vinyl spaces.\n",
                "fill": 0,
@@ -3216,9 +4254,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 101
+                  "y": 93
                },
-               "id": 43,
+               "id": 36,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3248,11 +4286,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_index_bsize{job=~\"$job\", alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}} ({{index_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name ($tag_label_pairs_index_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_index_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_space_index_bsize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -3298,17 +4395,17 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
-               "description": "Total size of tuples and all indexes in the space (memtx engine).\nName of space is specified after dash.\n",
+               "description": "Total size of tuples and all indexes in the space (memtx engine).\nName of space is specified after dash.\n\n`No data` may be displayed because of tarantool/metrics issue #321,\nuse `metrics >= 0.12.0` to fix.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 101
+                  "y": 93
                },
-               "id": 44,
+               "id": 37,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3338,11 +4435,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_total_bsize{job=~\"$job\", alias=~\"$alias\", engine=\"memtx\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_space_total_bsize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_engine",
+                           "operator": "=",
+                           "value": "memtx"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -3399,16 +4555,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 109
+            "y": 101
          },
-         "id": 45,
+         "id": 38,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "The amount of data stored in the `.run` files located in the `vinyl_dir` directory.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -3416,9 +4572,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 110
+                  "y": 102
                },
-               "id": 46,
+               "id": 39,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3448,11 +4604,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_disk_data_size{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_disk_data_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -3498,7 +4701,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "The amount of data stored in the `.index` files located in the `vinyl_dir` directory.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -3506,9 +4709,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 110
+                  "y": 102
                },
-               "id": 47,
+               "id": 40,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3538,11 +4741,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_disk_index_size{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_disk_index_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -3588,7 +4838,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Amount of memory in bytes currently used to store tuples (data).\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -3596,9 +4846,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 118
+                  "y": 110
                },
-               "id": 48,
+               "id": 41,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3628,11 +4878,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_tuple_cache{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_memory_tuple_cache"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -3678,7 +4975,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -3686,9 +4983,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 118
+                  "y": 110
                },
-               "id": 49,
+               "id": 42,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3718,11 +5015,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_page_index{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_memory_page_index"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -3768,7 +5112,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Amount of memory in bytes used by bloom filters.\n",
                "fill": 0,
@@ -3776,9 +5120,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 118
+                  "y": 110
                },
-               "id": 50,
+               "id": 43,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3808,11 +5152,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_bloom_filter{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_memory_bloom_filter"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -3858,7 +5249,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "The estimated average rate of taking dumps, bytes per second.\nInitially, the rate value is 10 megabytes per second\nand being recalculated depending on the the actual rate.\nOnly significant dumps that are larger than one megabyte\nare used for the estimate.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -3866,9 +5257,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 126
+                  "y": 118
                },
-               "id": 51,
+               "id": 44,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3898,11 +5289,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_dump_bandwidth{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_regulator_dump_bandwidth"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -3948,7 +5386,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "The actual average rate of performing the write operations, bytes per second.\nThe rate is calculated as a 5-second moving average.\nIf the metric value is gradually going down, this can indicate some disk issues.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -3956,9 +5394,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 126
+                  "y": 118
                },
-               "id": 52,
+               "id": 45,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -3988,11 +5426,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_write_rate{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_regulator_write_rate"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -4038,7 +5523,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "The write rate limit, bytes per second.\nThe regulator imposes the limit on transactions based on the observed dump/compaction performance.\nIf the metric value is down to approximately 100 Kbps,\nthis indicates issues with the disk or the scheduler.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4046,9 +5531,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 126
+                  "y": 118
                },
-               "id": 53,
+               "id": 46,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4078,11 +5563,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_rate_limit{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_regulator_rate_limit"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -4128,7 +5660,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "«Level 0» (L0) memory area in bytes. L0 is the area that\nvinyl can use for in-memory storage of an LSM tree.\nBy monitoring this metric, you can see when L0 is getting\nclose to its maximum (tnt_vinyl_regulator_dump_watermark),\nat which time a dump will occur. You can expect L0 = 0\nimmediately after the dump operation is completed.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4136,9 +5668,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 134
+                  "y": 126
                },
-               "id": 54,
+               "id": 47,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4168,11 +5700,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_level0{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_memory_level0"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -4218,7 +5797,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "The maximum amount of memory used for in-memory storing of a vinyl LSM tree.\nWhen accessing this maximum, the dumping must occur.\nFor details, see https://www.tarantool.io/en/doc/latest/book/box/engines/#engines-algorithm-filling-lsm.\nThe value is slightly smaller than the amount of memory allocated for vinyl trees,\nwhich is the `vinyl_memory` parameter.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4226,9 +5805,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 134
+                  "y": 126
                },
-               "id": 55,
+               "id": 48,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4258,11 +5837,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_dump_watermark{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_regulator_dump_watermark"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -4308,7 +5934,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "The number of fibers that are blocked waiting for Vinyl level0 memory quota.\n\nPanel works with `metrics >= 0.13.0` and `Tarantool >= 2.8.3`.\n",
                "fill": 0,
@@ -4316,9 +5942,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 134
+                  "y": 126
                },
-               "id": 56,
+               "id": 49,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4348,11 +5974,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_blocked_writers{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_regulator_blocked_writers"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -4398,7 +6071,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average per second rate of commits (successful transaction ends).\nIt includes implicit commits: for example, any insert operation causes a commit\nunless it is within a `box.begin()`–`box.commit()` block.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4406,9 +6079,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 142
+                  "y": 134
                },
-               "id": 57,
+               "id": 50,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4438,11 +6111,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_commit{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_tx_commit"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -4488,7 +6214,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average per second rate of rollbacks (unsuccessful transaction ends).\nThis is not merely a count of explicit `box.rollback()` requests — it includes requests\nthat ended with errors.\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4496,9 +6222,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 142
+                  "y": 134
                },
-               "id": 58,
+               "id": 51,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4528,11 +6254,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_rollback{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_tx_rollback"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -4578,7 +6357,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average per second rate of conflicts that caused transactions to roll back.\nThe ratio `tx conflicts` / `tx commits` above 5% indicates that vinyl is not healthy.\nAt this moment you’ll probably see a lot of other problems with vinyl.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4586,9 +6365,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 142
+                  "y": 134
                },
-               "id": 59,
+               "id": 52,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4618,11 +6397,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_conflict{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_tx_conflict"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -4668,7 +6500,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Number of current read views, that is, transactions entered a read-only state\nto avoid conflict temporarily.\nIf the value stays non-zero for a long time, it indicates of a memory leak.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4676,9 +6508,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 142
+                  "y": 134
                },
-               "id": 60,
+               "id": 53,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4708,11 +6540,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_tx_read_views{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_tx_read_views"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -4758,7 +6637,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "The number of the scheduler dump/compaction tasks in progress now.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4766,9 +6645,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 150
+                  "y": 142
                },
-               "id": 61,
+               "id": 54,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4798,11 +6677,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_scheduler_tasks{job=~\"$job\", alias=~\"$alias\", status=\"inprogress\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_scheduler_tasks"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "inprogress"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -4848,7 +6780,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Scheduler dump/compaction tasks failed.\nAverage per second rate is shown.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4856,9 +6788,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 150
+                  "y": 142
                },
-               "id": 62,
+               "id": 55,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4888,11 +6820,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_tasks{job=~\"$job\",alias=~\"$alias\",status=\"failed\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_scheduler_tasks"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status",
+                           "operator": "=",
+                           "value": "failed"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -4938,7 +6929,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Time spent by all worker threads performing dumps.\nAverage per second rate is shown.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4946,9 +6937,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 150
+                  "y": 142
                },
-               "id": 63,
+               "id": 56,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4978,11 +6969,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_dump_time{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_scheduler_dump_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -5028,7 +7072,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Scheduler dumps completed average per second rate.\n\nPanel works with `metrics >= 0.13.0`.\n",
                "fill": 0,
@@ -5036,9 +7080,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 150
+                  "y": 142
                },
-               "id": 64,
+               "id": 57,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5068,11 +7112,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_dump_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_vinyl_scheduler_dump_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -5129,16 +7226,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 158
+            "y": 150
          },
-         "id": 65,
+         "id": 58,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "This is the average share of time\nspent by instance process executing in user mode.\nMetrics obtained using `getrusage()` call.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -5146,9 +7243,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 159
+                  "y": 151
                },
-               "id": 66,
+               "id": 59,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5178,11 +7275,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_cpu_user_time{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_cpu_user_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -5228,7 +7378,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "This is the average share of time\nspent by instance process executing in kernel mode.\nMetrics obtained using `getrusage()` call.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -5236,9 +7386,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 159
+                  "y": 151
                },
-               "id": 67,
+               "id": 60,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5268,11 +7418,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_cpu_system_time{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_cpu_system_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -5318,7 +7521,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Amount of time that each process has been scheduled\nin user mode, measured in clock ticks (divide by\nsysconf(_SC_CLK_TCK)).  This includes guest time,\nguest_time (time spent running a virtual CPU, see\nbelow), so that applications that are not aware of\nthe guest time field do not lose that time from\ntheir calculations. Average ticks per second is displayed.\n\nMetrics are obtained by parsing `/proc/self/task/[pid]/stat`.\n",
                "fill": 0,
@@ -5326,9 +7529,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 167
+                  "y": 159
                },
-               "id": 68,
+               "id": 61,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5358,11 +7561,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_cpu_thread{job=~\"$job\",alias=~\"$alias\",kind=\"user\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{thread_name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_thread_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_thread_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_cpu_thread"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_kind",
+                           "operator": "=",
+                           "value": "user"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -5408,7 +7676,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Amount of time that this process has been scheduled\nin kernel mode, measured in clock ticks (divide by\nsysconf(_SC_CLK_TCK)). Average ticks per second is displayed.\n\nMetrics are obtained by parsing `/proc/self/task/[pid]/stat`.\n",
                "fill": 0,
@@ -5416,9 +7684,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 167
+                  "y": 159
                },
-               "id": 69,
+               "id": 62,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5448,11 +7716,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_cpu_thread{job=~\"$job\",alias=~\"$alias\",kind=\"system\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{thread_name}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias — $tag_label_pairs_thread_name",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_thread_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_cpu_thread"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_kind",
+                           "operator": "=",
+                           "value": "system"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -5509,16 +7842,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 175
+            "y": 167
          },
-         "id": 70,
+         "id": 63,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance. \n",
                "fill": 0,
@@ -5526,9 +7859,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 176
+                  "y": 168
                },
-               "id": 71,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5558,11 +7891,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_info_memory_lua{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_info_memory_lua"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -5608,7 +7988,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Memory used by runtime arena.\nRuntime arena stores network buffers, tuples\ncreated with box.tuple.new and other objects\nallocated by application not covered by basic\nLua mechanisms (spaces data and indexes\nare not included here, see memtx/vinyl arena).\n",
                "fill": 0,
@@ -5616,9 +7996,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 176
+                  "y": 168
                },
-               "id": 72,
+               "id": 65,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5648,11 +8028,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_runtime_used{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_runtime_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -5698,7 +8125,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Memory in use by active transactions.\nFor the vinyl storage engine, this is the total size of\nall allocated objects (struct txv, struct vy_tx, struct vy_read_interval)\nand tuples pinned for those objects. \n",
                "fill": 0,
@@ -5706,9 +8133,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 176
+                  "y": 168
                },
-               "id": 73,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5738,11 +8165,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_info_memory_tx{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_info_memory_tx"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -5788,7 +8262,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of fiber context switches.\nContext switches are counted over all current fibers.\n",
                "fill": 0,
@@ -5796,9 +8270,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 184
+                  "y": 176
                },
-               "id": 74,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5828,11 +8302,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_csw{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_fiber_csw"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -5878,7 +8399,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Duration of last event loop iteration (tx thread).\nHigh duration results in longer responses,\npossible bad health signals and may be the\nreason of \"Too long WAL write\" errors.\n\nPanel works with `metrics >= 0.13.0`.\n",
                "fill": 0,
@@ -5886,9 +8407,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 184
+                  "y": 176
                },
-               "id": 75,
+               "id": 68,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5918,11 +8439,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_ev_loop_time{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_ev_loop_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -5968,7 +8536,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Current number of fibers in tx thread. \n\nPanel works with `metrics >= 0.13.0`.\n",
                "fill": 0,
@@ -5976,9 +8544,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 192
+                  "y": 184
                },
-               "id": 76,
+               "id": 69,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6008,11 +8576,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_amount{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_fiber_amount"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -6058,7 +8673,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Amount of memory used by current fibers.\n",
                "fill": 0,
@@ -6066,9 +8681,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 192
+                  "y": 184
                },
-               "id": 77,
+               "id": 70,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6098,11 +8713,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_memused{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_fiber_memused"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -6148,7 +8810,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Amount of memory reserved for current fibers.\n",
                "fill": 0,
@@ -6156,9 +8818,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 192
+                  "y": 184
                },
-               "id": 78,
+               "id": 71,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6188,11 +8850,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_memalloc{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_fiber_memalloc"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -6249,16 +8958,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 200
+            "y": 192
          },
-         "id": 79,
+         "id": 72,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average number of snap restores (guard assertions\nleading to stopping trace executions) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -6266,9 +8975,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 201
+                  "y": 193
                },
-               "id": 80,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6298,11 +9007,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_snap_restore{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_jit_snap_restore"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -6348,7 +9110,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average number of new JIT traces per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -6356,9 +9118,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 201
+                  "y": 193
                },
-               "id": 81,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6388,11 +9150,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_trace_num{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_jit_trace_num"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -6438,7 +9253,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average number of JIT trace aborts per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -6446,9 +9261,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 201
+                  "y": 193
                },
-               "id": 82,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6478,11 +9293,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_trace_abort{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_jit_trace_abort"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -6528,7 +9396,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Total size of allocated machine code areas.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -6536,9 +9404,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 201
+                  "y": 193
                },
-               "id": 83,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6568,11 +9436,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_jit_mcode_size{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_jit_mcode_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -6618,7 +9533,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average number of strings being extracted from hash instead of allocating per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -6626,9 +9541,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 209
+                  "y": 201
                },
-               "id": 84,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6658,11 +9573,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_strhash_hit{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_strhash_hit"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -6708,7 +9676,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average number of strings being allocated due to hash miss per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -6716,9 +9684,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 209
+                  "y": 201
                },
-               "id": 85,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6748,11 +9716,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_strhash_miss{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_strhash_miss"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -6798,7 +9819,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average count of incremental GC steps (atomic state) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -6806,9 +9827,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 217
+                  "y": 209
                },
-               "id": 86,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6838,11 +9859,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_atomic{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_gc_steps_atomic"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -6888,7 +9962,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average count of incremental GC steps (sweepstring state) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -6896,9 +9970,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 217
+                  "y": 209
                },
-               "id": 87,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6928,11 +10002,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_sweepstring{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_gc_steps_sweepstring"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -6978,7 +10105,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average count of incremental GC steps (finalize state) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -6986,9 +10113,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 217
+                  "y": 209
                },
-               "id": 88,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7018,11 +10145,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_finalize{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_gc_steps_finalize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -7068,7 +10248,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average count of incremental GC steps (sweep state) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7076,9 +10256,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 225
+                  "y": 217
                },
-               "id": 89,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7108,11 +10288,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_sweep{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_gc_steps_sweep"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -7158,7 +10391,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average count of incremental GC steps (propagate state) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7166,9 +10399,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 225
+                  "y": 217
                },
-               "id": 90,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7198,11 +10431,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_propagate{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_gc_steps_propagate"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -7248,7 +10534,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average count of incremental GC steps (pause state) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7256,9 +10542,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 225
+                  "y": 217
                },
-               "id": 91,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7288,11 +10574,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_pause{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_gc_steps_pause"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -7338,7 +10677,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Number of allocated string objects.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7346,9 +10685,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 233
+                  "y": 225
                },
-               "id": 92,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7378,11 +10717,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_strnum{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_gc_strnum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -7428,7 +10814,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Number of allocated table objects.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7436,9 +10822,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 233
+                  "y": 225
                },
-               "id": 93,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7468,11 +10854,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_tabnum{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_gc_tabnum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -7518,7 +10951,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Number of allocated cdata objects.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7526,9 +10959,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 233
+                  "y": 225
                },
-               "id": 94,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7558,11 +10991,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_cdatanum{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_gc_cdatanum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -7608,7 +11088,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Number of allocated userdata objects.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7616,9 +11096,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 233
+                  "y": 225
                },
-               "id": 95,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7648,11 +11128,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_udatanum{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_gc_udatanum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -7698,7 +11225,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Current allocated Lua memory.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7706,9 +11233,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 241
+                  "y": 233
                },
-               "id": 96,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7738,11 +11265,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_memory{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_gc_memory"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -7788,7 +11362,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average amount of freed Lua memory per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7796,9 +11370,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 241
+                  "y": 233
                },
-               "id": 97,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7828,11 +11402,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_freed{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_gc_freed"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -7878,7 +11505,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average amount of allocated Lua memory per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7886,9 +11513,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 241
+                  "y": 233
                },
-               "id": 98,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7918,11 +11545,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_allocated{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "lj_gc_allocated"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -7979,16 +11659,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 249
+            "y": 241
          },
-         "id": 99,
+         "id": 92,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Total count of SELECT requests to all instance spaces.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -7996,9 +11676,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 250
+                  "y": 242
                },
-               "id": 100,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8028,11 +11708,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"select\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "select"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -8078,7 +11817,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Total count of INSERT requests to all instance spaces.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8086,9 +11825,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 250
+                  "y": 242
                },
-               "id": 101,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8118,11 +11857,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"insert\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "insert"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -8168,7 +11966,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Total count of REPLACE requests to all instance spaces.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8176,9 +11974,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 250
+                  "y": 242
                },
-               "id": 102,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8208,11 +12006,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"replace\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "replace"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -8258,7 +12115,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Total count of UPSERT requests to all instance spaces.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8266,9 +12123,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 258
+                  "y": 250
                },
-               "id": 103,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8298,11 +12155,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"upsert\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "upsert"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -8348,7 +12264,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Total count of UPDATE requests to all instance spaces.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8356,9 +12272,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 258
+                  "y": 250
                },
-               "id": 104,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8388,11 +12304,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"update\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "update"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -8438,7 +12413,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Total count of DELETE requests to all instance spaces.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8446,9 +12421,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 258
+                  "y": 250
                },
-               "id": 105,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8478,11 +12453,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"delete\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "delete"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -8528,7 +12562,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Requests to execute stored procedures.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8536,9 +12570,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 266
+                  "y": 258
                },
-               "id": 106,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8568,11 +12602,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"call\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "call"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -8618,7 +12711,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Calls to evaluate Lua code.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8626,9 +12719,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 266
+                  "y": 258
                },
-               "id": 107,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8658,11 +12751,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"eval\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "eval"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -8708,7 +12860,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Requests resulted in error.\nGraph shows average errors per second.\n",
                "fill": 0,
@@ -8716,9 +12868,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 266
+                  "y": 258
                },
-               "id": 108,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8748,11 +12900,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"error\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "error"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -8798,7 +13009,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Authentication requests.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8806,9 +13017,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 274
+                  "y": 266
                },
-               "id": 109,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8838,11 +13049,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"auth\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "auth"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -8888,7 +13158,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "SQL prepare calls.\nGraph shows average calls per second.\n\nPanel works with Tarantool 2.x.\n",
                "fill": 0,
@@ -8896,9 +13166,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 274
+                  "y": 266
                },
-               "id": 110,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8928,11 +13198,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"prepare\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "prepare"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -8978,7 +13307,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "SQL execute calls.\nGraph shows average calls per second.\n\nPanel works with Tarantool 2.x.\n",
                "fill": 0,
@@ -8986,9 +13315,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 274
+                  "y": 266
                },
-               "id": 111,
+               "id": 104,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9018,11 +13347,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"execute\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_operation",
+                           "operator": "=",
+                           "value": "execute"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -9079,16 +13467,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 282
+            "y": 274
          },
-         "id": 112,
+         "id": 105,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of ops (callbacks, events, etc) waiting in queue\nfor application to serve with rd_kafka_poll().\n",
                "fill": 0,
@@ -9096,9 +13484,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 283
+                  "y": 275
                },
-               "id": 113,
+               "id": 106,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9128,11 +13516,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_replyq{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_replyq"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -9178,7 +13631,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Current number of messages in producer queues.\n",
                "fill": 0,
@@ -9186,9 +13639,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 283
+                  "y": 275
                },
-               "id": 114,
+               "id": 107,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9218,11 +13671,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_msg_size{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_msg_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -9268,7 +13786,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Current number of messages in producer queues.\n",
                "fill": 0,
@@ -9276,9 +13794,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 283
+                  "y": 275
                },
-               "id": 115,
+               "id": 108,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9308,11 +13826,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_msg_cnt{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_msg_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -9358,7 +13941,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of requests sent to Kafka brokers.\nGraph shows mean requests per second.\n",
                "fill": 0,
@@ -9366,9 +13949,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 291
+                  "y": 283
                },
-               "id": 116,
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9398,11 +13981,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_tx{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_tx"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -9448,7 +14102,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Amount of bytes transmitted to Kafka brokers.\nGraph shows mean bytes per second.\n",
                "fill": 0,
@@ -9456,9 +14110,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 291
+                  "y": 283
                },
-               "id": 117,
+               "id": 110,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9488,11 +14142,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_tx_bytes{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_tx_bytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -9538,7 +14263,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of responses received from Kafka brokers.\nGraph shows mean responses per second.\n",
                "fill": 0,
@@ -9546,9 +14271,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 291
+                  "y": 283
                },
-               "id": 118,
+               "id": 111,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9578,11 +14303,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_rx{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_rx"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -9628,7 +14424,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Amount of bytes received from Kafka brokers.\nGraph shows mean bytes per second.\n",
                "fill": 0,
@@ -9636,9 +14432,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 291
+                  "y": 283
                },
-               "id": 119,
+               "id": 112,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9668,11 +14464,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_rx_bytes{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_rx_bytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -9718,7 +14585,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of messages transmitted (produced) to Kafka brokers.\nGraph shows mean messages per second.\n",
                "fill": 0,
@@ -9726,9 +14593,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 299
+                  "y": 291
                },
-               "id": 120,
+               "id": 113,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9758,11 +14625,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_txmsgs{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_txmsgs"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -9808,7 +14746,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Amount of message bytes (including framing, such as per-Message\nframing and MessageSet/batch framing) transmitted to Kafka brokers.\nGraph shows mean bytes per second.\n",
                "fill": 0,
@@ -9816,9 +14754,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 299
+                  "y": 291
                },
-               "id": 121,
+               "id": 114,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9848,11 +14786,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_txmsg_bytes{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_txmsg_bytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -9898,7 +14907,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of messages consumed, not including ignored\nmessages (due to offset, etc), from Kafka brokers.\n",
                "fill": 0,
@@ -9906,9 +14915,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 299
+                  "y": 291
                },
-               "id": 122,
+               "id": 115,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9938,11 +14947,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_rxmsgs{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_rxmsgs"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -9988,7 +15068,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Amount of message bytes (including framing) received\nfrom Kafka brokers.\nGraph shows mean bytes per second.\n",
                "fill": 0,
@@ -9996,9 +15076,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 299
+                  "y": 291
                },
-               "id": 123,
+               "id": 116,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10028,11 +15108,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_rxmsg_bytes{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_rxmsg_bytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -10089,16 +15240,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 307
+            "y": 299
          },
-         "id": 124,
+         "id": 117,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Time since last broker state change.\n",
                "fill": 0,
@@ -10106,9 +15257,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 308
+                  "y": 300
                },
-               "id": 125,
+               "id": 118,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -10138,11 +15289,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_stateage{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_broker_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_broker_stateage"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -10188,7 +15410,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of connection attempts to a broker, including successful and failed,\nand name resolution failures.\nGraph shows mean attempts per second.\n",
                "fill": 0,
@@ -10196,9 +15418,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 308
+                  "y": 300
                },
-               "id": 126,
+               "id": 119,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10228,11 +15450,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_connects{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_broker_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_broker_connects"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -10278,7 +15577,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of disconnects from a broker (triggered by broker, network, load-balancer, etc.)\nGraph shows mean disconnects per second.\n",
                "fill": 0,
@@ -10286,9 +15585,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 308
+                  "y": 300
                },
-               "id": 127,
+               "id": 120,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10318,11 +15617,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_disconnects{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_broker_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_broker_disconnects"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -10368,7 +15744,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of broker thread poll wakeups.\nGraph shows mean wakeups per second.\n",
                "fill": 0,
@@ -10376,9 +15752,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 308
+                  "y": 300
                },
-               "id": 128,
+               "id": 121,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10408,11 +15784,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_wakeups{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_broker_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_broker_wakeups"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -10458,7 +15911,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of requests awaiting transmission to a broker.\n",
                "fill": 0,
@@ -10466,9 +15919,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 316
+                  "y": 308
                },
-               "id": 129,
+               "id": 122,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10498,11 +15951,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_outbuf_cnt{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_broker_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_broker_outbuf_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -10548,7 +16072,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of messages awaiting transmission to a broker.\n",
                "fill": 0,
@@ -10556,9 +16080,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 316
+                  "y": 308
                },
-               "id": 130,
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10588,11 +16112,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_outbuf_msg_cnt{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_broker_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_broker_outbuf_msg_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -10638,7 +16233,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of requests in-flight to a broker awaiting response.\n",
                "fill": 0,
@@ -10646,9 +16241,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 316
+                  "y": 308
                },
-               "id": 131,
+               "id": 124,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10678,11 +16273,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_waitresp_cnt{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_broker_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_broker_waitresp_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -10728,7 +16394,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of messages in-flight to a broker awaiting response.\n",
                "fill": 0,
@@ -10736,9 +16402,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 316
+                  "y": 308
                },
-               "id": 132,
+               "id": 125,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10768,11 +16434,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_waitresp_msg_cnt{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_broker_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_broker_waitresp_msg_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -10818,7 +16555,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of requests sent to a broker.\nGraph shows mean attempts per second.\n",
                "fill": 0,
@@ -10826,9 +16563,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 324
+                  "y": 316
                },
-               "id": 133,
+               "id": 126,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10858,11 +16595,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_tx{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_broker_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_broker_tx"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -10908,7 +16722,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Amount of bytes sent to a broker.\nGraph shows mean bytes per second.\n",
                "fill": 0,
@@ -10916,9 +16730,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 324
+                  "y": 316
                },
-               "id": 134,
+               "id": 127,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10948,11 +16762,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_txbytes{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_broker_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_broker_txbytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -10998,7 +16889,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of transmission errors to a broker.\nGraph shows mean errors per second.\n",
                "fill": 0,
@@ -11006,9 +16897,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 324
+                  "y": 316
                },
-               "id": 135,
+               "id": 128,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11038,11 +16929,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_txerrs{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_broker_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_broker_txerrs"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -11088,7 +17056,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of request retries to a broker.\nGraph shows mean retries per second.\n",
                "fill": 0,
@@ -11096,9 +17064,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 332
+                  "y": 324
                },
-               "id": 136,
+               "id": 129,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11128,11 +17096,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_txretries{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_broker_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_broker_txretries"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -11178,7 +17223,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Time since last socket send to a broker (or -1 if no sends yet for current connection).\n",
                "fill": 0,
@@ -11186,9 +17231,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 332
+                  "y": 324
                },
-               "id": 137,
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -11218,11 +17263,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_txidle{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_broker_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_broker_txidle"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -11268,7 +17384,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of requests timed out for a broker.\nGraph shows mean retries per second.\n",
                "fill": 0,
@@ -11276,9 +17392,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 332
+                  "y": 324
                },
-               "id": 138,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11308,11 +17424,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_req_timeouts{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_broker_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_broker_req_timeouts"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -11358,7 +17551,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of responses received from a broker.\nGraph shows mean attempts per second.\n",
                "fill": 0,
@@ -11366,9 +17559,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 340
+                  "y": 332
                },
-               "id": 139,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11398,11 +17591,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_rx{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_broker_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_broker_rx"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -11448,7 +17718,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Amount of bytes received from a broker.\nGraph shows mean bytes per second.\n",
                "fill": 0,
@@ -11456,9 +17726,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 340
+                  "y": 332
                },
-               "id": 140,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11488,11 +17758,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_rxbytes{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_broker_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_broker_rxbytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -11538,7 +17885,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of errors received from a broker.\nGraph shows mean errors per second.\n",
                "fill": 0,
@@ -11546,9 +17893,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 340
+                  "y": 332
                },
-               "id": 141,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11578,11 +17925,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_rxerrs{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_broker_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_broker_rxerrs"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -11628,7 +18052,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of mber of unmatched correlation ids in response\n(typically for timed out requests).\nGraph shows mean errors per second.\n",
                "fill": 0,
@@ -11636,9 +18060,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 348
+                  "y": 340
                },
-               "id": 142,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11668,11 +18092,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_rxcorriderrs{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_broker_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_broker_rxcorriderrs"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -11718,7 +18219,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Time since last socket receive (or -1 if no sends yet for current connection).\n",
                "fill": 0,
@@ -11726,9 +18227,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 348
+                  "y": 340
                },
-               "id": 143,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -11758,11 +18259,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_rxidle{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_broker_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_broker_rxidle"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -11808,7 +18380,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of partial MessageSets received.\nGraph shows mean retries per second.\n",
                "fill": 0,
@@ -11816,9 +18388,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 348
+                  "y": 340
                },
-               "id": 144,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11848,11 +18420,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_rxpartial{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_broker_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_broker_rxpartial"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -11898,7 +18547,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of requests sent, separated by type.\nGraph shows mean requests per second.\n",
                "fill": 0,
@@ -11906,9 +18555,9 @@
                   "h": 10,
                   "w": 24,
                   "x": 0,
-                  "y": 356
+                  "y": 348
                },
-               "id": 145,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11938,11 +18587,94 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_req{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{request}} — {{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_request — $tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_broker_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_request"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_broker_req"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -11988,7 +18720,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "99th percentile of internal producer queue latency.\n",
                "fill": 0,
@@ -11996,9 +18728,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 366
+                  "y": 358
                },
-               "id": 146,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12028,11 +18760,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_int_latency{job=~\"$job\",alias=~\"$alias\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_broker_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_broker_int_latency"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -12078,7 +18887,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "99th percentile of internal request queue latency.\n",
                "fill": 0,
@@ -12086,9 +18895,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 366
+                  "y": 358
                },
-               "id": 147,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12118,11 +18927,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_outbuf_latency{job=~\"$job\",alias=~\"$alias\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_broker_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_broker_outbuf_latency"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -12168,7 +19054,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "99th percentile of round-trip time.\n",
                "fill": 0,
@@ -12176,9 +19062,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 366
+                  "y": 358
                },
-               "id": 148,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12208,11 +19094,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_rtt{job=~\"$job\",alias=~\"$alias\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_broker_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_broker_rtt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -12258,7 +19221,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "99th percentile of broker throttling time.\n",
                "fill": 0,
@@ -12266,9 +19229,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 366
+                  "y": 358
                },
-               "id": 149,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12298,11 +19261,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_throttle{job=~\"$job\",alias=~\"$alias\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_broker_name) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_broker_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_broker_throttle"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -12359,16 +19399,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 374
+            "y": 366
          },
-         "id": 150,
+         "id": 143,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Age of client's topic object.\n",
                "fill": 0,
@@ -12376,9 +19416,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 375
+                  "y": 367
                },
-               "id": 151,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12408,11 +19448,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_age{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{topic}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_topic) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_topic"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_topic_age"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -12458,7 +19569,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Age of metadata from broker for this topic.\n",
                "fill": 0,
@@ -12466,9 +19577,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 375
+                  "y": 367
                },
-               "id": 152,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12498,11 +19609,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_metadata_age{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{topic}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_topic) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_topic"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_topic_metadata_age"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -12548,7 +19730,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "99th percentile of batch size.\n",
                "fill": 0,
@@ -12556,9 +19738,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 383
+                  "y": 375
                },
-               "id": 153,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12588,11 +19770,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_batchsize{job=~\"$job\",alias=~\"$alias\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{topic}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_topic) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_topic"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_topic_batchsize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -12638,7 +19897,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "99th percentile of batch message count.\n",
                "fill": 0,
@@ -12646,9 +19905,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 383
+                  "y": 375
                },
-               "id": 154,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12678,11 +19937,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_batchcnt{job=~\"$job\",alias=~\"$alias\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{topic}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_topic) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_topic"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_topic_batchcnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -12728,7 +20064,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of messages waiting to be produced in first-level\nqueue of a partition.\n",
                "fill": 0,
@@ -12736,9 +20072,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 391
+                  "y": 383
                },
-               "id": 155,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12768,11 +20104,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_partitions_msgq_cnt{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_topic, $tag_label_pairs_partition) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_topic"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_partition"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_topic_partitions_msgq_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -12818,7 +20231,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of messages ready to be produced in transmit\nqueue of a partition.\n",
                "fill": 0,
@@ -12826,9 +20239,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 391
+                  "y": 383
                },
-               "id": 156,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12858,11 +20271,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_partitions_xmit_msgq_cnt{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_topic, $tag_label_pairs_partition) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_topic"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_partition"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_topic_partitions_xmit_msgq_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -12908,7 +20398,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of pre-fetched messages in fetch\nqueue of a partition.\n",
                "fill": 0,
@@ -12916,9 +20406,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 391
+                  "y": 383
                },
-               "id": 157,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12948,11 +20438,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_partitions_fetchq_cnt{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_topic, $tag_label_pairs_partition) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_topic"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_partition"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_topic_partitions_fetchq_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -12998,7 +20565,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Amount of message bytes waiting to be produced in first-level\nqueue of a partition.\n",
                "fill": 0,
@@ -13006,9 +20573,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 399
+                  "y": 391
                },
-               "id": 158,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13038,11 +20605,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_partitions_msgq_bytes{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_topic, $tag_label_pairs_partition) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_topic"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_partition"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_topic_partitions_msgq_bytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -13088,7 +20732,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Amount of message bytes ready to be produced in transmit\nqueue of a partition.\n",
                "fill": 0,
@@ -13096,9 +20740,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 399
+                  "y": 391
                },
-               "id": 159,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13128,11 +20772,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_partitions_xmit_msgq_bytes{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_topic, $tag_label_pairs_partition) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_topic"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_partition"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_topic_partitions_xmit_msgq_bytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -13178,7 +20899,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Amount of pre-fetched messages bytes in\nfetch queue of a partition.\n",
                "fill": 0,
@@ -13186,9 +20907,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 399
+                  "y": 391
                },
-               "id": 160,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13218,11 +20939,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_partitions_fetchq_size{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_topic, $tag_label_pairs_partition) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_topic"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_partition"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_topic_partitions_fetchq_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -13268,7 +21066,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of messages transmitted (produced) of a partition topic.\nGraph shows mean messages per second.\n",
                "fill": 0,
@@ -13276,9 +21074,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 407
+                  "y": 399
                },
-               "id": 161,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13308,11 +21106,94 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_topic_partitions_txmsgs{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_topic, $tag_label_pairs_partition) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_topic"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_partition"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_topic_partitions_txmsgs"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -13358,7 +21239,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Amout of message bytes transmitted (produced) of a partition topic.\nGraph shows mean bytes per second.\n",
                "fill": 0,
@@ -13366,9 +21247,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 407
+                  "y": 399
                },
-               "id": 162,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13398,11 +21279,94 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_topic_partitions_txbytes{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_topic, $tag_label_pairs_partition) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_topic"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_partition"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_topic_partitions_txbytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -13448,7 +21412,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of messages consumed, not including ignored messages,\nof a partition topic.\nGraph shows mean messages per second.\n",
                "fill": 0,
@@ -13456,9 +21420,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 407
+                  "y": 399
                },
-               "id": 163,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13488,11 +21452,94 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_topic_partitions_rxmsgs{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_topic, $tag_label_pairs_partition) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_topic"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_partition"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_topic_partitions_rxmsgs"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -13538,7 +21585,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Amout of message bytes consumed, not including ignored messages,\nof a partition topic.\nGraph shows mean bytes per second.\n",
                "fill": 0,
@@ -13546,9 +21593,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 407
+                  "y": 399
                },
-               "id": 164,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13578,11 +21625,94 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_topic_partitions_rxbytes{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_topic, $tag_label_pairs_partition) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_topic"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_partition"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_topic_partitions_rxbytes"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -13628,7 +21758,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of dropped outdated messages of a partition topic.\nGraph shows mean messages per second.\n",
                "fill": 0,
@@ -13636,9 +21766,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 415
+                  "y": 407
                },
-               "id": 165,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13668,11 +21798,94 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_topic_partitions_rx_ver_drops{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_topic, $tag_label_pairs_partition) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_topic"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_partition"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_topic_partitions_rx_ver_drops"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -13718,7 +21931,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Current number of messages in-flight to/from broker\nof a partition topic.\n",
                "fill": 0,
@@ -13726,9 +21939,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 415
+                  "y": 407
                },
-               "id": 166,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13758,11 +21971,88 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_partitions_msgs_inflight{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_topic, $tag_label_pairs_partition) — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_topic"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_partition"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_topic_partitions_msgs_inflight"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -13819,16 +22109,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 423
+            "y": 415
          },
-         "id": 167,
+         "id": 160,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Time elapsed since last state change.\n",
                "fill": 0,
@@ -13836,9 +22126,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 424
+                  "y": 416
                },
-               "id": 168,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -13868,11 +22158,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_cgrp_stateage{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_cgrp_stateage"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -13918,7 +22273,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Time elapsed since last rebalance (assign or revoke).\n",
                "fill": 0,
@@ -13926,9 +22281,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 424
+                  "y": 416
                },
-               "id": 169,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13958,11 +22313,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_cgrp_rebalance_age{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_cgrp_rebalance_age"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -14008,7 +22428,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of rebalances (assign or revoke).\nGraph shows mean requests per second.\n",
                "fill": 0,
@@ -14016,9 +22436,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 432
+                  "y": 424
                },
-               "id": 170,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14048,11 +22468,82 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_cgrp_rebalance_cnt{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_cgrp_rebalance_cnt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -14098,7 +22589,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Current assignment's partition count.\n",
                "fill": 0,
@@ -14106,9 +22597,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 432
+                  "y": 424
                },
-               "id": 171,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14138,11 +22629,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_cgrp_assignment_size{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_cgrp_assignment_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -14199,16 +22755,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 440
+            "y": 432
          },
-         "id": 172,
+         "id": 165,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Time elapsed since last idemp_state change.\n",
                "fill": 0,
@@ -14216,9 +22772,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 441
+                  "y": 433
                },
-               "id": 173,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -14248,11 +22804,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_eos_idemp_stateage{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_eos_idemp_stateage"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -14298,7 +22919,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Time elapsed since last txn_state change.\n",
                "fill": 0,
@@ -14306,9 +22927,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 441
+                  "y": 433
                },
-               "id": 174,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -14338,11 +22959,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_eos_txn_stateage{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias ($tag_label_pairs_type, $tag_label_pairs_connector_name)",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_kafka_eos_txn_stateage"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -14399,16 +23085,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 449
+            "y": 441
          },
-         "id": 175,
+         "id": 168,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "A number of task tuples checked for expiration (expired + skipped).\nGraph shows mean tuples per second.\n",
                "fill": 0,
@@ -14416,9 +23102,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 450
+                  "y": 442
                },
-               "id": 176,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14448,11 +23134,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_expiration_checked_count{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_expiration_checked_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -14498,7 +23243,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "A number of task expired tuples.\nGraph shows mean tuples per second.\n",
                "fill": 0,
@@ -14506,9 +23251,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 450
+                  "y": 442
                },
-               "id": 177,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14538,11 +23283,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_expiration_expired_count{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_expiration_expired_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -14588,7 +23392,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "A number of task restarts since start.\nFrom the start is equal to 1.\n",
                "fill": 0,
@@ -14596,9 +23400,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 458
+                  "y": 450
                },
-               "id": 178,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14628,11 +23432,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_expiration_restarts{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_expiration_restarts"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -14678,7 +23535,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "A task's operation time.\n",
                "fill": 0,
@@ -14686,9 +23543,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 458
+                  "y": 450
                },
-               "id": 179,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14718,11 +23575,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_expiration_working_time{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_expiration_working_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -14779,16 +23689,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 466
+            "y": 458
          },
-         "id": 180,
+         "id": 173,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Amount of tuples scanned in request.\nData resets between each collect.\nGraph shows average per request.\n",
                "fill": 0,
@@ -14796,9 +23706,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 467
+                  "y": 459
                },
-               "id": 181,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14828,11 +23738,28 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_scanned_tuples_sum{job=~\"$job\"} /\ntdg_scanned_tuples_count{job=~\"$job\"}\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type_name}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_type_name — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT mean(\"tdg_scanned_tuples_sum\") / mean(\"tdg_scanned_tuples_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_scanned_tuples_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_scanned_tuples_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_scanned_tuples_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_scanned_tuples_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_type_name\" fill(null)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
                   }
                ],
                "thresholds": [ ],
@@ -14878,7 +23805,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Amount of tuples returned in request.\nData resets between each collect.\nGraph shows average per request.\n",
                "fill": 0,
@@ -14886,9 +23813,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 467
+                  "y": 459
                },
-               "id": 182,
+               "id": 175,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14918,11 +23845,28 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_returned_tuples_sum{job=~\"$job\"} /\ntdg_returned_tuples_count{job=~\"$job\"}\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type_name}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_type_name — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT mean(\"tdg_returned_tuples_sum\") / mean(\"tdg_returned_tuples_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_returned_tuples_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_returned_tuples_sum') AND $timeFilter),\n(SELECT \"value\" as \"tdg_returned_tuples_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_returned_tuples_count') AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_type_name\" fill(null)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
                   }
                ],
                "thresholds": [ ],
@@ -14968,7 +23912,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Amount of tuples scanned in request.\nData resets between each collect.\nGraph shows maximum observation.\n",
                "fill": 0,
@@ -14976,9 +23920,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 475
+                  "y": 467
                },
-               "id": 183,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15008,11 +23952,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_scanned_tuples_max{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_scanned_tuples_max"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -15058,7 +24049,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Amount of tuples returned in request.\nData resets between each collect.\nGraph shows maximum observation.\n",
                "fill": 0,
@@ -15066,9 +24057,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 475
+                  "y": 467
                },
-               "id": 184,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15098,11 +24089,58 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_returned_tuples_max{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_returned_tuples_max"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -15159,16 +24197,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 483
+            "y": 475
          },
-         "id": 185,
+         "id": 178,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "A number of files processed.\n",
                "fill": 0,
@@ -15176,9 +24214,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 484
+                  "y": 476
                },
-               "id": 186,
+               "id": 179,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15208,11 +24246,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_connector_input_file_processed_count{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{connector_name}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_connector_name — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_connector_input_file_processed_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -15258,7 +24349,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "A number of objects processed over all files.\n",
                "fill": 0,
@@ -15266,9 +24357,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 484
+                  "y": 476
                },
-               "id": 187,
+               "id": 180,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15298,11 +24389,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_connector_input_file_processed_objects_count{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{connector_name}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_connector_name — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_connector_input_file_processed_objects_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -15348,7 +24492,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "A number of files failed to process.\n",
                "fill": 0,
@@ -15356,9 +24500,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 484
+                  "y": 476
                },
-               "id": 188,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15388,11 +24532,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_connector_input_file_failed_count{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{connector_name}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_connector_name — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_connector_input_file_failed_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -15438,7 +24635,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Current file size.\n",
                "fill": 0,
@@ -15446,9 +24643,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 492
+                  "y": 484
                },
-               "id": 189,
+               "id": 182,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15478,11 +24675,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_connector_input_file_size{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{connector_name}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_connector_name — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_connector_input_file_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -15528,7 +24778,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Processed bytes count from the current file.\n",
                "fill": 0,
@@ -15536,9 +24786,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 492
+                  "y": 484
                },
-               "id": 190,
+               "id": 183,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15568,11 +24818,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_connector_input_file_current_bytes_processed{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{connector_name}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_connector_name — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_connector_input_file_current_bytes_processed"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -15618,7 +24921,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 0,
                "description": "Processed objects count from the current file.\n",
                "fill": 0,
@@ -15626,9 +24929,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 492
+                  "y": 484
                },
-               "id": 191,
+               "id": 184,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15658,11 +24961,64 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_connector_input_file_current_processed_objects{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{connector_name}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_connector_name — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_connector_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_connector_input_file_current_processed_objects"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -15719,16 +25075,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 500
+            "y": 492
          },
-         "id": 192,
+         "id": 185,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "A number of successfully executed GraphQL queries.\nGraph shows mean requests per second.\n",
                "fill": 0,
@@ -15736,9 +25092,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 501
+                  "y": 493
                },
-               "id": 193,
+               "id": 186,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15768,11 +25124,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_graphql_query_time_count{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{operation_name}} ({{schema}}, {{entity}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_operation_name ($tag_label_pairs_schema, $tag_label_pairs_entity) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_operation_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_schema"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_entity"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_graphql_query_time_count"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -15818,7 +25239,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average time of GraphQL query execution.\nOnly success requests are count.\n",
                "fill": 0,
@@ -15826,9 +25247,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 501
+                  "y": 493
                },
-               "id": 194,
+               "id": 187,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15858,11 +25279,28 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_graphql_query_time_sum{job=~\"$job\",alias=~\"$alias\"} /\ntdg_graphql_query_time_count{job=~\"$job\",alias=~\"$alias\"}\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{operation_name}} ({{schema}}, {{entity}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_operation_name ($tag_label_pairs_schema, $tag_label_pairs_entity) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT mean(\"tdg_graphql_query_time_sum\") / mean(\"tdg_graphql_query_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_graphql_query_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_query_time_sum' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter),\n(SELECT \"value\" as \"tdg_graphql_query_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_query_time_count' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_operation_name\",\n\"label_pairs_schema\", \"label_pairs_entity\" fill(null)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
                   }
                ],
                "thresholds": [ ],
@@ -15908,7 +25346,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "A number of GraphQL queries failed to execute.\nGraph shows mean requests per second.\n",
                "fill": 0,
@@ -15916,9 +25354,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 501
+                  "y": 493
                },
-               "id": 195,
+               "id": 188,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15948,11 +25386,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_graphql_query_fail{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{operation_name}} ({{schema}}, {{entity}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_operation_name ($tag_label_pairs_schema, $tag_label_pairs_entity) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_operation_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_schema"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_entity"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_graphql_query_fail"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -15998,7 +25501,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "A number of successfully executed GraphQL mutations.\nGraph shows mean requests per second.\n",
                "fill": 0,
@@ -16006,9 +25509,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 509
+                  "y": 501
                },
-               "id": 196,
+               "id": 189,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16038,11 +25541,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_graphql_mutation_time_count{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{operation_name}} ({{schema}}, {{entity}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_operation_name ($tag_label_pairs_schema, $tag_label_pairs_entity) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_operation_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_schema"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_entity"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_graphql_mutation_time_count"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -16088,7 +25656,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average time of GraphQL mutation execution.\nOnly success requests are count.\n",
                "fill": 0,
@@ -16096,9 +25664,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 509
+                  "y": 501
                },
-               "id": 197,
+               "id": 190,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16128,11 +25696,28 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_graphql_mutation_time_sum{job=~\"$job\",alias=~\"$alias\"} /\ntdg_graphql_mutation_time_count{job=~\"$job\",alias=~\"$alias\"}\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{operation_name}} ({{schema}}, {{entity}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_operation_name ($tag_label_pairs_schema, $tag_label_pairs_entity) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT mean(\"tdg_graphql_mutation_time_sum\") / mean(\"tdg_graphql_mutation_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_graphql_mutation_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_mutation_time_sum' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter),\n(SELECT \"value\" as \"tdg_graphql_mutation_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_graphql_mutation_time_count' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_operation_name\",\n\"label_pairs_schema\", \"label_pairs_entity\" fill(null)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
                   }
                ],
                "thresholds": [ ],
@@ -16178,7 +25763,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "A number of GraphQL mutations failed to execute.\nGraph shows mean requests per second.\n",
                "fill": 0,
@@ -16186,9 +25771,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 509
+                  "y": 501
                },
-               "id": 198,
+               "id": 191,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16218,11 +25803,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_graphql_mutation_fail{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{operation_name}} ({{schema}}, {{entity}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_operation_name ($tag_label_pairs_schema, $tag_label_pairs_entity) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_operation_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_schema"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_entity"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_graphql_mutation_fail"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -16279,16 +25929,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 517
+            "y": 509
          },
-         "id": 199,
+         "id": 192,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of repository.put method calls through IProto.\nGraph shows mean requests per second.\n",
                "fill": 0,
@@ -16296,9 +25946,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 518
+                  "y": 510
                },
-               "id": 200,
+               "id": 193,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16328,11 +25978,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"$job\",alias=~\"$alias\",method=\"repository.put\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_type — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_iproto_data_query_exec_time_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "=",
+                           "value": "repository.put"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -16378,7 +26093,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "99th percentile of repository.put IProto call execution time.\n",
                "fill": 0,
@@ -16386,9 +26101,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 518
+                  "y": 510
                },
-               "id": 201,
+               "id": 194,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16418,11 +26133,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"$job\",alias=~\"$alias\",method=\"repository.put\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_type — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "=",
+                           "value": "repository.put"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -16468,7 +26248,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of repository.put_batch method calls through IProto.\nGraph shows mean requests per second.\n",
                "fill": 0,
@@ -16476,9 +26256,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 518
+                  "y": 510
                },
-               "id": 202,
+               "id": 195,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16508,11 +26288,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"$job\",alias=~\"$alias\",method=\"repository.put_batch\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_type — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_iproto_data_query_exec_time_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "=",
+                           "value": "repository.put_batch"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -16558,7 +26403,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "99th percentile of repository.put_batch IProto call execution time.\n",
                "fill": 0,
@@ -16566,9 +26411,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 518
+                  "y": 510
                },
-               "id": 203,
+               "id": 196,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16598,11 +26443,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"$job\",alias=~\"$alias\",method=\"repository.put_batch\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_type — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "=",
+                           "value": "repository.put_batch"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -16648,7 +26558,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of repository.find method calls through IProto.\nGraph shows mean requests per second.\n",
                "fill": 0,
@@ -16656,9 +26566,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 526
+                  "y": 518
                },
-               "id": 204,
+               "id": 197,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16688,11 +26598,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"$job\",alias=~\"$alias\",method=\"repository.find\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_type — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_iproto_data_query_exec_time_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "=",
+                           "value": "repository.find"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -16738,7 +26713,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "99th percentile of repository.find IProto call execution time.\n",
                "fill": 0,
@@ -16746,9 +26721,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 526
+                  "y": 518
                },
-               "id": 205,
+               "id": 198,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16778,11 +26753,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"$job\",alias=~\"$alias\",method=\"repository.find\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_type — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "=",
+                           "value": "repository.find"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -16828,7 +26868,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of repository.update method calls through IProto.\nGraph shows mean requests per second.\n",
                "fill": 0,
@@ -16836,9 +26876,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 534
+                  "y": 526
                },
-               "id": 206,
+               "id": 199,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16868,11 +26908,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"$job\",alias=~\"$alias\",method=\"repository.update\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_type — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_iproto_data_query_exec_time_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "=",
+                           "value": "repository.update"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -16918,7 +27023,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "99th percentile of repository.update IProto call execution time.\n",
                "fill": 0,
@@ -16926,9 +27031,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 534
+                  "y": 526
                },
-               "id": 207,
+               "id": 200,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16958,11 +27063,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"$job\",alias=~\"$alias\",method=\"repository.update\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_type — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "=",
+                           "value": "repository.update"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -17008,7 +27178,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of repository.get method calls through IProto.\nGraph shows mean requests per second.\n",
                "fill": 0,
@@ -17016,9 +27186,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 534
+                  "y": 526
                },
-               "id": 208,
+               "id": 201,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17048,11 +27218,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"$job\",alias=~\"$alias\",method=\"repository.get\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_type — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_iproto_data_query_exec_time_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "=",
+                           "value": "repository.get"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -17098,7 +27333,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "99th percentile of repository.get IProto call execution time.\n",
                "fill": 0,
@@ -17106,9 +27341,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 534
+                  "y": 526
                },
-               "id": 209,
+               "id": 202,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17138,11 +27373,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"$job\",alias=~\"$alias\",method=\"repository.get\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_type — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "=",
+                           "value": "repository.get"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -17188,7 +27488,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of repository.delete method calls through IProto.\nGraph shows mean requests per second.\n",
                "fill": 0,
@@ -17196,9 +27496,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 542
+                  "y": 534
                },
-               "id": 210,
+               "id": 203,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17228,11 +27528,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"$job\",alias=~\"$alias\",method=\"repository.delete\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_type — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_iproto_data_query_exec_time_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "=",
+                           "value": "repository.delete"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -17278,7 +27643,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "99th percentile of repository.delete IProto call execution time.\n",
                "fill": 0,
@@ -17286,9 +27651,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 542
+                  "y": 534
                },
-               "id": 211,
+               "id": 204,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17318,11 +27683,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"$job\",alias=~\"$alias\",method=\"repository.delete\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_type — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "=",
+                           "value": "repository.delete"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -17368,7 +27798,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of repository.count method calls through IProto.\nGraph shows mean requests per second.\n",
                "fill": 0,
@@ -17376,9 +27806,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 542
+                  "y": 534
                },
-               "id": 212,
+               "id": 205,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17408,11 +27838,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"$job\",alias=~\"$alias\",method=\"repository.count\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_type — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_iproto_data_query_exec_time_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "=",
+                           "value": "repository.count"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -17458,7 +27953,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "99th percentile of repository.count IProto call execution time.\n",
                "fill": 0,
@@ -17466,9 +27961,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 542
+                  "y": 534
                },
-               "id": 213,
+               "id": 206,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17498,11 +27993,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"$job\",alias=~\"$alias\",method=\"repository.count\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_type — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "=",
+                           "value": "repository.count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -17548,7 +28108,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of repository.map_reduce method calls through IProto.\nGraph shows mean requests per second.\n",
                "fill": 0,
@@ -17556,9 +28116,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 550
+                  "y": 542
                },
-               "id": 214,
+               "id": 207,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17588,11 +28148,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"$job\",alias=~\"$alias\",method=\"repository.map_reduce\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_type — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_iproto_data_query_exec_time_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "=",
+                           "value": "repository.map_reduce"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -17638,7 +28263,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "99th percentile of repository.map_reduce IProto call execution time.\n",
                "fill": 0,
@@ -17646,9 +28271,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 550
+                  "y": 542
                },
-               "id": 215,
+               "id": 208,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17678,11 +28303,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"$job\",alias=~\"$alias\",method=\"repository.map_reduce\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_type — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "=",
+                           "value": "repository.map_reduce"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -17728,7 +28418,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of repository.call_on_storage method calls through IProto.\nGraph shows mean requests per second.\n",
                "fill": 0,
@@ -17736,9 +28426,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 550
+                  "y": 542
                },
-               "id": 216,
+               "id": 209,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17768,11 +28458,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"$job\",alias=~\"$alias\",method=\"repository.call_on_storage\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_type — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_iproto_data_query_exec_time_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "=",
+                           "value": "repository.call_on_storage"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -17818,7 +28573,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "99th percentile of repository.call_on_storage IProto call execution time.\n",
                "fill": 0,
@@ -17826,9 +28581,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 550
+                  "y": 542
                },
-               "id": 217,
+               "id": 210,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17858,11 +28613,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"$job\",alias=~\"$alias\",method=\"repository.call_on_storage\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_type — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_iproto_data_query_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "=",
+                           "value": "repository.call_on_storage"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -17919,16 +28739,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 558
+            "y": 550
          },
-         "id": 218,
+         "id": 211,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of TDG REST API GET requests processed with code 2xx.\nGraph shows mean requests per second.\n",
                "fill": 0,
@@ -17936,9 +28756,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 559
+                  "y": 551
                },
-               "id": 219,
+               "id": 212,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17968,11 +28788,94 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_rest_exec_time_count{job=~\"$job\",alias=~\"$alias\",method=\"GET\",status_code=~\"^2\\\\d{2}$\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_method $tag_label_pairs_type (code $tag_label_pairs_status_code) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_status_code"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_method"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_rest_exec_time_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "=",
+                           "value": "GET"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status_code",
+                           "operator": "=~",
+                           "value": "/^2\\d{2}$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -18018,7 +28921,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of TDG REST API GET requests processed with code 4xx.\nGraph shows mean requests per second.\n",
                "fill": 0,
@@ -18026,9 +28929,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 559
+                  "y": 551
                },
-               "id": 220,
+               "id": 213,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18058,11 +28961,94 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_rest_exec_time_count{job=~\"$job\",alias=~\"$alias\",method=\"GET\",status_code=~\"^4\\\\d{2}$\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_method $tag_label_pairs_type (code $tag_label_pairs_status_code) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_status_code"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_method"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_rest_exec_time_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "=",
+                           "value": "GET"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status_code",
+                           "operator": "=~",
+                           "value": "/^4\\d{2}$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -18108,7 +29094,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of TDG REST API GET requests processed with code 5xx.\nGraph shows mean requests per second.\n",
                "fill": 0,
@@ -18116,9 +29102,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 559
+                  "y": 551
                },
-               "id": 221,
+               "id": 214,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18148,11 +29134,94 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_rest_exec_time_count{job=~\"$job\",alias=~\"$alias\",method=\"GET\",status_code=~\"^5\\\\d{2}$\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_method $tag_label_pairs_type (code $tag_label_pairs_status_code) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_status_code"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_method"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_rest_exec_time_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "=",
+                           "value": "GET"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status_code",
+                           "operator": "=~",
+                           "value": "/^5\\d{2}$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -18198,7 +29267,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "99th percentile of TDG REST API request execution time.\nOnly GET requests processed with code 2xx are displayed.\n",
                "fill": 0,
@@ -18206,9 +29275,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 567
+                  "y": 559
                },
-               "id": 222,
+               "id": 215,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18238,11 +29307,94 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_rest_exec_time{job=~\"$job\",alias=~\"$alias\",method=\"GET\",status_code=~\"^2\\\\d{2}$\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_method $tag_label_pairs_type (code $tag_label_pairs_status_code) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_status_code"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_method"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_rest_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "=",
+                           "value": "GET"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status_code",
+                           "operator": "=~",
+                           "value": "/^2\\d{2}$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -18288,7 +29440,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "99th percentile of TDG REST API request execution time.\nOnly GET requests processed with code 4xx are displayed.\n",
                "fill": 0,
@@ -18296,9 +29448,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 567
+                  "y": 559
                },
-               "id": 223,
+               "id": 216,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18328,11 +29480,94 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_rest_exec_time{job=~\"$job\",alias=~\"$alias\",method=\"GET\",status_code=~\"^4\\\\d{2}$\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_method $tag_label_pairs_type (code $tag_label_pairs_status_code) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_status_code"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_method"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_rest_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "=",
+                           "value": "GET"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status_code",
+                           "operator": "=~",
+                           "value": "/^4\\d{2}$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -18378,7 +29613,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "99th percentile of TDG REST API request execution time.\nOnly GET requests processed with code 5xx are displayed.\n",
                "fill": 0,
@@ -18386,9 +29621,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 567
+                  "y": 559
                },
-               "id": 224,
+               "id": 217,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18418,11 +29653,94 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_rest_exec_time{job=~\"$job\",alias=~\"$alias\",method=\"GET\",status_code=~\"^5\\\\d{2}$\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_method $tag_label_pairs_type (code $tag_label_pairs_status_code) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_status_code"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_method"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_rest_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "=",
+                           "value": "GET"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status_code",
+                           "operator": "=~",
+                           "value": "/^5\\d{2}$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -18468,7 +29786,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of TDG REST API POST/PUT/DELETE requests\nprocessed with code 2xx.\nGraph shows mean requests per second.\n",
                "fill": 0,
@@ -18476,9 +29794,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 575
+                  "y": 567
                },
-               "id": 225,
+               "id": 218,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18508,11 +29826,94 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_rest_exec_time_count{job=~\"$job\",alias=~\"$alias\",method!=\"GET\",status_code=~\"^2\\\\d{2}$\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_method $tag_label_pairs_type (code $tag_label_pairs_status_code) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_status_code"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_method"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_rest_exec_time_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "!=",
+                           "value": "GET"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status_code",
+                           "operator": "=~",
+                           "value": "/^2\\d{2}$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -18558,7 +29959,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of TDG REST API POST/PUT/DELETE requests\nprocessed with code 4xx.\nGraph shows mean requests per second.\n",
                "fill": 0,
@@ -18566,9 +29967,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 575
+                  "y": 567
                },
-               "id": 226,
+               "id": 219,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18598,11 +29999,94 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_rest_exec_time_count{job=~\"$job\",alias=~\"$alias\",method!=\"GET\",status_code=~\"^4\\\\d{2}$\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_method $tag_label_pairs_type (code $tag_label_pairs_status_code) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_status_code"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_method"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_rest_exec_time_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "!=",
+                           "value": "GET"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status_code",
+                           "operator": "=~",
+                           "value": "/^4\\d{2}$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -18648,7 +30132,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of TDG REST API POST/PUT/DELETE requests\nprocessed with code 5xx.\nGraph shows mean requests per second.\n",
                "fill": 0,
@@ -18656,9 +30140,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 575
+                  "y": 567
                },
-               "id": 227,
+               "id": 220,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18688,11 +30172,94 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_rest_exec_time_count{job=~\"$job\",alias=~\"$alias\",method!=\"GET\",status_code=~\"^5\\\\d{2}$\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_method $tag_label_pairs_type (code $tag_label_pairs_status_code) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_status_code"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_method"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_rest_exec_time_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "!=",
+                           "value": "GET"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status_code",
+                           "operator": "=~",
+                           "value": "/^5\\d{2}$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -18738,7 +30305,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "99th percentile of TDG REST API request execution time.\nOnly POST/PUT/DELETE requests processed with code 2xx\nare displayed.\n",
                "fill": 0,
@@ -18746,9 +30313,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 583
+                  "y": 575
                },
-               "id": 228,
+               "id": 221,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18778,11 +30345,94 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_rest_exec_time{job=~\"$job\",alias=~\"$alias\",method!=\"GET\",status_code=~\"^2\\\\d{2}$\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_method $tag_label_pairs_type (code $tag_label_pairs_status_code) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_status_code"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_method"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_rest_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "!=",
+                           "value": "GET"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status_code",
+                           "operator": "=~",
+                           "value": "/^2\\d{2}$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -18828,7 +30478,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "99th percentile of TDG REST API request execution time.\nOnly POST/PUT/DELETE requests processed with code 4xx\nare displayed.\n",
                "fill": 0,
@@ -18836,9 +30486,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 583
+                  "y": 575
                },
-               "id": 229,
+               "id": 222,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18868,11 +30518,94 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_rest_exec_time{job=~\"$job\",alias=~\"$alias\",method!=\"GET\",status_code=~\"^4\\\\d{2}$\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_method $tag_label_pairs_type (code $tag_label_pairs_status_code) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_status_code"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_method"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_rest_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "!=",
+                           "value": "GET"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status_code",
+                           "operator": "=~",
+                           "value": "/^4\\d{2}$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -18918,7 +30651,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "99th percentile of TDG REST API request execution time.\nOnly POST/PUT/DELETE requests processed with code 5xx\nare displayed.\n",
                "fill": 0,
@@ -18926,9 +30659,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 583
+                  "y": 575
                },
-               "id": 230,
+               "id": 223,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18958,11 +30691,94 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_rest_exec_time{job=~\"$job\",alias=~\"$alias\",method!=\"GET\",status_code=~\"^5\\\\d{2}$\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_method $tag_label_pairs_type (code $tag_label_pairs_status_code) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_type"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_status_code"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_method"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_rest_exec_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_method",
+                           "operator": "!=",
+                           "value": "GET"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_status_code",
+                           "operator": "=~",
+                           "value": "/^5\\d{2}$/"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_quantile",
+                           "operator": "=",
+                           "value": "0.99"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -19019,16 +30835,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 591
+            "y": 583
          },
-         "id": 231,
+         "id": 224,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of TDG jobs started.\nGraph shows mean jobs per second.\n",
                "fill": 0,
@@ -19036,9 +30852,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 592
+                  "y": 584
                },
-               "id": 232,
+               "id": 225,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19068,11 +30884,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_jobs_started{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_kind"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_jobs_started"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -19118,7 +30999,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of TDG jobs failed.\nGraph shows mean jobs per second.\n",
                "fill": 0,
@@ -19126,9 +31007,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 592
+                  "y": 584
                },
-               "id": 233,
+               "id": 226,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19158,11 +31039,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_jobs_failed{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_kind"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_jobs_failed"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -19208,7 +31154,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of TDG jobs succeeded.\nGraph shows mean jobs per second.\n",
                "fill": 0,
@@ -19216,9 +31162,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 592
+                  "y": 584
                },
-               "id": 234,
+               "id": 227,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19248,11 +31194,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_jobs_succeeded{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_kind"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_jobs_succeeded"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -19298,7 +31309,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of TDG jobs running now.\n",
                "fill": 0,
@@ -19306,9 +31317,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 600
+                  "y": 592
                },
-               "id": 235,
+               "id": 228,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -19338,11 +31349,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_jobs_running{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_kind"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_jobs_running"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -19388,7 +31458,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average time of TDG job execution.\n",
                "fill": 0,
@@ -19396,9 +31466,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 600
+                  "y": 592
                },
-               "id": 236,
+               "id": 229,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19428,11 +31498,28 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_jobs_execution_time_sum{job=~\"$job\",alias=~\"$alias\"} /\ntdg_jobs_execution_time_count{job=~\"$job\",alias=~\"$alias\"}\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT mean(\"tdg_jobs_execution_time_sum\") / mean(\"tdg_jobs_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_jobs_execution_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_jobs_execution_time_sum' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter),\n(SELECT \"value\" as \"tdg_jobs_execution_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_jobs_execution_time_count' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\" fill(null)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
                   }
                ],
                "thresholds": [ ],
@@ -19478,7 +31565,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of TDG tasks started.\nGraph shows mean tasks per second.\n",
                "fill": 0,
@@ -19486,9 +31573,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 608
+                  "y": 600
                },
-               "id": 237,
+               "id": 230,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19518,11 +31605,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_tasks_started{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_kind) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_kind"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_tasks_started"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -19568,7 +31720,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of TDG tasks failed.\nGraph shows mean tasks per second.\n",
                "fill": 0,
@@ -19576,9 +31728,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 608
+                  "y": 600
                },
-               "id": 238,
+               "id": 231,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19608,11 +31760,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_tasks_failed{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_kind) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_kind"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_tasks_failed"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -19658,7 +31875,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of TDG tasks succeeded.\nGraph shows mean tasks per second.\n",
                "fill": 0,
@@ -19666,9 +31883,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 608
+                  "y": 600
                },
-               "id": 239,
+               "id": 232,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19698,11 +31915,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_tasks_succeeded{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_kind) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_kind"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_tasks_succeeded"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -19748,7 +32030,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of TDG tasks stopped.\nGraph shows mean tasks per second.\n",
                "fill": 0,
@@ -19756,9 +32038,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 608
+                  "y": 600
                },
-               "id": 240,
+               "id": 233,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19788,11 +32070,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_tasks_stopped{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_kind) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_kind"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_tasks_stopped"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -19838,7 +32185,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of TDG tasks running now.\n",
                "fill": 0,
@@ -19846,9 +32193,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 616
+                  "y": 608
                },
-               "id": 241,
+               "id": 234,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -19878,11 +32225,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_tasks_running{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_kind) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_kind"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_tasks_running"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -19928,7 +32334,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average time of TDG task execution.\n",
                "fill": 0,
@@ -19936,9 +32342,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 616
+                  "y": 608
                },
-               "id": 242,
+               "id": 235,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19968,11 +32374,28 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_tasks_execution_time_sum{job=~\"$job\",alias=~\"$alias\"} /\ntdg_tasks_execution_time_count{job=~\"$job\",alias=~\"$alias\"}\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_kind) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT mean(\"tdg_tasks_execution_time_sum\") / mean(\"tdg_tasks_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_tasks_execution_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_tasks_execution_time_sum' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter),\n(SELECT \"value\" as \"tdg_tasks_execution_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_tasks_execution_time_count' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\",\n\"label_pairs_kind\" fill(null)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
                   }
                ],
                "thresholds": [ ],
@@ -20018,7 +32441,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of TDG system tasks started.\nGraph shows mean tasks per second.\n",
                "fill": 0,
@@ -20026,9 +32449,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 624
+                  "y": 616
                },
-               "id": 243,
+               "id": 236,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20058,11 +32481,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_system_tasks_started{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_kind) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_kind"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_system_tasks_started"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -20108,7 +32596,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of TDG system tasks failed.\nGraph shows mean tasks per second.\n",
                "fill": 0,
@@ -20116,9 +32604,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 624
+                  "y": 616
                },
-               "id": 244,
+               "id": 237,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20148,11 +32636,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_system_tasks_failed{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_kind) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_kind"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_system_tasks_failed"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -20198,7 +32751,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of TDG system tasks succeeded.\nGraph shows mean tasks per second.\n",
                "fill": 0,
@@ -20206,9 +32759,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 624
+                  "y": 616
                },
-               "id": 245,
+               "id": 238,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20238,11 +32791,76 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_system_tasks_succeeded{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_kind) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_kind"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           },
+                           {
+                              "params": [
+                                 "1s"
+                              ],
+                              "type": "non_negative_derivative"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_system_tasks_succeeded"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -20288,7 +32906,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Number of TDG system tasks running now.\n",
                "fill": 0,
@@ -20296,9 +32914,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 632
+                  "y": 624
                },
-               "id": 246,
+               "id": 239,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -20328,11 +32946,70 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_system_tasks_running{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_kind) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_name"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_kind"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "null"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "tarantool_http",
+                     "policy": "autogen",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tdg_system_tasks_running"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
                   }
                ],
                "thresholds": [ ],
@@ -20378,7 +33055,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "influxdb",
                "decimals": 3,
                "description": "Average time of TDG system task execution.\n",
                "fill": 0,
@@ -20386,9 +33063,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 632
+                  "y": 624
                },
-               "id": 247,
+               "id": 240,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20418,11 +33095,28 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_system_tasks_execution_time_sum{job=~\"$job\",alias=~\"$alias\"} /\ntdg_system_tasks_execution_time_count{job=~\"$job\",alias=~\"$alias\"}\n",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
-                     "refId": "A"
+                     "alias": "$tag_label_pairs_name ($tag_label_pairs_kind) — $tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT mean(\"tdg_system_tasks_execution_time_sum\") / mean(\"tdg_system_tasks_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_system_tasks_execution_time_sum\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_system_tasks_execution_time_sum' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter),\n(SELECT \"value\" as \"tdg_system_tasks_execution_time_count\" FROM \"autogen\".\"tarantool_http\"\nWHERE (\"metric_name\" = 'tdg_system_tasks_execution_time_count' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\",\n\"label_pairs_kind\" fill(null)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
                   }
                ],
                "thresholds": [ ],
@@ -20478,46 +33172,24 @@
    "schemaVersion": 21,
    "style": "dark",
    "tags": [
-      "tarantool",
-      "TDG"
+      "tarantool"
    ],
    "templating": {
       "list": [
          {
             "allValue": null,
             "current": {
-               "text": "${PROMETHEUS_JOB}",
-               "value": "${PROMETHEUS_JOB}"
-            },
-            "hide": 2,
-            "includeAll": false,
-            "label": "Prometheus job",
-            "multi": false,
-            "name": "job",
-            "options": [
-               {
-                  "text": "${PROMETHEUS_JOB}",
-                  "value": "${PROMETHEUS_JOB}"
-               }
-            ],
-            "query": "${PROMETHEUS_JOB}",
-            "refresh": 0,
-            "type": "custom"
-         },
-         {
-            "allValue": null,
-            "current": {
                "text": "all",
                "value": "$__all"
             },
-            "datasource": "${DS_PROMETHEUS}",
+            "datasource": "influxdb",
             "hide": 0,
             "includeAll": true,
             "label": "Instances",
             "multi": true,
             "name": "alias",
             "options": [ ],
-            "query": "label_values(tnt_info_uptime{job=~\"$job\"},alias)",
+            "query": "SHOW TAG VALUES FROM \"autogen\".\"tarantool_http\" WITH KEY=\"label_pairs_alias\"",
             "refresh": 2,
             "regex": "",
             "sort": 0,

--- a/tests/InfluxDB/dashboard_with_custom_panels.jsonnet
+++ b/tests/InfluxDB/dashboard_with_custom_panels.jsonnet
@@ -22,6 +22,7 @@ dashboard.addPanels([
     metric_name='my_component_status',
     policy=variable.influxdb.policy,
     measurement=variable.influxdb.measurement,
+    alias=variable.influxdb.alias,
     converter='last',
   )),
 
@@ -40,6 +41,7 @@ dashboard.addPanels([
     metric_name='my_component_load_metric_count',
     policy=variable.influxdb.policy,
     measurement=variable.influxdb.measurement,
+    alias=variable.influxdb.alias,
   )),
 
   common.default_graph(
@@ -60,7 +62,9 @@ dashboard.addPanels([
       group_tags=['label_pairs_alias'],
       alias='$tag_label_pairs_alias',
       fill='null',
-    ).where('metric_name', '=', 'my_component_load_metric').where('label_pairs_quantile', '=', '0.99')
+    ).where('metric_name', '=', 'my_component_load_metric')
+    .where('label_pairs_alias', '=~', variable.influxdb.alias)
+    .where('label_pairs_quantile', '=', '0.99')
     .selectField('value').addConverter('mean')
   ),
 ]).build()

--- a/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
+++ b/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
@@ -169,6 +169,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_level",
                            "operator": "=",
                            "value": "warning"
@@ -303,6 +309,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_cartridge_issues"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -506,6 +518,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_replication_status"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -656,6 +674,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_read_only"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -757,6 +781,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_replication_lag"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -891,6 +921,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_clock_delta"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -1067,6 +1103,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_status",
                            "operator": "=~",
                            "value": "/^2\\d{2}$/"
@@ -1225,6 +1267,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "http_server_request_latency_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -1389,6 +1437,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_status",
                            "operator": "=~",
                            "value": "/^5\\d{2}$/"
@@ -1541,6 +1595,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "http_server_request_latency"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -1705,6 +1765,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_quantile",
                            "operator": "=",
                            "value": "0.99"
@@ -1863,6 +1929,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "http_server_request_latency"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -2026,6 +2098,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_info_memory_net"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -2163,6 +2241,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_received_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -2300,6 +2384,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_sent_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -2437,6 +2527,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -2568,6 +2664,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -2705,6 +2807,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_in_progress_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -2836,6 +2944,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_in_progress_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -2973,6 +3087,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_in_stream_queue_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -3104,6 +3224,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_requests_in_stream_queue_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -3241,6 +3367,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_connections_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -3372,6 +3504,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_net_connections_current"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -3537,6 +3675,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_quota_used_ratio"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -3668,6 +3812,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_arena_used_ratio"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -3799,6 +3949,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_items_used_ratio"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -3930,6 +4086,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_quota_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -4061,6 +4223,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_arena_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -4192,6 +4360,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_items_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -4323,6 +4497,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_quota_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -4454,6 +4634,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_arena_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -4585,6 +4771,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_slab_items_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -4745,6 +4937,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_engine",
                            "operator": "=",
                            "value": "memtx"
@@ -4888,6 +5086,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_engine",
                            "operator": "=",
                            "value": "vinyl"
@@ -5028,6 +5232,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_space_bsize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -5177,6 +5387,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_space_index_bsize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -5314,6 +5530,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_space_total_bsize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -5471,6 +5693,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_disk_data_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -5602,6 +5830,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_disk_index_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -5733,6 +5967,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_memory_tuple_cache"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -5864,6 +6104,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_memory_page_index"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -5995,6 +6241,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_memory_bloom_filter"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -6126,6 +6378,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_regulator_dump_bandwidth"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -6257,6 +6515,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_regulator_write_rate"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -6388,6 +6652,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_regulator_rate_limit"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -6519,6 +6789,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_memory_level0"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -6650,6 +6926,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_regulator_dump_watermark"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -6781,6 +7063,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_regulator_blocked_writers"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -6918,6 +7206,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_tx_commit"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -7055,6 +7349,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_tx_rollback"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -7192,6 +7492,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_tx_conflict"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -7323,6 +7629,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_tx_read_views"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -7454,6 +7766,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_scheduler_tasks"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -7600,6 +7918,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_status",
                            "operator": "=",
                            "value": "failed"
@@ -7740,6 +8064,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_scheduler_dump_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -7877,6 +8207,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_vinyl_scheduler_dump_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -8034,6 +8370,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_cpu_user_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -8171,6 +8513,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_cpu_system_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -8322,6 +8670,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_info_memory_lua"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -8453,6 +8807,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_runtime_used"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -8584,6 +8944,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_info_memory_tx"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -8715,6 +9081,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_fiber_csw"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -8846,6 +9218,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_ev_loop_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -8977,6 +9355,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_fiber_amount"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -9108,6 +9492,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_fiber_memused"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -9239,6 +9629,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_fiber_memalloc"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -9396,6 +9792,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_jit_snap_restore"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -9533,6 +9935,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_jit_trace_num"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -9670,6 +10078,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_jit_trace_abort"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -9801,6 +10215,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_jit_mcode_size"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -9938,6 +10358,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_strhash_hit"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -10075,6 +10501,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_strhash_miss"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -10212,6 +10644,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_atomic"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -10349,6 +10787,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_sweepstring"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -10486,6 +10930,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_finalize"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -10623,6 +11073,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_sweep"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -10760,6 +11216,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_propagate"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -10897,6 +11359,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_steps_pause"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -11028,6 +11496,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_strnum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -11159,6 +11633,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_tabnum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -11290,6 +11770,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_cdatanum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -11421,6 +11907,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_udatanum"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -11552,6 +12044,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_memory"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -11689,6 +12187,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_freed"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -11826,6 +12330,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "lj_gc_allocated"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -11986,6 +12496,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "select"
@@ -12126,6 +12642,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -12272,6 +12794,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "replace"
@@ -12412,6 +12940,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -12558,6 +13092,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "update"
@@ -12698,6 +13238,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -12844,6 +13390,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "call"
@@ -12984,6 +13536,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -13130,6 +13688,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "error"
@@ -13270,6 +13834,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -13416,6 +13986,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "prepare"
@@ -13556,6 +14132,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_stats_op_total"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -13728,6 +14310,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "select"
@@ -13874,6 +14462,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -14038,6 +14632,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "select"
@@ -14187,6 +14787,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "select"
@@ -14305,7 +14911,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tnt_crud_tuples_fetched\") / (mean(\"tnt_crud_stats_count_ok\") + mean(\"tnt_crud_stats_count_error\"))\nas \"tnt_crud_tuples_per_request\" FROM\n(SELECT \"value\" as \"tnt_crud_tuples_fetched\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tnt_crud_tuples_fetched' AND \"label_pairs_operation\" = 'select') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_error\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_operation\" = 'select'\nAND \"label_pairs_status\" = 'error') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_ok\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_operation\" = 'select'\nAND \"label_pairs_status\" = 'ok') AND $timeFilter)\nGROUP BY time($__interval * 2), \"label_pairs_alias\", \"label_pairs_name\" fill(0)\n",
+                     "query": "SELECT mean(\"tnt_crud_tuples_fetched\") / (mean(\"tnt_crud_stats_count_ok\") + mean(\"tnt_crud_stats_count_error\"))\nas \"tnt_crud_tuples_per_request\" FROM\n(SELECT \"value\" as \"tnt_crud_tuples_fetched\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tnt_crud_tuples_fetched' AND \"label_pairs_alias\" =~ /^$alias$/\nAND \"label_pairs_operation\" = 'select') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_error\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_alias\" =~ /^$alias$/\nAND \"label_pairs_operation\" = 'select' AND \"label_pairs_status\" = 'error') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_ok\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_alias\" =~ /^$alias$/\nAND \"label_pairs_operation\" = 'select' AND \"label_pairs_status\" = 'ok') AND $timeFilter)\nGROUP BY time($__interval * 2), \"label_pairs_alias\", \"label_pairs_name\" fill(0)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -14412,7 +15018,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tnt_crud_tuples_lookup\") / (mean(\"tnt_crud_stats_count_ok\") + mean(\"tnt_crud_stats_count_error\"))\nas \"tnt_crud_tuples_per_request\" FROM\n(SELECT \"value\" as \"tnt_crud_tuples_lookup\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tnt_crud_tuples_lookup' AND \"label_pairs_operation\" = 'select') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_error\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_operation\" = 'select'\nAND \"label_pairs_status\" = 'error') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_ok\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_operation\" = 'select'\nAND \"label_pairs_status\" = 'ok') AND $timeFilter)\nGROUP BY time($__interval * 2), \"label_pairs_alias\", \"label_pairs_name\" fill(0)\n",
+                     "query": "SELECT mean(\"tnt_crud_tuples_lookup\") / (mean(\"tnt_crud_stats_count_ok\") + mean(\"tnt_crud_stats_count_error\"))\nas \"tnt_crud_tuples_per_request\" FROM\n(SELECT \"value\" as \"tnt_crud_tuples_lookup\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tnt_crud_tuples_lookup' AND \"label_pairs_alias\" =~ /^$alias$/\nAND \"label_pairs_operation\" = 'select') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_error\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_alias\" =~ /^$alias$/\nAND \"label_pairs_operation\" = 'select' AND \"label_pairs_status\" = 'error') AND $timeFilter),\n(SELECT \"value\" as \"tnt_crud_stats_count_ok\" FROM \"${INFLUXDB_POLICY}\".\"${INFLUXDB_MEASUREMENT}\"\nWHERE (\"metric_name\" = 'tnt_crud_stats_count' AND \"label_pairs_alias\" =~ /^$alias$/\nAND \"label_pairs_operation\" = 'select' AND \"label_pairs_status\" = 'ok') AND $timeFilter)\nGROUP BY time($__interval * 2), \"label_pairs_alias\", \"label_pairs_name\" fill(0)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -14559,6 +15165,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_map_reduces"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -14711,6 +15323,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "insert"
@@ -14857,6 +15475,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -15021,6 +15645,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "insert"
@@ -15167,6 +15797,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -15331,6 +15967,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "insert_many"
@@ -15477,6 +16119,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -15641,6 +16289,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "insert_many"
@@ -15787,6 +16441,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -15951,6 +16611,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "replace"
@@ -16097,6 +16763,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -16261,6 +16933,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "replace"
@@ -16407,6 +17085,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -16571,6 +17255,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "replace_many"
@@ -16717,6 +17407,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -16881,6 +17577,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "replace_many"
@@ -17027,6 +17729,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -17191,6 +17899,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "upsert"
@@ -17337,6 +18051,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -17501,6 +18221,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "upsert"
@@ -17647,6 +18373,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -17811,6 +18543,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "upsert_many"
@@ -17957,6 +18695,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -18121,6 +18865,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "upsert_many"
@@ -18267,6 +19017,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -18431,6 +19187,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "update"
@@ -18577,6 +19339,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -18741,6 +19509,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "update"
@@ -18887,6 +19661,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -19051,6 +19831,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "delete"
@@ -19197,6 +19983,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -19361,6 +20153,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "delete"
@@ -19507,6 +20305,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -19671,6 +20475,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "count"
@@ -19817,6 +20627,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -19981,6 +20797,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "count"
@@ -20127,6 +20949,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -20291,6 +21119,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "get"
@@ -20437,6 +21271,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -20601,6 +21441,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "get"
@@ -20747,6 +21593,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -20911,6 +21763,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "borders"
@@ -21057,6 +21915,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -21221,6 +22085,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "borders"
@@ -21367,6 +22237,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -21531,6 +22407,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "len"
@@ -21677,6 +22559,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -21841,6 +22729,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "len"
@@ -21987,6 +22881,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -22151,6 +23051,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "truncate"
@@ -22297,6 +23203,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -22461,6 +23373,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_operation",
                            "operator": "=",
                            "value": "truncate"
@@ -22607,6 +23525,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "tnt_crud_stats"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         },
                         {
                            "condition": "AND",
@@ -22788,6 +23712,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "expirationd_checked_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -22931,6 +23861,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "expirationd_expired_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -23068,6 +24004,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "expirationd_restarts"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -23205,6 +24147,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "expirationd_working_time"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -23356,6 +24304,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "my_component_status"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -23493,6 +24447,12 @@
                            "key": "metric_name",
                            "operator": "=",
                            "value": "my_component_load_metric_count"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
                         }
                      ]
                   }
@@ -23627,6 +24587,12 @@
                         },
                         {
                            "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        },
+                        {
+                           "condition": "AND",
                            "key": "label_pairs_quantile",
                            "operator": "=",
                            "value": "0.99"
@@ -23690,7 +24656,31 @@
       "tarantool"
    ],
    "templating": {
-      "list": [ ]
+      "list": [
+         {
+            "allValue": null,
+            "current": {
+               "text": "all",
+               "value": "$__all"
+            },
+            "datasource": "${DS_INFLUXDB}",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Instances",
+            "multi": true,
+            "name": "alias",
+            "options": [ ],
+            "query": "SHOW TAG VALUES FROM \"${INFLUXDB_MEASUREMENT}\" WITH KEY=\"label_pairs_alias\"",
+            "refresh": 2,
+            "regex": "",
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+         }
+      ]
    },
    "time": {
       "from": "now-3h",

--- a/tests/Prometheus/dashboard_compiled.json
+++ b/tests/Prometheus/dashboard_compiled.json
@@ -532,7 +532,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_cartridge_issues{job=~\"$job\",level=\"warning\"}",
+                     "expr": "tnt_cartridge_issues{job=~\"$job\",alias=~\"$alias\",level=\"warning\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -622,7 +622,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_cartridge_issues{job=~\"$job\",level=\"critical\"}",
+                     "expr": "tnt_cartridge_issues{job=~\"$job\",alias=~\"$alias\",level=\"critical\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -766,7 +766,7 @@
                },
                "targets": [
                   {
-                     "expr": "tnt_replication_status{job=~\"$job\"}",
+                     "expr": "tnt_replication_status{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} {{stream}} ({{id}})",
@@ -875,7 +875,7 @@
                },
                "targets": [
                   {
-                     "expr": "tnt_read_only{job=~\"$job\"}",
+                     "expr": "tnt_read_only{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -929,7 +929,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_replication_lag{job=~\"$job\"}",
+                     "expr": "tnt_replication_lag{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} ({{id}})",
@@ -1016,7 +1016,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_clock_delta{job=~\"$job\"}",
+                     "expr": "tnt_clock_delta{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} ({{delta}})",
@@ -1124,7 +1124,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(http_server_request_latency_count{job=~\"$job\",status=~\"^2\\\\d{2}$\"}[$__rate_interval])",
+                     "expr": "rate(http_server_request_latency_count{job=~\"$job\",alias=~\"$alias\",status=~\"^2\\\\d{2}$\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
@@ -1214,7 +1214,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(http_server_request_latency_count{job=~\"$job\",status=~\"^4\\\\d{2}$\"}[$__rate_interval])",
+                     "expr": "rate(http_server_request_latency_count{job=~\"$job\",alias=~\"$alias\",status=~\"^4\\\\d{2}$\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
@@ -1304,7 +1304,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(http_server_request_latency_count{job=~\"$job\",status=~\"^5\\\\d{2}$\"}[$__rate_interval])",
+                     "expr": "rate(http_server_request_latency_count{job=~\"$job\",alias=~\"$alias\",status=~\"^5\\\\d{2}$\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
@@ -1394,7 +1394,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "http_server_request_latency{job=~\"$job\",quantile=\"0.99\",status=~\"^2\\\\d{2}$\"}",
+                     "expr": "http_server_request_latency{job=~\"$job\",alias=~\"$alias\",quantile=\"0.99\",status=~\"^2\\\\d{2}$\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
@@ -1484,7 +1484,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "http_server_request_latency{job=~\"$job\",quantile=\"0.99\",status=~\"^4\\\\d{2}$\"}",
+                     "expr": "http_server_request_latency{job=~\"$job\",alias=~\"$alias\",quantile=\"0.99\",status=~\"^4\\\\d{2}$\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
@@ -1574,7 +1574,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "http_server_request_latency{job=~\"$job\",quantile=\"0.99\",status=~\"^5\\\\d{2}$\"}",
+                     "expr": "http_server_request_latency{job=~\"$job\",alias=~\"$alias\",quantile=\"0.99\",status=~\"^5\\\\d{2}$\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
@@ -1684,7 +1684,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_info_memory_net{job=~\"$job\"}",
+                     "expr": "tnt_info_memory_net{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1774,7 +1774,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_received_total{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_received_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1864,7 +1864,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_sent_total{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_sent_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1954,7 +1954,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_total{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_requests_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2044,7 +2044,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_current{job=~\"$job\"}",
+                     "expr": "tnt_net_requests_current{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2134,7 +2134,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_in_progress_total{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_requests_in_progress_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2224,7 +2224,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_in_progress_current{job=~\"$job\"}",
+                     "expr": "tnt_net_requests_in_progress_current{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2314,7 +2314,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_in_stream_queue_total{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_requests_in_stream_queue_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2404,7 +2404,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_in_stream_queue_current{job=~\"$job\"}",
+                     "expr": "tnt_net_requests_in_stream_queue_current{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2494,7 +2494,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_connections_total{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_connections_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2584,7 +2584,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_connections_current{job=~\"$job\"}",
+                     "expr": "tnt_net_connections_current{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2708,7 +2708,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_used_ratio{job=~\"$job\"}",
+                     "expr": "tnt_slab_quota_used_ratio{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2798,7 +2798,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_used_ratio{job=~\"$job\"}",
+                     "expr": "tnt_slab_arena_used_ratio{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2888,7 +2888,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_used_ratio{job=~\"$job\"}",
+                     "expr": "tnt_slab_items_used_ratio{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2978,7 +2978,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_used{job=~\"$job\"}",
+                     "expr": "tnt_slab_quota_used{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3068,7 +3068,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_used{job=~\"$job\"}",
+                     "expr": "tnt_slab_arena_used{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3158,7 +3158,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_used{job=~\"$job\"}",
+                     "expr": "tnt_slab_items_used{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3248,7 +3248,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_size{job=~\"$job\"}",
+                     "expr": "tnt_slab_quota_size{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3338,7 +3338,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_size{job=~\"$job\"}",
+                     "expr": "tnt_slab_arena_size{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3428,7 +3428,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_size{job=~\"$job\"}",
+                     "expr": "tnt_slab_items_size{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3538,7 +3538,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_len{job=~\"$job\", engine=\"memtx\"}",
+                     "expr": "tnt_space_len{job=~\"$job\", alias=~\"$alias\", engine=\"memtx\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3628,7 +3628,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_tuples{job=~\"$job\", engine=\"vinyl\"}",
+                     "expr": "tnt_vinyl_tuples{job=~\"$job\", alias=~\"$alias\", engine=\"vinyl\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3718,7 +3718,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_bsize{job=~\"$job\", engine=\"memtx\"}",
+                     "expr": "tnt_space_bsize{job=~\"$job\", alias=~\"$alias\", engine=\"memtx\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3808,7 +3808,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_index_bsize{job=~\"$job\"}",
+                     "expr": "tnt_space_index_bsize{job=~\"$job\", alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}} ({{index_name}})",
@@ -3898,7 +3898,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_total_bsize{job=~\"$job\", engine=\"memtx\"}",
+                     "expr": "tnt_space_total_bsize{job=~\"$job\", alias=~\"$alias\", engine=\"memtx\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -4008,7 +4008,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_disk_data_size{job=~\"$job\"}",
+                     "expr": "tnt_vinyl_disk_data_size{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4098,7 +4098,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_disk_index_size{job=~\"$job\"}",
+                     "expr": "tnt_vinyl_disk_index_size{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4188,7 +4188,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_tuple_cache{job=~\"$job\"}",
+                     "expr": "tnt_vinyl_memory_tuple_cache{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4278,7 +4278,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_page_index{job=~\"$job\"}",
+                     "expr": "tnt_vinyl_memory_page_index{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4368,7 +4368,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_bloom_filter{job=~\"$job\"}",
+                     "expr": "tnt_vinyl_memory_bloom_filter{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4458,7 +4458,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_dump_bandwidth{job=~\"$job\"}",
+                     "expr": "tnt_vinyl_regulator_dump_bandwidth{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4548,7 +4548,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_write_rate{job=~\"$job\"}",
+                     "expr": "tnt_vinyl_regulator_write_rate{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4638,7 +4638,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_rate_limit{job=~\"$job\"}",
+                     "expr": "tnt_vinyl_regulator_rate_limit{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4728,7 +4728,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_level0{job=~\"$job\"}",
+                     "expr": "tnt_vinyl_memory_level0{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4818,7 +4818,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_dump_watermark{job=~\"$job\"}",
+                     "expr": "tnt_vinyl_regulator_dump_watermark{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4908,7 +4908,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_blocked_writers{job=~\"$job\"}",
+                     "expr": "tnt_vinyl_regulator_blocked_writers{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4998,7 +4998,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_commit{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_tx_commit{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5088,7 +5088,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_rollback{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_tx_rollback{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5178,7 +5178,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_conflict{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_tx_conflict{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5268,7 +5268,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_tx_read_views{job=~\"$job\"}",
+                     "expr": "tnt_vinyl_tx_read_views{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5358,7 +5358,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_scheduler_tasks{job=~\"$job\", status=\"inprogress\"}",
+                     "expr": "tnt_vinyl_scheduler_tasks{job=~\"$job\", alias=~\"$alias\", status=\"inprogress\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5448,7 +5448,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_tasks{job=~\"$job\",status=\"failed\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_scheduler_tasks{job=~\"$job\",alias=~\"$alias\",status=\"failed\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5538,7 +5538,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_dump_time{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_scheduler_dump_time{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5628,7 +5628,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_dump_total{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_scheduler_dump_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5738,7 +5738,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_cpu_user_time{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(tnt_cpu_user_time{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5828,7 +5828,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_cpu_system_time{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(tnt_cpu_system_time{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5938,7 +5938,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_info_memory_lua{job=~\"$job\"}",
+                     "expr": "tnt_info_memory_lua{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6028,7 +6028,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_runtime_used{job=~\"$job\"}",
+                     "expr": "tnt_runtime_used{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6118,7 +6118,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_info_memory_tx{job=~\"$job\"}",
+                     "expr": "tnt_info_memory_tx{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6208,7 +6208,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_csw{job=~\"$job\"}",
+                     "expr": "tnt_fiber_csw{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6298,7 +6298,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_ev_loop_time{job=~\"$job\"}",
+                     "expr": "tnt_ev_loop_time{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6388,7 +6388,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_amount{job=~\"$job\"}",
+                     "expr": "tnt_fiber_amount{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6478,7 +6478,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_memused{job=~\"$job\"}",
+                     "expr": "tnt_fiber_memused{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6568,7 +6568,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_memalloc{job=~\"$job\"}",
+                     "expr": "tnt_fiber_memalloc{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6678,7 +6678,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_snap_restore{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(lj_jit_snap_restore{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6768,7 +6768,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_trace_num{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(lj_jit_trace_num{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6858,7 +6858,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_trace_abort{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(lj_jit_trace_abort{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6948,7 +6948,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_jit_mcode_size{job=~\"$job\"}",
+                     "expr": "lj_jit_mcode_size{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7038,7 +7038,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_strhash_hit{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(lj_strhash_hit{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7128,7 +7128,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_strhash_miss{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(lj_strhash_miss{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7218,7 +7218,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_atomic{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_atomic{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7308,7 +7308,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_sweepstring{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_sweepstring{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7398,7 +7398,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_finalize{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_finalize{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7488,7 +7488,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_sweep{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_sweep{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7578,7 +7578,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_propagate{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_propagate{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7668,7 +7668,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_pause{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_pause{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7758,7 +7758,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_strnum{job=~\"$job\"}",
+                     "expr": "lj_gc_strnum{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7848,7 +7848,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_tabnum{job=~\"$job\"}",
+                     "expr": "lj_gc_tabnum{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7938,7 +7938,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_cdatanum{job=~\"$job\"}",
+                     "expr": "lj_gc_cdatanum{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8028,7 +8028,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_udatanum{job=~\"$job\"}",
+                     "expr": "lj_gc_udatanum{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8118,7 +8118,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_memory{job=~\"$job\"}",
+                     "expr": "lj_gc_memory{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8208,7 +8208,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_freed{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_freed{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8298,7 +8298,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_allocated{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_allocated{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8408,7 +8408,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",operation=\"select\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"select\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8498,7 +8498,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",operation=\"insert\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"insert\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8588,7 +8588,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",operation=\"replace\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"replace\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8678,7 +8678,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",operation=\"upsert\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"upsert\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8768,7 +8768,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",operation=\"update\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"update\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8858,7 +8858,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",operation=\"delete\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"delete\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8948,7 +8948,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",operation=\"call\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"call\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9038,7 +9038,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",operation=\"eval\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"eval\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9128,7 +9128,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",operation=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9218,7 +9218,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",operation=\"auth\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"auth\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9308,7 +9308,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",operation=\"prepare\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"prepare\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9398,7 +9398,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",operation=\"execute\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"execute\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9508,7 +9508,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"select\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"select\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -9598,7 +9598,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"select\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"select\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -9688,7 +9688,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"select\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"select\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -9778,7 +9778,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"select\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"select\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -9868,7 +9868,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_tuples_fetched{job=~\"$job\",operation=\"select\"}[$__rate_interval]) /\n(sum without (status) (rate(tnt_crud_stats_count{job=~\"$job\",operation=\"select\"}[$__rate_interval])))\n",
+                     "expr": "rate(tnt_crud_tuples_fetched{job=~\"$job\",alias=~\"$alias\", operation=\"select\"}[$__rate_interval]) /\n(sum without (status) (rate(tnt_crud_stats_count{job=~\"$job\",operation=\"select\"}[$__rate_interval])))\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -9958,7 +9958,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_tuples_lookup{job=~\"$job\",operation=\"select\"}[$__rate_interval]) /\n(sum without (status) (rate(tnt_crud_stats_count{job=~\"$job\",operation=\"select\"}[$__rate_interval])))\n",
+                     "expr": "rate(tnt_crud_tuples_lookup{job=~\"$job\",alias=~\"$alias\", operation=\"select\"}[$__rate_interval]) /\n(sum without (status) (rate(tnt_crud_stats_count{job=~\"$job\",operation=\"select\"}[$__rate_interval])))\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10048,7 +10048,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_map_reduces{job=~\"$job\",operation=\"select\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_map_reduces{job=~\"$job\",alias=~\"$alias\",operation=\"select\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10138,7 +10138,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"insert\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"insert\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10228,7 +10228,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"insert\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"insert\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10318,7 +10318,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"insert\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"insert\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10408,7 +10408,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"insert\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"insert\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10498,7 +10498,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"insert_many\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"insert_many\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10588,7 +10588,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"insert_many\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"insert_many\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10678,7 +10678,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"insert_many\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"insert_many\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10768,7 +10768,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"insert_many\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"insert_many\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10858,7 +10858,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"replace\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"replace\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10948,7 +10948,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"replace\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"replace\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11038,7 +11038,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"replace\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"replace\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11128,7 +11128,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"replace\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"replace\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11218,7 +11218,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"replace_many\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"replace_many\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11308,7 +11308,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"replace_many\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"replace_many\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11398,7 +11398,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"replace_many\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"replace_many\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11488,7 +11488,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"replace_many\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"replace_many\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11578,7 +11578,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"upsert\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"upsert\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11668,7 +11668,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"upsert\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"upsert\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11758,7 +11758,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"upsert\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"upsert\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11848,7 +11848,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"upsert\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"upsert\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11938,7 +11938,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"upsert_many\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"upsert_many\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12028,7 +12028,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"upsert_many\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"upsert_many\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12118,7 +12118,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"upsert_many\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"upsert_many\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12208,7 +12208,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"upsert_many\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"upsert_many\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12298,7 +12298,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"update\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"update\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12388,7 +12388,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"update\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"update\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12478,7 +12478,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"update\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"update\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12568,7 +12568,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"update\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"update\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12658,7 +12658,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"delete\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"delete\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12748,7 +12748,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"delete\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"delete\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12838,7 +12838,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"delete\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"delete\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12928,7 +12928,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"delete\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"delete\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13018,7 +13018,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"count\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"count\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13108,7 +13108,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"count\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"count\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13198,7 +13198,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"count\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"count\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13288,7 +13288,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"count\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"count\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13378,7 +13378,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"get\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"get\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13468,7 +13468,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"get\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"get\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13558,7 +13558,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"get\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"get\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13648,7 +13648,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"get\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"get\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13738,7 +13738,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"borders\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"borders\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13828,7 +13828,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"borders\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"borders\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13918,7 +13918,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"borders\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"borders\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14008,7 +14008,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"borders\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"borders\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14098,7 +14098,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"len\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"len\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14188,7 +14188,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"len\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"len\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14278,7 +14278,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"len\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"len\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14368,7 +14368,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"len\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"len\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14458,7 +14458,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"truncate\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"truncate\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14548,7 +14548,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"truncate\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"truncate\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14638,7 +14638,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",operation=\"truncate\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"truncate\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14728,7 +14728,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",operation=\"truncate\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"truncate\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14838,7 +14838,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(expirationd_checked_count{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(expirationd_checked_count{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -14928,7 +14928,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(expirationd_expired_count{job=~\"$job\"}[$__rate_interval])",
+                     "expr": "rate(expirationd_expired_count{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -15018,7 +15018,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "expirationd_restarts{job=~\"$job\"}",
+                     "expr": "expirationd_restarts{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -15108,7 +15108,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "expirationd_working_time{job=~\"$job\"}",
+                     "expr": "expirationd_working_time{job=~\"$job\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -15192,6 +15192,29 @@
             "query": "${PROMETHEUS_JOB}",
             "refresh": 0,
             "type": "custom"
+         },
+         {
+            "allValue": null,
+            "current": {
+               "text": "all",
+               "value": "$__all"
+            },
+            "datasource": "${DS_PROMETHEUS}",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Instances",
+            "multi": true,
+            "name": "alias",
+            "options": [ ],
+            "query": "label_values(tnt_info_uptime{job=~\"$job\"},alias)",
+            "refresh": 2,
+            "regex": "",
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tags": [ ],
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
          }
       ]
    },

--- a/tests/Prometheus/dashboard_static_compiled.json
+++ b/tests/Prometheus/dashboard_static_compiled.json
@@ -516,7 +516,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_cartridge_issues{job=~\"tarantool\",level=\"warning\"}",
+                     "expr": "tnt_cartridge_issues{job=~\"tarantool\",alias=~\".*\",level=\"warning\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -606,7 +606,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_cartridge_issues{job=~\"tarantool\",level=\"critical\"}",
+                     "expr": "tnt_cartridge_issues{job=~\"tarantool\",alias=~\".*\",level=\"critical\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -750,7 +750,7 @@
                },
                "targets": [
                   {
-                     "expr": "tnt_replication_status{job=~\"tarantool\"}",
+                     "expr": "tnt_replication_status{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} {{stream}} ({{id}})",
@@ -859,7 +859,7 @@
                },
                "targets": [
                   {
-                     "expr": "tnt_read_only{job=~\"tarantool\"}",
+                     "expr": "tnt_read_only{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -913,7 +913,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_replication_lag{job=~\"tarantool\"}",
+                     "expr": "tnt_replication_lag{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} ({{id}})",
@@ -1000,7 +1000,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_clock_delta{job=~\"tarantool\"}",
+                     "expr": "tnt_clock_delta{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} ({{delta}})",
@@ -1108,7 +1108,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(http_server_request_latency_count{job=~\"tarantool\",status=~\"^2\\\\d{2}$\"}[$__rate_interval])",
+                     "expr": "rate(http_server_request_latency_count{job=~\"tarantool\",alias=~\".*\",status=~\"^2\\\\d{2}$\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
@@ -1198,7 +1198,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(http_server_request_latency_count{job=~\"tarantool\",status=~\"^4\\\\d{2}$\"}[$__rate_interval])",
+                     "expr": "rate(http_server_request_latency_count{job=~\"tarantool\",alias=~\".*\",status=~\"^4\\\\d{2}$\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
@@ -1288,7 +1288,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(http_server_request_latency_count{job=~\"tarantool\",status=~\"^5\\\\d{2}$\"}[$__rate_interval])",
+                     "expr": "rate(http_server_request_latency_count{job=~\"tarantool\",alias=~\".*\",status=~\"^5\\\\d{2}$\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
@@ -1378,7 +1378,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "http_server_request_latency{job=~\"tarantool\",quantile=\"0.99\",status=~\"^2\\\\d{2}$\"}",
+                     "expr": "http_server_request_latency{job=~\"tarantool\",alias=~\".*\",quantile=\"0.99\",status=~\"^2\\\\d{2}$\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
@@ -1468,7 +1468,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "http_server_request_latency{job=~\"tarantool\",quantile=\"0.99\",status=~\"^4\\\\d{2}$\"}",
+                     "expr": "http_server_request_latency{job=~\"tarantool\",alias=~\".*\",quantile=\"0.99\",status=~\"^4\\\\d{2}$\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
@@ -1558,7 +1558,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "http_server_request_latency{job=~\"tarantool\",quantile=\"0.99\",status=~\"^5\\\\d{2}$\"}",
+                     "expr": "http_server_request_latency{job=~\"tarantool\",alias=~\".*\",quantile=\"0.99\",status=~\"^5\\\\d{2}$\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
@@ -1668,7 +1668,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_info_memory_net{job=~\"tarantool\"}",
+                     "expr": "tnt_info_memory_net{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1758,7 +1758,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_received_total{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_received_total{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1848,7 +1848,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_sent_total{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_sent_total{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1938,7 +1938,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_total{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_requests_total{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2028,7 +2028,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_current{job=~\"tarantool\"}",
+                     "expr": "tnt_net_requests_current{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2118,7 +2118,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_in_progress_total{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_requests_in_progress_total{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2208,7 +2208,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_in_progress_current{job=~\"tarantool\"}",
+                     "expr": "tnt_net_requests_in_progress_current{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2298,7 +2298,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_in_stream_queue_total{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_requests_in_stream_queue_total{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2388,7 +2388,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_in_stream_queue_current{job=~\"tarantool\"}",
+                     "expr": "tnt_net_requests_in_stream_queue_current{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2478,7 +2478,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_connections_total{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_connections_total{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2568,7 +2568,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_connections_current{job=~\"tarantool\"}",
+                     "expr": "tnt_net_connections_current{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2692,7 +2692,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_used_ratio{job=~\"tarantool\"}",
+                     "expr": "tnt_slab_quota_used_ratio{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2782,7 +2782,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_used_ratio{job=~\"tarantool\"}",
+                     "expr": "tnt_slab_arena_used_ratio{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2872,7 +2872,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_used_ratio{job=~\"tarantool\"}",
+                     "expr": "tnt_slab_items_used_ratio{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2962,7 +2962,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_used{job=~\"tarantool\"}",
+                     "expr": "tnt_slab_quota_used{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3052,7 +3052,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_used{job=~\"tarantool\"}",
+                     "expr": "tnt_slab_arena_used{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3142,7 +3142,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_used{job=~\"tarantool\"}",
+                     "expr": "tnt_slab_items_used{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3232,7 +3232,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_size{job=~\"tarantool\"}",
+                     "expr": "tnt_slab_quota_size{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3322,7 +3322,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_size{job=~\"tarantool\"}",
+                     "expr": "tnt_slab_arena_size{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3412,7 +3412,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_size{job=~\"tarantool\"}",
+                     "expr": "tnt_slab_items_size{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3522,7 +3522,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_len{job=~\"tarantool\", engine=\"memtx\"}",
+                     "expr": "tnt_space_len{job=~\"tarantool\", alias=~\".*\", engine=\"memtx\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3612,7 +3612,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_tuples{job=~\"tarantool\", engine=\"vinyl\"}",
+                     "expr": "tnt_vinyl_tuples{job=~\"tarantool\", alias=~\".*\", engine=\"vinyl\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3702,7 +3702,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_bsize{job=~\"tarantool\", engine=\"memtx\"}",
+                     "expr": "tnt_space_bsize{job=~\"tarantool\", alias=~\".*\", engine=\"memtx\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3792,7 +3792,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_index_bsize{job=~\"tarantool\"}",
+                     "expr": "tnt_space_index_bsize{job=~\"tarantool\", alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}} ({{index_name}})",
@@ -3882,7 +3882,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_total_bsize{job=~\"tarantool\", engine=\"memtx\"}",
+                     "expr": "tnt_space_total_bsize{job=~\"tarantool\", alias=~\".*\", engine=\"memtx\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3992,7 +3992,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_disk_data_size{job=~\"tarantool\"}",
+                     "expr": "tnt_vinyl_disk_data_size{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4082,7 +4082,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_disk_index_size{job=~\"tarantool\"}",
+                     "expr": "tnt_vinyl_disk_index_size{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4172,7 +4172,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_tuple_cache{job=~\"tarantool\"}",
+                     "expr": "tnt_vinyl_memory_tuple_cache{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4262,7 +4262,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_page_index{job=~\"tarantool\"}",
+                     "expr": "tnt_vinyl_memory_page_index{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4352,7 +4352,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_bloom_filter{job=~\"tarantool\"}",
+                     "expr": "tnt_vinyl_memory_bloom_filter{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4442,7 +4442,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_dump_bandwidth{job=~\"tarantool\"}",
+                     "expr": "tnt_vinyl_regulator_dump_bandwidth{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4532,7 +4532,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_write_rate{job=~\"tarantool\"}",
+                     "expr": "tnt_vinyl_regulator_write_rate{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4622,7 +4622,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_rate_limit{job=~\"tarantool\"}",
+                     "expr": "tnt_vinyl_regulator_rate_limit{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4712,7 +4712,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_level0{job=~\"tarantool\"}",
+                     "expr": "tnt_vinyl_memory_level0{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4802,7 +4802,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_dump_watermark{job=~\"tarantool\"}",
+                     "expr": "tnt_vinyl_regulator_dump_watermark{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4892,7 +4892,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_blocked_writers{job=~\"tarantool\"}",
+                     "expr": "tnt_vinyl_regulator_blocked_writers{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4982,7 +4982,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_commit{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_tx_commit{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5072,7 +5072,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_rollback{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_tx_rollback{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5162,7 +5162,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_conflict{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_tx_conflict{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5252,7 +5252,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_tx_read_views{job=~\"tarantool\"}",
+                     "expr": "tnt_vinyl_tx_read_views{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5342,7 +5342,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_scheduler_tasks{job=~\"tarantool\", status=\"inprogress\"}",
+                     "expr": "tnt_vinyl_scheduler_tasks{job=~\"tarantool\", alias=~\".*\", status=\"inprogress\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5432,7 +5432,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_tasks{job=~\"tarantool\",status=\"failed\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_scheduler_tasks{job=~\"tarantool\",alias=~\".*\",status=\"failed\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5522,7 +5522,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_dump_time{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_scheduler_dump_time{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5612,7 +5612,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_dump_total{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_scheduler_dump_total{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5722,7 +5722,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_cpu_user_time{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tnt_cpu_user_time{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5812,7 +5812,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_cpu_system_time{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tnt_cpu_system_time{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5922,7 +5922,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_info_memory_lua{job=~\"tarantool\"}",
+                     "expr": "tnt_info_memory_lua{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6012,7 +6012,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_runtime_used{job=~\"tarantool\"}",
+                     "expr": "tnt_runtime_used{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6102,7 +6102,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_info_memory_tx{job=~\"tarantool\"}",
+                     "expr": "tnt_info_memory_tx{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6192,7 +6192,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_csw{job=~\"tarantool\"}",
+                     "expr": "tnt_fiber_csw{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6282,7 +6282,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_ev_loop_time{job=~\"tarantool\"}",
+                     "expr": "tnt_ev_loop_time{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6372,7 +6372,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_amount{job=~\"tarantool\"}",
+                     "expr": "tnt_fiber_amount{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6462,7 +6462,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_memused{job=~\"tarantool\"}",
+                     "expr": "tnt_fiber_memused{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6552,7 +6552,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_memalloc{job=~\"tarantool\"}",
+                     "expr": "tnt_fiber_memalloc{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6662,7 +6662,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_snap_restore{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(lj_jit_snap_restore{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6752,7 +6752,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_trace_num{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(lj_jit_trace_num{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6842,7 +6842,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_trace_abort{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(lj_jit_trace_abort{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6932,7 +6932,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_jit_mcode_size{job=~\"tarantool\"}",
+                     "expr": "lj_jit_mcode_size{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7022,7 +7022,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_strhash_hit{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(lj_strhash_hit{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7112,7 +7112,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_strhash_miss{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(lj_strhash_miss{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7202,7 +7202,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_atomic{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_atomic{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7292,7 +7292,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_sweepstring{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_sweepstring{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7382,7 +7382,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_finalize{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_finalize{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7472,7 +7472,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_sweep{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_sweep{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7562,7 +7562,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_propagate{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_propagate{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7652,7 +7652,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_pause{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_pause{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7742,7 +7742,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_strnum{job=~\"tarantool\"}",
+                     "expr": "lj_gc_strnum{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7832,7 +7832,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_tabnum{job=~\"tarantool\"}",
+                     "expr": "lj_gc_tabnum{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7922,7 +7922,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_cdatanum{job=~\"tarantool\"}",
+                     "expr": "lj_gc_cdatanum{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8012,7 +8012,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_udatanum{job=~\"tarantool\"}",
+                     "expr": "lj_gc_udatanum{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8102,7 +8102,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_memory{job=~\"tarantool\"}",
+                     "expr": "lj_gc_memory{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8192,7 +8192,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_freed{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_freed{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8282,7 +8282,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_allocated{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_allocated{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8392,7 +8392,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"select\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\".*\",operation=\"select\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8482,7 +8482,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"insert\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\".*\",operation=\"insert\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8572,7 +8572,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"replace\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\".*\",operation=\"replace\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8662,7 +8662,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"upsert\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\".*\",operation=\"upsert\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8752,7 +8752,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"update\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\".*\",operation=\"update\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8842,7 +8842,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"delete\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\".*\",operation=\"delete\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8932,7 +8932,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"call\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\".*\",operation=\"call\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9022,7 +9022,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"eval\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\".*\",operation=\"eval\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9112,7 +9112,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\".*\",operation=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9202,7 +9202,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"auth\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\".*\",operation=\"auth\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9292,7 +9292,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"prepare\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\".*\",operation=\"prepare\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9382,7 +9382,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"execute\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\".*\",operation=\"execute\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9492,7 +9492,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"select\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"select\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -9582,7 +9582,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"select\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"select\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -9672,7 +9672,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"select\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"select\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -9762,7 +9762,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"select\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"select\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -9852,7 +9852,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_tuples_fetched{job=~\"tarantool\",operation=\"select\"}[$__rate_interval]) /\n(sum without (status) (rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"select\"}[$__rate_interval])))\n",
+                     "expr": "rate(tnt_crud_tuples_fetched{job=~\"tarantool\",alias=~\".*\", operation=\"select\"}[$__rate_interval]) /\n(sum without (status) (rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"select\"}[$__rate_interval])))\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -9942,7 +9942,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_tuples_lookup{job=~\"tarantool\",operation=\"select\"}[$__rate_interval]) /\n(sum without (status) (rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"select\"}[$__rate_interval])))\n",
+                     "expr": "rate(tnt_crud_tuples_lookup{job=~\"tarantool\",alias=~\".*\", operation=\"select\"}[$__rate_interval]) /\n(sum without (status) (rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"select\"}[$__rate_interval])))\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10032,7 +10032,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_map_reduces{job=~\"tarantool\",operation=\"select\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_map_reduces{job=~\"tarantool\",alias=~\".*\",operation=\"select\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10122,7 +10122,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"insert\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"insert\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10212,7 +10212,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"insert\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"insert\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10302,7 +10302,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"insert\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"insert\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10392,7 +10392,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"insert\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"insert\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10482,7 +10482,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"insert_many\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"insert_many\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10572,7 +10572,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"insert_many\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"insert_many\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10662,7 +10662,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"insert_many\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"insert_many\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10752,7 +10752,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"insert_many\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"insert_many\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10842,7 +10842,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"replace\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"replace\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10932,7 +10932,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"replace\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"replace\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11022,7 +11022,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"replace\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"replace\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11112,7 +11112,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"replace\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"replace\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11202,7 +11202,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"replace_many\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"replace_many\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11292,7 +11292,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"replace_many\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"replace_many\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11382,7 +11382,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"replace_many\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"replace_many\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11472,7 +11472,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"replace_many\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"replace_many\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11562,7 +11562,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"upsert\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"upsert\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11652,7 +11652,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"upsert\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"upsert\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11742,7 +11742,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"upsert\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"upsert\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11832,7 +11832,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"upsert\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"upsert\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11922,7 +11922,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"upsert_many\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"upsert_many\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12012,7 +12012,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"upsert_many\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"upsert_many\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12102,7 +12102,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"upsert_many\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"upsert_many\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12192,7 +12192,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"upsert_many\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"upsert_many\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12282,7 +12282,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"update\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"update\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12372,7 +12372,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"update\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"update\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12462,7 +12462,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"update\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"update\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12552,7 +12552,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"update\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"update\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12642,7 +12642,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"delete\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"delete\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12732,7 +12732,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"delete\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"delete\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12822,7 +12822,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"delete\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"delete\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12912,7 +12912,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"delete\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"delete\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13002,7 +13002,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"count\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"count\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13092,7 +13092,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"count\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"count\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13182,7 +13182,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"count\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"count\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13272,7 +13272,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"count\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"count\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13362,7 +13362,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"get\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"get\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13452,7 +13452,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"get\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"get\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13542,7 +13542,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"get\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"get\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13632,7 +13632,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"get\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"get\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13722,7 +13722,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"borders\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"borders\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13812,7 +13812,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"borders\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"borders\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13902,7 +13902,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"borders\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"borders\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13992,7 +13992,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"borders\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"borders\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14082,7 +14082,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"len\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"len\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14172,7 +14172,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"len\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"len\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14262,7 +14262,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"len\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"len\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14352,7 +14352,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"len\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"len\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14442,7 +14442,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"truncate\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"truncate\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14532,7 +14532,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"truncate\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"truncate\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14622,7 +14622,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"truncate\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\".*\",operation=\"truncate\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14712,7 +14712,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"tarantool\",operation=\"truncate\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\".*\",operation=\"truncate\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14822,7 +14822,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(expirationd_checked_count{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(expirationd_checked_count{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -14912,7 +14912,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(expirationd_expired_count{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(expirationd_expired_count{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -15002,7 +15002,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "expirationd_restarts{job=~\"tarantool\"}",
+                     "expr": "expirationd_restarts{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -15092,7 +15092,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "expirationd_working_time{job=~\"tarantool\"}",
+                     "expr": "expirationd_working_time{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",

--- a/tests/Prometheus/dashboard_static_with_instance_variable.sh
+++ b/tests/Prometheus/dashboard_static_with_instance_variable.sh
@@ -2,4 +2,5 @@
 
 make DATASOURCE=Prometheus \
      JOB=tarantool \
+     WITH_INSTANCE_VARIABLE=TRUE \
      build-static-prometheus

--- a/tests/Prometheus/dashboard_static_with_instance_variable_compiled.json
+++ b/tests/Prometheus/dashboard_static_with_instance_variable_compiled.json
@@ -1,21 +1,5 @@
 {
-   "__inputs": [
-      {
-         "description": "Prometheus Tarantool metrics bank",
-         "label": "Prometheus",
-         "name": "DS_PROMETHEUS",
-         "pluginId": "prometheus",
-         "pluginName": "Prometheus",
-         "type": "datasource"
-      },
-      {
-         "description": "Prometheus Tarantool metrics job",
-         "label": "Job",
-         "name": "PROMETHEUS_JOB",
-         "type": "constant",
-         "value": "tarantool"
-      }
-   ],
+   "__inputs": [ ],
    "__requires": [
       {
          "id": "grafana",
@@ -84,7 +68,7 @@
          "panels": [
             {
                "columns": [ ],
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "description": "Overview of Tarantool instances observed by Prometheus job.\n\nIf instance row is *red*, it means Prometheus can't reach\nURI specified in targets or ran into error.\nIf instance row is *green*, it means instance is up and running and\nPrometheus is successfully extracting metrics from it.\n\"Uptime\" column shows time since instant start.\n",
                "gridPos": {
                   "h": 8,
@@ -149,7 +133,7 @@
                ],
                "targets": [
                   {
-                     "expr": "up{job=~\"$job\"} * on(instance) group_left(alias) tnt_info_uptime{job=~\"$job\"} or\non(instance) label_replace(up{job=~\"$job\"}, \"alias\", \"Not available\", \"instance\", \".*\")\n",
+                     "expr": "up{job=~\"tarantool\"} * on(instance) group_left(alias) tnt_info_uptime{job=~\"tarantool\"} or\non(instance) label_replace(up{job=~\"tarantool\"}, \"alias\", \"Not available\", \"instance\", \".*\")\n",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -164,7 +148,7 @@
                "type": "table"
             },
             {
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "description": "Count of running Tarantool instances observed by Prometheus job.\nIf Prometheus can't reach URI specified in targets\nor ran into error, instance is not counted.\n",
                "gridPos": {
                   "h": 3,
@@ -206,7 +190,7 @@
                "pluginVersion": "6.6.0",
                "targets": [
                   {
-                     "expr": "sum(up{job=~\"$job\"})",
+                     "expr": "sum(up{job=~\"tarantool\"})",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "",
@@ -218,7 +202,7 @@
                "type": "stat"
             },
             {
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "description": "Overall value of memory used by Tarantool\nitems and indexes (*arena_used* value).\nIf Tarantool instance is not available\nfor Prometheus metrics extraction now,\nits contribution is not counted.\n",
                "gridPos": {
                   "h": 3,
@@ -260,7 +244,7 @@
                "pluginVersion": "6.6.0",
                "targets": [
                   {
-                     "expr": "sum(tnt_slab_arena_used{job=~\"$job\"})",
+                     "expr": "sum(tnt_slab_arena_used{job=~\"tarantool\"})",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "",
@@ -272,7 +256,7 @@
                "type": "stat"
             },
             {
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "description": "Overall value of memory available for Tarantool items\nand indexes allocation (*memtx_memory* or *quota_size* values).\nIf Tarantool instance is not available for Prometheus metrics\nextraction now, its contribution is not counted.\n",
                "gridPos": {
                   "h": 3,
@@ -314,7 +298,7 @@
                "pluginVersion": "6.6.0",
                "targets": [
                   {
-                     "expr": "sum(tnt_slab_quota_size{job=~\"$job\"})",
+                     "expr": "sum(tnt_slab_quota_size{job=~\"tarantool\"})",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "",
@@ -326,7 +310,7 @@
                "type": "stat"
             },
             {
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "description": "Overall rate of HTTP requests processed\non Tarantool instances (all methods and response codes).\nIf Tarantool instance is not available for Prometheus metrics\nextraction now, its contribution is not counted.\n",
                "gridPos": {
                   "h": 5,
@@ -368,7 +352,7 @@
                "pluginVersion": "6.6.0",
                "targets": [
                   {
-                     "expr": "sum(rate(http_server_request_latency_count{job=~\"$job\"}[$__rate_interval]))",
+                     "expr": "sum(rate(http_server_request_latency_count{job=~\"tarantool\"}[$__rate_interval]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "",
@@ -380,7 +364,7 @@
                "type": "stat"
             },
             {
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "description": "Overall rate of network requests processed on Tarantool instances.\nIf Tarantool instance is not available for Prometheus metrics\nextraction now, its contribution is not counted.\n",
                "gridPos": {
                   "h": 5,
@@ -422,7 +406,7 @@
                "pluginVersion": "6.6.0",
                "targets": [
                   {
-                     "expr": "sum(rate(tnt_net_requests_total{job=~\"$job\"}[$__rate_interval]))",
+                     "expr": "sum(rate(tnt_net_requests_total{job=~\"tarantool\"}[$__rate_interval]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "",
@@ -434,7 +418,7 @@
                "type": "stat"
             },
             {
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "description": "Overall rate of operations performed on Tarantool spaces\n(*select*, *insert*, *update* etc.).\nIf Tarantool instance is not available for Prometheus metrics\nextraction now, its contribution is not counted.\n",
                "gridPos": {
                   "h": 5,
@@ -476,7 +460,7 @@
                "pluginVersion": "6.6.0",
                "targets": [
                   {
-                     "expr": "sum(rate(tnt_stats_op_total{job=~\"$job\"}[$__rate_interval]))",
+                     "expr": "sum(rate(tnt_stats_op_total{job=~\"tarantool\"}[$__rate_interval]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "",
@@ -492,7 +476,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Number of \"warning\" issues on each cluster instance.\n\"warning\" issues includes high replication lag, replication long idle,\nfailover and switchover issues, clock issues, memory fragmentation,\nconfiguration issues and alien members warnings.\n\nPanel works with `cartridge >= 2.0.2`, `metrics >= 0.6.0`,\nwhile `metrics >= 0.9.0` is recommended for per instance display.\n",
                "fill": 0,
@@ -532,7 +516,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_cartridge_issues{job=~\"$job\",alias=~\"$alias\",level=\"warning\"}",
+                     "expr": "tnt_cartridge_issues{job=~\"tarantool\",alias=~\"$alias\",level=\"warning\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -582,7 +566,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Number of \"critical\" issues on each cluster instance.\n\"critical\" issues includes replication process critical fails and\nrunning out of available memory.\n\nPanel works with `cartridge >= 2.0.2`, `metrics >= 0.6.0`,\nwhile `metrics >= 0.9.0` is recommended for per instance display.\n",
                "fill": 0,
@@ -622,7 +606,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_cartridge_issues{job=~\"$job\",alias=~\"$alias\",level=\"critical\"}",
+                     "expr": "tnt_cartridge_issues{job=~\"tarantool\",alias=~\"$alias\",level=\"critical\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -668,7 +652,7 @@
                ]
             },
             {
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "description": "`follows` status means replication is running.\nOtherwise, `not running` is displayed.\n\nPanel works with `metrics >= 0.13.0` and Grafana 8.x.\n",
                "fieldConfig": {
                   "defaults": {
@@ -766,7 +750,7 @@
                },
                "targets": [
                   {
-                     "expr": "tnt_replication_status{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_replication_status{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} {{stream}} ({{id}})",
@@ -777,7 +761,7 @@
                "type": "timeseries"
             },
             {
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "description": "`master` status means instance is available for read and\nwrite operations. `replica` status means instance is\navailable only for read operations.\n\nPanel works with `metrics >= 0.11.0` and Grafana 8.x.\n",
                "fieldConfig": {
                   "defaults": {
@@ -875,7 +859,7 @@
                },
                "targets": [
                   {
-                     "expr": "tnt_read_only{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_read_only{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -890,7 +874,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "description": "Replication lag value for Tarantool instance.\n\nPanel works with `metrics >= 0.13.0`.\n",
                "fill": 0,
                "gridPos": {
@@ -929,7 +913,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_replication_lag{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_replication_lag{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} ({{id}})",
@@ -977,7 +961,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "description": "Clock drift across the cluster.\nmax shows difference with the fastest clock (always positive),\nmin shows difference with the slowest clock (always negative).\n\nPanel works with `metrics >= 0.10.0`.\n",
                "fill": 1,
                "gridPos": {
@@ -1016,7 +1000,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_clock_delta{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_clock_delta{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} ({{delta}})",
@@ -1084,7 +1068,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Requests, processed with success (code 2xx) on Tarantool's side.\nGraph shows mean count per second.\n",
                "fill": 0,
@@ -1124,7 +1108,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(http_server_request_latency_count{job=~\"$job\",alias=~\"$alias\",status=~\"^2\\\\d{2}$\"}[$__rate_interval])",
+                     "expr": "rate(http_server_request_latency_count{job=~\"tarantool\",alias=~\"$alias\",status=~\"^2\\\\d{2}$\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
@@ -1174,7 +1158,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Requests, processed with 4xx error on Tarantool's side.\nGraph shows mean count per second.\n",
                "fill": 0,
@@ -1214,7 +1198,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(http_server_request_latency_count{job=~\"$job\",alias=~\"$alias\",status=~\"^4\\\\d{2}$\"}[$__rate_interval])",
+                     "expr": "rate(http_server_request_latency_count{job=~\"tarantool\",alias=~\"$alias\",status=~\"^4\\\\d{2}$\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
@@ -1264,7 +1248,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Requests, processed with 5xx error on Tarantool's side.\nGraph shows mean count per second.\n",
                "fill": 0,
@@ -1304,7 +1288,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(http_server_request_latency_count{job=~\"$job\",alias=~\"$alias\",status=~\"^5\\\\d{2}$\"}[$__rate_interval])",
+                     "expr": "rate(http_server_request_latency_count{job=~\"tarantool\",alias=~\"$alias\",status=~\"^5\\\\d{2}$\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
@@ -1354,7 +1338,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "99th percentile of requests latency.\nIncludes only requests processed with success\n(code 2xx) on Tarantool's side.\n",
                "fill": 0,
@@ -1394,7 +1378,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "http_server_request_latency{job=~\"$job\",alias=~\"$alias\",quantile=\"0.99\",status=~\"^2\\\\d{2}$\"}",
+                     "expr": "http_server_request_latency{job=~\"tarantool\",alias=~\"$alias\",quantile=\"0.99\",status=~\"^2\\\\d{2}$\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
@@ -1444,7 +1428,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "99th percentile of requests latency.\nIncludes only requests processed with\n4xx error on Tarantool's side.\n",
                "fill": 0,
@@ -1484,7 +1468,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "http_server_request_latency{job=~\"$job\",alias=~\"$alias\",quantile=\"0.99\",status=~\"^4\\\\d{2}$\"}",
+                     "expr": "http_server_request_latency{job=~\"tarantool\",alias=~\"$alias\",quantile=\"0.99\",status=~\"^4\\\\d{2}$\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
@@ -1534,7 +1518,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "99th percentile of requests latency.\nIncludes only requests processed with\n5xx error on Tarantool's side.\n",
                "fill": 0,
@@ -1574,7 +1558,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "http_server_request_latency{job=~\"$job\",alias=~\"$alias\",quantile=\"0.99\",status=~\"^5\\\\d{2}$\"}",
+                     "expr": "http_server_request_latency{job=~\"tarantool\",alias=~\"$alias\",quantile=\"0.99\",status=~\"^5\\\\d{2}$\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
@@ -1644,7 +1628,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Memory used for network input/output buffers.\n",
                "fill": 0,
@@ -1684,7 +1668,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_info_memory_net{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_info_memory_net{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1734,7 +1718,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Data received by instance from binary protocol connections.\nGraph shows average bytes per second.\n",
                "fill": 0,
@@ -1774,7 +1758,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_received_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_received_total{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1824,7 +1808,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Data sent by instance with binary protocol connections.\nGraph shows average bytes per second.\n",
                "fill": 0,
@@ -1864,7 +1848,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_sent_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_sent_total{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1914,7 +1898,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Number of network requests this instance has handled.\nGraph shows mean rps.\n\nPanel will be removed in favor of \"Processed requests\"\nand \"Requests in queue (overall)\" panels.\n",
                "fill": 0,
@@ -1954,7 +1938,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_requests_total{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2004,7 +1988,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Number of pending network requests.\n\nPanel will be removed in favor of \"Requests in progress\"\nand \"Requests in queue (current)\" panels.\n",
                "fill": 0,
@@ -2044,7 +2028,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_current{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_net_requests_current{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2094,7 +2078,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average number of requests processed by tx thread per second.\n\nPanel works with `metrics >= 0.13.0` and `Tarantool >= 2.10-beta2`.\n",
                "fill": 0,
@@ -2134,7 +2118,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_in_progress_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_requests_in_progress_total{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2184,7 +2168,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Number of requests currently being processed in the tx thread.\n\nPanel works with `metrics >= 0.13.0` and `Tarantool >= 2.10-beta2`.\n",
                "fill": 0,
@@ -2224,7 +2208,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_in_progress_current{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_net_requests_in_progress_current{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2274,7 +2258,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average number of requests which was placed in queues\nof streams per second.\n\nPanel works with `metrics >= 0.13.0` and `Tarantool >= 2.10-beta2`.\n",
                "fill": 0,
@@ -2314,7 +2298,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_in_stream_queue_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_requests_in_stream_queue_total{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2364,7 +2348,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Number of requests currently waiting in queues of streams.\n\nPanel works with `metrics >= 0.13.0` and `Tarantool >= 2.10-beta2`.\n",
                "fill": 0,
@@ -2404,7 +2388,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_in_stream_queue_current{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_net_requests_in_stream_queue_current{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2454,7 +2438,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average number of new binary protocol connections per second.\n",
                "fill": 0,
@@ -2494,7 +2478,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_connections_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_connections_total{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2544,7 +2528,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Number of current active binary protocol connections.\n",
                "fill": 0,
@@ -2584,7 +2568,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_connections_current{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_net_connections_current{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2668,7 +2652,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "`quota_used_ratio` = `quota_used` / `quota_size`.\n\n`quota_used` – used by slab allocator (for both tuple and index slabs).\n\n`quota_size` – memory limit for slab allocator (as configured in the *memtx_memory* parameter).\n",
                "fill": 0,
@@ -2708,7 +2692,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_used_ratio{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_slab_quota_used_ratio{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2758,7 +2742,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "`arena_used_ratio` = `arena_used` / `arena_size`.\n\n`arena_used` – used for both tuples and indexes.\n\n`arena_size` – allocated for both tuples and indexes.\n",
                "fill": 0,
@@ -2798,7 +2782,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_used_ratio{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_slab_arena_used_ratio{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2848,7 +2832,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "`items_used_ratio` = `items_used` / `items_size`.\n\n`items_used` – used only for tuples.\n\n`items_size` – allocated only for tuples.\n",
                "fill": 0,
@@ -2888,7 +2872,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_used_ratio{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_slab_items_used_ratio{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2938,7 +2922,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Memory used by slab allocator (for both tuple and index slabs).\n",
                "fill": 0,
@@ -2978,7 +2962,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_used{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_slab_quota_used{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3028,7 +3012,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Memory used for both tuples and indexes.\n",
                "fill": 0,
@@ -3068,7 +3052,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_used{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_slab_arena_used{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3118,7 +3102,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Memory used for only tuples.\n",
                "fill": 0,
@@ -3158,7 +3142,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_used{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_slab_items_used{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3208,7 +3192,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Memory limit for slab allocator (as configured in the *memtx_memory* parameter).\n",
                "fill": 0,
@@ -3248,7 +3232,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_size{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_slab_quota_size{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3298,7 +3282,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Memory allocated for both tuples and indexes by slab allocator.\n",
                "fill": 0,
@@ -3338,7 +3322,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_size{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_slab_arena_size{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3388,7 +3372,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Memory allocated for only tuples by slab allocator.\n",
                "fill": 0,
@@ -3428,7 +3412,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_size{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_slab_items_size{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3498,7 +3482,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Number of records in the space (memtx engine).\nName of space is specified after dash.\n",
                "fill": 0,
@@ -3538,7 +3522,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_len{job=~\"$job\", alias=~\"$alias\", engine=\"memtx\"}",
+                     "expr": "tnt_space_len{job=~\"tarantool\", alias=~\"$alias\", engine=\"memtx\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3588,7 +3572,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Number of records in the space (vinyl engine).\nName of space is specified after dash.\nBy default this metrics is disabled,\nto enable it you must set global variable\ninclude_vinyl_count to true. Beware that\ncount() operation scans the space and may\nslow down your app. \n\nPanel works with `metrics >= 0.13.0`.\n",
                "fill": 0,
@@ -3628,7 +3612,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_tuples{job=~\"$job\", alias=~\"$alias\", engine=\"vinyl\"}",
+                     "expr": "tnt_vinyl_tuples{job=~\"tarantool\", alias=~\"$alias\", engine=\"vinyl\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3678,7 +3662,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Total number of bytes in all tuples of the space (memtx engine).\nName of space is specified after dash.\n",
                "fill": 0,
@@ -3718,7 +3702,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_bsize{job=~\"$job\", alias=~\"$alias\", engine=\"memtx\"}",
+                     "expr": "tnt_space_bsize{job=~\"tarantool\", alias=~\"$alias\", engine=\"memtx\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3768,7 +3752,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Total number of bytes taken by the index.\nName of space is specified after dash,\nindex name specified in parentheses.\nIncludes both memtx and vinyl spaces.\n",
                "fill": 0,
@@ -3808,7 +3792,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_index_bsize{job=~\"$job\", alias=~\"$alias\"}",
+                     "expr": "tnt_space_index_bsize{job=~\"tarantool\", alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}} ({{index_name}})",
@@ -3858,7 +3842,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Total size of tuples and all indexes in the space (memtx engine).\nName of space is specified after dash.\n",
                "fill": 0,
@@ -3898,7 +3882,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_total_bsize{job=~\"$job\", alias=~\"$alias\", engine=\"memtx\"}",
+                     "expr": "tnt_space_total_bsize{job=~\"tarantool\", alias=~\"$alias\", engine=\"memtx\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3968,7 +3952,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "The amount of data stored in the `.run` files located in the `vinyl_dir` directory.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4008,7 +3992,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_disk_data_size{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_vinyl_disk_data_size{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4058,7 +4042,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "The amount of data stored in the `.index` files located in the `vinyl_dir` directory.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4098,7 +4082,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_disk_index_size{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_vinyl_disk_index_size{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4148,7 +4132,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Amount of memory in bytes currently used to store tuples (data).\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4188,7 +4172,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_tuple_cache{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_vinyl_memory_tuple_cache{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4238,7 +4222,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4278,7 +4262,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_page_index{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_vinyl_memory_page_index{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4328,7 +4312,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Amount of memory in bytes used by bloom filters.\n",
                "fill": 0,
@@ -4368,7 +4352,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_bloom_filter{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_vinyl_memory_bloom_filter{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4418,7 +4402,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "The estimated average rate of taking dumps, bytes per second.\nInitially, the rate value is 10 megabytes per second\nand being recalculated depending on the the actual rate.\nOnly significant dumps that are larger than one megabyte\nare used for the estimate.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4458,7 +4442,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_dump_bandwidth{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_vinyl_regulator_dump_bandwidth{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4508,7 +4492,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "The actual average rate of performing the write operations, bytes per second.\nThe rate is calculated as a 5-second moving average.\nIf the metric value is gradually going down, this can indicate some disk issues.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4548,7 +4532,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_write_rate{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_vinyl_regulator_write_rate{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4598,7 +4582,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "The write rate limit, bytes per second.\nThe regulator imposes the limit on transactions based on the observed dump/compaction performance.\nIf the metric value is down to approximately 100 Kbps,\nthis indicates issues with the disk or the scheduler.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4638,7 +4622,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_rate_limit{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_vinyl_regulator_rate_limit{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4688,7 +4672,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "«Level 0» (L0) memory area in bytes. L0 is the area that\nvinyl can use for in-memory storage of an LSM tree.\nBy monitoring this metric, you can see when L0 is getting\nclose to its maximum (tnt_vinyl_regulator_dump_watermark),\nat which time a dump will occur. You can expect L0 = 0\nimmediately after the dump operation is completed.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4728,7 +4712,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_level0{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_vinyl_memory_level0{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4778,7 +4762,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "The maximum amount of memory used for in-memory storing of a vinyl LSM tree.\nWhen accessing this maximum, the dumping must occur.\nFor details, see https://www.tarantool.io/en/doc/latest/book/box/engines/#engines-algorithm-filling-lsm.\nThe value is slightly smaller than the amount of memory allocated for vinyl trees,\nwhich is the `vinyl_memory` parameter.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4818,7 +4802,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_dump_watermark{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_vinyl_regulator_dump_watermark{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4868,7 +4852,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "The number of fibers that are blocked waiting for Vinyl level0 memory quota.\n\nPanel works with `metrics >= 0.13.0` and `Tarantool >= 2.8.3`.\n",
                "fill": 0,
@@ -4908,7 +4892,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_blocked_writers{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_vinyl_regulator_blocked_writers{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4958,7 +4942,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average per second rate of commits (successful transaction ends).\nIt includes implicit commits: for example, any insert operation causes a commit\nunless it is within a `box.begin()`–`box.commit()` block.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4998,7 +4982,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_commit{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_tx_commit{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5048,7 +5032,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average per second rate of rollbacks (unsuccessful transaction ends).\nThis is not merely a count of explicit `box.rollback()` requests — it includes requests\nthat ended with errors.\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -5088,7 +5072,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_rollback{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_tx_rollback{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5138,7 +5122,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average per second rate of conflicts that caused transactions to roll back.\nThe ratio `tx conflicts` / `tx commits` above 5% indicates that vinyl is not healthy.\nAt this moment you’ll probably see a lot of other problems with vinyl.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -5178,7 +5162,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_conflict{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_tx_conflict{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5228,7 +5212,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Number of current read views, that is, transactions entered a read-only state\nto avoid conflict temporarily.\nIf the value stays non-zero for a long time, it indicates of a memory leak.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -5268,7 +5252,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_tx_read_views{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_vinyl_tx_read_views{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5318,7 +5302,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "The number of the scheduler dump/compaction tasks in progress now.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -5358,7 +5342,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_scheduler_tasks{job=~\"$job\", alias=~\"$alias\", status=\"inprogress\"}",
+                     "expr": "tnt_vinyl_scheduler_tasks{job=~\"tarantool\", alias=~\"$alias\", status=\"inprogress\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5408,7 +5392,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Scheduler dump/compaction tasks failed.\nAverage per second rate is shown.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -5448,7 +5432,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_tasks{job=~\"$job\",alias=~\"$alias\",status=\"failed\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_scheduler_tasks{job=~\"tarantool\",alias=~\"$alias\",status=\"failed\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5498,7 +5482,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Time spent by all worker threads performing dumps.\nAverage per second rate is shown.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -5538,7 +5522,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_dump_time{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_scheduler_dump_time{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5588,7 +5572,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Scheduler dumps completed average per second rate.\n\nPanel works with `metrics >= 0.13.0`.\n",
                "fill": 0,
@@ -5628,7 +5612,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_dump_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_scheduler_dump_total{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5698,7 +5682,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "This is the average share of time\nspent by instance process executing in user mode.\nMetrics obtained using `getrusage()` call.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -5738,7 +5722,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_cpu_user_time{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tnt_cpu_user_time{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5788,7 +5772,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "This is the average share of time\nspent by instance process executing in kernel mode.\nMetrics obtained using `getrusage()` call.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -5828,7 +5812,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_cpu_system_time{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tnt_cpu_system_time{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5898,7 +5882,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance. \n",
                "fill": 0,
@@ -5938,7 +5922,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_info_memory_lua{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_info_memory_lua{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5988,7 +5972,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Memory used by runtime arena.\nRuntime arena stores network buffers, tuples\ncreated with box.tuple.new and other objects\nallocated by application not covered by basic\nLua mechanisms (spaces data and indexes\nare not included here, see memtx/vinyl arena).\n",
                "fill": 0,
@@ -6028,7 +6012,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_runtime_used{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_runtime_used{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6078,7 +6062,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Memory in use by active transactions.\nFor the vinyl storage engine, this is the total size of\nall allocated objects (struct txv, struct vy_tx, struct vy_read_interval)\nand tuples pinned for those objects. \n",
                "fill": 0,
@@ -6118,7 +6102,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_info_memory_tx{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_info_memory_tx{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6168,7 +6152,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Number of fiber context switches.\nContext switches are counted over all current fibers.\n",
                "fill": 0,
@@ -6208,7 +6192,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_csw{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_fiber_csw{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6258,7 +6242,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Duration of last event loop iteration (tx thread).\nHigh duration results in longer responses,\npossible bad health signals and may be the\nreason of \"Too long WAL write\" errors.\n\nPanel works with `metrics >= 0.13.0`.\n",
                "fill": 0,
@@ -6298,7 +6282,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_ev_loop_time{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_ev_loop_time{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6348,7 +6332,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Current number of fibers in tx thread. \n\nPanel works with `metrics >= 0.13.0`.\n",
                "fill": 0,
@@ -6388,7 +6372,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_amount{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_fiber_amount{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6438,7 +6422,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Amount of memory used by current fibers.\n",
                "fill": 0,
@@ -6478,7 +6462,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_memused{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_fiber_memused{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6528,7 +6512,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Amount of memory reserved for current fibers.\n",
                "fill": 0,
@@ -6568,7 +6552,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_memalloc{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_fiber_memalloc{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6638,7 +6622,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average number of snap restores (guard assertions\nleading to stopping trace executions) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -6678,7 +6662,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_snap_restore{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(lj_jit_snap_restore{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6728,7 +6712,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average number of new JIT traces per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -6768,7 +6752,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_trace_num{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(lj_jit_trace_num{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6818,7 +6802,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average number of JIT trace aborts per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -6858,7 +6842,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_trace_abort{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(lj_jit_trace_abort{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6908,7 +6892,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Total size of allocated machine code areas.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -6948,7 +6932,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_jit_mcode_size{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "lj_jit_mcode_size{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6998,7 +6982,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average number of strings being extracted from hash instead of allocating per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7038,7 +7022,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_strhash_hit{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(lj_strhash_hit{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7088,7 +7072,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average number of strings being allocated due to hash miss per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7128,7 +7112,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_strhash_miss{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(lj_strhash_miss{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7178,7 +7162,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average count of incremental GC steps (atomic state) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7218,7 +7202,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_atomic{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_atomic{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7268,7 +7252,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average count of incremental GC steps (sweepstring state) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7308,7 +7292,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_sweepstring{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_sweepstring{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7358,7 +7342,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average count of incremental GC steps (finalize state) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7398,7 +7382,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_finalize{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_finalize{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7448,7 +7432,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average count of incremental GC steps (sweep state) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7488,7 +7472,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_sweep{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_sweep{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7538,7 +7522,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average count of incremental GC steps (propagate state) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7578,7 +7562,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_propagate{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_propagate{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7628,7 +7612,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average count of incremental GC steps (pause state) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7668,7 +7652,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_pause{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_pause{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7718,7 +7702,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Number of allocated string objects.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7758,7 +7742,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_strnum{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "lj_gc_strnum{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7808,7 +7792,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Number of allocated table objects.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7848,7 +7832,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_tabnum{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "lj_gc_tabnum{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7898,7 +7882,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Number of allocated cdata objects.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7938,7 +7922,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_cdatanum{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "lj_gc_cdatanum{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7988,7 +7972,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Number of allocated userdata objects.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -8028,7 +8012,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_udatanum{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "lj_gc_udatanum{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8078,7 +8062,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Current allocated Lua memory.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -8118,7 +8102,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_memory{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "lj_gc_memory{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8168,7 +8152,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average amount of freed Lua memory per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -8208,7 +8192,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_freed{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_freed{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8258,7 +8242,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average amount of allocated Lua memory per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -8298,7 +8282,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_allocated{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_allocated{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8368,7 +8352,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Total count of SELECT requests to all instance spaces.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8408,7 +8392,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"select\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\"$alias\",operation=\"select\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8458,7 +8442,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Total count of INSERT requests to all instance spaces.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8498,7 +8482,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"insert\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\"$alias\",operation=\"insert\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8548,7 +8532,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Total count of REPLACE requests to all instance spaces.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8588,7 +8572,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"replace\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\"$alias\",operation=\"replace\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8638,7 +8622,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Total count of UPSERT requests to all instance spaces.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8678,7 +8662,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"upsert\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\"$alias\",operation=\"upsert\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8728,7 +8712,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Total count of UPDATE requests to all instance spaces.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8768,7 +8752,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"update\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\"$alias\",operation=\"update\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8818,7 +8802,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Total count of DELETE requests to all instance spaces.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8858,7 +8842,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"delete\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\"$alias\",operation=\"delete\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8908,7 +8892,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Requests to execute stored procedures.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8948,7 +8932,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"call\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\"$alias\",operation=\"call\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8998,7 +8982,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Calls to evaluate Lua code.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -9038,7 +9022,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"eval\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\"$alias\",operation=\"eval\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9088,7 +9072,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Requests resulted in error.\nGraph shows average errors per second.\n",
                "fill": 0,
@@ -9128,7 +9112,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\"$alias\",operation=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9178,7 +9162,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Authentication requests.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -9218,7 +9202,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"auth\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\"$alias\",operation=\"auth\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9268,7 +9252,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "SQL prepare calls.\nGraph shows average calls per second.\n\nPanel works with Tarantool 2.x.\n",
                "fill": 0,
@@ -9308,7 +9292,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"prepare\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\"$alias\",operation=\"prepare\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9358,7 +9342,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "SQL execute calls.\nGraph shows average calls per second.\n\nPanel works with Tarantool 2.x.\n",
                "fill": 0,
@@ -9398,7 +9382,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"execute\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\"$alias\",operation=\"execute\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9468,7 +9452,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of success SELECT and PAIRS requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -9508,7 +9492,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"select\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"select\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -9558,7 +9542,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of success SELECT and PAIRS CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -9598,7 +9582,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"select\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"select\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -9648,7 +9632,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of error SELECT and PAIRS requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -9688,7 +9672,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"select\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"select\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -9738,7 +9722,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of error SELECT and PAIRS CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -9778,7 +9762,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"select\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"select\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -9828,7 +9812,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average number of tuples fetched during SELECT/PAIRS request for a space.\nBoth success and error requests are taken into consideration.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -9868,7 +9852,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_tuples_fetched{job=~\"$job\",alias=~\"$alias\", operation=\"select\"}[$__rate_interval]) /\n(sum without (status) (rate(tnt_crud_stats_count{job=~\"$job\",operation=\"select\"}[$__rate_interval])))\n",
+                     "expr": "rate(tnt_crud_tuples_fetched{job=~\"tarantool\",alias=~\"$alias\", operation=\"select\"}[$__rate_interval]) /\n(sum without (status) (rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"select\"}[$__rate_interval])))\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -9918,7 +9902,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average number of tuples looked up on storages while collecting responses\nfor SELECT/PAIRS requests (including scrolls for multibatch requests)\nfor a space. Both success and error requests are taken into consideration.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -9958,7 +9942,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_tuples_lookup{job=~\"$job\",alias=~\"$alias\", operation=\"select\"}[$__rate_interval]) /\n(sum without (status) (rate(tnt_crud_stats_count{job=~\"$job\",operation=\"select\"}[$__rate_interval])))\n",
+                     "expr": "rate(tnt_crud_tuples_lookup{job=~\"tarantool\",alias=~\"$alias\", operation=\"select\"}[$__rate_interval]) /\n(sum without (status) (rate(tnt_crud_stats_count{job=~\"tarantool\",operation=\"select\"}[$__rate_interval])))\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10008,7 +9992,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Number of SELECT and PAIRS requests that resulted in map reduce.\nGraph shows average requests per second.\nBoth success and error requests are taken into consideration.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -10048,7 +10032,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_map_reduces{job=~\"$job\",alias=~\"$alias\",operation=\"select\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_map_reduces{job=~\"tarantool\",alias=~\"$alias\",operation=\"select\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10098,7 +10082,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of success insert and insert_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -10138,7 +10122,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"insert\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"insert\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10188,7 +10172,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of success insert and insert_object CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -10228,7 +10212,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"insert\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"insert\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10278,7 +10262,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of error insert and insert_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -10318,7 +10302,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"insert\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"insert\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10368,7 +10352,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of error insert and insert_object CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -10408,7 +10392,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"insert\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"insert\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10458,7 +10442,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of success insert_many and insert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -10498,7 +10482,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"insert_many\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"insert_many\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10548,7 +10532,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of success insert_many and insert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -10588,7 +10572,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"insert_many\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"insert_many\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10638,7 +10622,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of error insert_many and insert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -10678,7 +10662,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"insert_many\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"insert_many\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10728,7 +10712,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of error insert_many and insert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -10768,7 +10752,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"insert_many\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"insert_many\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10818,7 +10802,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of success replace and replace_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -10858,7 +10842,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"replace\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"replace\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10908,7 +10892,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of success replace and replace_object CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -10948,7 +10932,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"replace\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"replace\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -10998,7 +10982,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of error replace and replace_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -11038,7 +11022,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"replace\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"replace\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11088,7 +11072,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of error replace and replace_object CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -11128,7 +11112,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"replace\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"replace\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11178,7 +11162,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of success replace_many and replace_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -11218,7 +11202,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"replace_many\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"replace_many\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11268,7 +11252,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of success replace_many and replace_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -11308,7 +11292,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"replace_many\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"replace_many\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11358,7 +11342,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of error replace_many and replace_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -11398,7 +11382,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"replace_many\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"replace_many\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11448,7 +11432,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of error replace_many and replace_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -11488,7 +11472,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"replace_many\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"replace_many\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11538,7 +11522,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of success upsert and upsert_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -11578,7 +11562,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"upsert\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"upsert\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11628,7 +11612,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of success upsert and upsert_object CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -11668,7 +11652,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"upsert\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"upsert\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11718,7 +11702,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of error upsert and upsert_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -11758,7 +11742,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"upsert\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"upsert\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11808,7 +11792,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of error upsert and upsert_object CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -11848,7 +11832,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"upsert\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"upsert\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11898,7 +11882,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of success upsert_many and upsert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -11938,7 +11922,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"upsert_many\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"upsert_many\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -11988,7 +11972,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of success upsert_many and upsert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -12028,7 +12012,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"upsert_many\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"upsert_many\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12078,7 +12062,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of error upsert_many and upsert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -12118,7 +12102,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"upsert_many\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"upsert_many\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12168,7 +12152,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of error upsert_many and upsert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -12208,7 +12192,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"upsert_many\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"upsert_many\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12258,7 +12242,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of success update requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -12298,7 +12282,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"update\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"update\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12348,7 +12332,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of success update CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -12388,7 +12372,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"update\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"update\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12438,7 +12422,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of error update requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -12478,7 +12462,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"update\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"update\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12528,7 +12512,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of error update CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -12568,7 +12552,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"update\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"update\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12618,7 +12602,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of success delete requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -12658,7 +12642,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"delete\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"delete\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12708,7 +12692,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of success delete CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -12748,7 +12732,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"delete\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"delete\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12798,7 +12782,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of error delete requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -12838,7 +12822,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"delete\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"delete\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12888,7 +12872,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of error delete CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -12928,7 +12912,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"delete\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"delete\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -12978,7 +12962,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of success count requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -13018,7 +13002,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"count\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"count\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13068,7 +13052,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of success count CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -13108,7 +13092,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"count\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"count\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13158,7 +13142,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of error count requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -13198,7 +13182,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"count\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"count\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13248,7 +13232,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of error count CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -13288,7 +13272,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"count\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"count\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13338,7 +13322,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of success get requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -13378,7 +13362,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"get\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"get\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13428,7 +13412,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of success get CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -13468,7 +13452,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"get\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"get\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13518,7 +13502,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of error get requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -13558,7 +13542,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"get\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"get\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13608,7 +13592,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of error get CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -13648,7 +13632,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"get\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"get\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13698,7 +13682,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of success MIN and MAX requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -13738,7 +13722,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"borders\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"borders\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13788,7 +13772,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of success MIN and MAX CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -13828,7 +13812,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"borders\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"borders\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13878,7 +13862,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of error MIN and MAX requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -13918,7 +13902,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"borders\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"borders\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -13968,7 +13952,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of error MIN and MAX CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -14008,7 +13992,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"borders\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"borders\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14058,7 +14042,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of success len requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -14098,7 +14082,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"len\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"len\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14148,7 +14132,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of success len CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -14188,7 +14172,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"len\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"len\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14238,7 +14222,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of error len requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -14278,7 +14262,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"len\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"len\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14328,7 +14312,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of error len CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -14368,7 +14352,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"len\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"len\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14418,7 +14402,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of success truncate requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -14458,7 +14442,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"truncate\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"truncate\",status=\"ok\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14508,7 +14492,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of success truncate CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -14548,7 +14532,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"truncate\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"truncate\",status=\"ok\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14598,7 +14582,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "Total count of error truncate requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
@@ -14638,7 +14622,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"truncate\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_crud_stats_count{job=~\"tarantool\",alias=~\"$alias\",operation=\"truncate\",status=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14688,7 +14672,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 2,
                "description": "99th percentile of error truncate CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
                "fill": 0,
@@ -14728,7 +14712,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"truncate\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tnt_crud_stats{job=~\"tarantool\",alias=~\"$alias\",operation=\"truncate\",status=\"error\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -14798,7 +14782,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "A number of task tuples checked for expiration (expired + skipped).\nGraph shows mean tuples per second.\n",
                "fill": 0,
@@ -14838,7 +14822,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(expirationd_checked_count{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(expirationd_checked_count{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -14888,7 +14872,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "A number of task expired tuples.\nGraph shows mean tuples per second.\n",
                "fill": 0,
@@ -14928,7 +14912,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(expirationd_expired_count{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(expirationd_expired_count{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -14978,7 +14962,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "A number of task restarts since start.\nFrom the start is equal to 1.\n",
                "fill": 0,
@@ -15018,7 +15002,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "expirationd_restarts{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "expirationd_restarts{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -15068,7 +15052,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "A task's operation time.\n",
                "fill": 0,
@@ -15108,7 +15092,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "expirationd_working_time{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "expirationd_working_time{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -15161,296 +15145,6 @@
          "title": "expirationd module statistics",
          "titleSize": "h6",
          "type": "row"
-      },
-      {
-         "collapse": true,
-         "collapsed": true,
-         "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 429
-         },
-         "id": 182,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 3,
-               "description": "My custom component could have 3 statuses:\ncode 2 is OK, code 1 is suspended process, code 0 means issues in component.\n",
-               "fill": 0,
-               "gridPos": {
-                  "h": 6,
-                  "w": 24,
-                  "x": 0,
-                  "y": 430
-               },
-               "id": 183,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "my_component_status{job=~\"$job\",alias=~\"$alias\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "My custom component status",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "decimals": 0,
-                     "format": "none",
-                     "label": "requests per second",
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "decimals": 3,
-                     "format": "none",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 3,
-               "description": "My custom component processes requests\nand collects info on process to summary collector\n'my_component_load_metric'.\n",
-               "fill": 0,
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 0,
-                  "y": 436
-               },
-               "id": 184,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "rate(my_component_load_metric_count{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "My custom component load",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "decimals": 0,
-                     "format": "none",
-                     "label": "requests per second",
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "decimals": 3,
-                     "format": "none",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 3,
-               "description": "My custom component processes requests\nand collects info on process to summary collector\n'my_component_load_metric'.\n",
-               "fill": 0,
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 12,
-                  "y": 436
-               },
-               "id": 185,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "my_component_load_metric{job=~\"$job\",alias=~\"$alias\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "My custom component process",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "decimals": 0,
-                     "format": "s",
-                     "label": "process time",
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Tarantool network activity",
-         "titleSize": "h6",
-         "type": "row"
       }
    ],
    "refresh": "30s",
@@ -15465,38 +15159,17 @@
          {
             "allValue": null,
             "current": {
-               "text": "${PROMETHEUS_JOB}",
-               "value": "${PROMETHEUS_JOB}"
-            },
-            "hide": 2,
-            "includeAll": false,
-            "label": "Prometheus job",
-            "multi": false,
-            "name": "job",
-            "options": [
-               {
-                  "text": "${PROMETHEUS_JOB}",
-                  "value": "${PROMETHEUS_JOB}"
-               }
-            ],
-            "query": "${PROMETHEUS_JOB}",
-            "refresh": 0,
-            "type": "custom"
-         },
-         {
-            "allValue": null,
-            "current": {
                "text": "all",
                "value": "$__all"
             },
-            "datasource": "${DS_PROMETHEUS}",
+            "datasource": "Prometheus",
             "hide": 0,
             "includeAll": true,
             "label": "Instances",
             "multi": true,
             "name": "alias",
             "options": [ ],
-            "query": "label_values(tnt_info_uptime{job=~\"$job\"},alias)",
+            "query": "label_values(tnt_info_uptime{job=\"tarantool\"},alias)",
             "refresh": 2,
             "regex": "",
             "sort": 0,

--- a/tests/Prometheus/dashboard_tdg_static_compiled.json
+++ b/tests/Prometheus/dashboard_tdg_static_compiled.json
@@ -516,7 +516,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_cartridge_issues{job=~\"tarantool\",level=\"warning\"}",
+                     "expr": "tnt_cartridge_issues{job=~\"tarantool\",alias=~\".*\",level=\"warning\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -606,7 +606,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_cartridge_issues{job=~\"tarantool\",level=\"critical\"}",
+                     "expr": "tnt_cartridge_issues{job=~\"tarantool\",alias=~\".*\",level=\"critical\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -750,7 +750,7 @@
                },
                "targets": [
                   {
-                     "expr": "tnt_replication_status{job=~\"tarantool\"}",
+                     "expr": "tnt_replication_status{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} {{stream}} ({{id}})",
@@ -859,7 +859,7 @@
                },
                "targets": [
                   {
-                     "expr": "tnt_read_only{job=~\"tarantool\"}",
+                     "expr": "tnt_read_only{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -913,7 +913,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_replication_lag{job=~\"tarantool\"}",
+                     "expr": "tnt_replication_lag{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} ({{id}})",
@@ -1000,7 +1000,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_clock_delta{job=~\"tarantool\"}",
+                     "expr": "tnt_clock_delta{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} ({{delta}})",
@@ -1108,7 +1108,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_info_memory_net{job=~\"tarantool\"}",
+                     "expr": "tnt_info_memory_net{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1198,7 +1198,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_received_total{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_received_total{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1288,7 +1288,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_sent_total{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_sent_total{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1378,7 +1378,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_total{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_requests_total{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1468,7 +1468,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_current{job=~\"tarantool\"}",
+                     "expr": "tnt_net_requests_current{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1558,7 +1558,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_in_progress_total{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_requests_in_progress_total{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1648,7 +1648,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_in_progress_current{job=~\"tarantool\"}",
+                     "expr": "tnt_net_requests_in_progress_current{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1738,7 +1738,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_in_stream_queue_total{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_requests_in_stream_queue_total{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1828,7 +1828,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_in_stream_queue_current{job=~\"tarantool\"}",
+                     "expr": "tnt_net_requests_in_stream_queue_current{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1918,7 +1918,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_connections_total{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_connections_total{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2008,7 +2008,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_connections_current{job=~\"tarantool\"}",
+                     "expr": "tnt_net_connections_current{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2132,7 +2132,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_used_ratio{job=~\"tarantool\"}",
+                     "expr": "tnt_slab_quota_used_ratio{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2222,7 +2222,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_used_ratio{job=~\"tarantool\"}",
+                     "expr": "tnt_slab_arena_used_ratio{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2312,7 +2312,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_used_ratio{job=~\"tarantool\"}",
+                     "expr": "tnt_slab_items_used_ratio{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2402,7 +2402,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_used{job=~\"tarantool\"}",
+                     "expr": "tnt_slab_quota_used{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2492,7 +2492,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_used{job=~\"tarantool\"}",
+                     "expr": "tnt_slab_arena_used{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2582,7 +2582,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_used{job=~\"tarantool\"}",
+                     "expr": "tnt_slab_items_used{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2672,7 +2672,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_size{job=~\"tarantool\"}",
+                     "expr": "tnt_slab_quota_size{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2762,7 +2762,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_size{job=~\"tarantool\"}",
+                     "expr": "tnt_slab_arena_size{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2852,7 +2852,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_size{job=~\"tarantool\"}",
+                     "expr": "tnt_slab_items_size{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2962,7 +2962,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_len{job=~\"tarantool\", engine=\"memtx\"}",
+                     "expr": "tnt_space_len{job=~\"tarantool\", alias=~\".*\", engine=\"memtx\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3052,7 +3052,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_tuples{job=~\"tarantool\", engine=\"vinyl\"}",
+                     "expr": "tnt_vinyl_tuples{job=~\"tarantool\", alias=~\".*\", engine=\"vinyl\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3142,7 +3142,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_bsize{job=~\"tarantool\", engine=\"memtx\"}",
+                     "expr": "tnt_space_bsize{job=~\"tarantool\", alias=~\".*\", engine=\"memtx\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3232,7 +3232,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_index_bsize{job=~\"tarantool\"}",
+                     "expr": "tnt_space_index_bsize{job=~\"tarantool\", alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}} ({{index_name}})",
@@ -3322,7 +3322,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_total_bsize{job=~\"tarantool\", engine=\"memtx\"}",
+                     "expr": "tnt_space_total_bsize{job=~\"tarantool\", alias=~\".*\", engine=\"memtx\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3432,7 +3432,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_disk_data_size{job=~\"tarantool\"}",
+                     "expr": "tnt_vinyl_disk_data_size{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3522,7 +3522,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_disk_index_size{job=~\"tarantool\"}",
+                     "expr": "tnt_vinyl_disk_index_size{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3612,7 +3612,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_tuple_cache{job=~\"tarantool\"}",
+                     "expr": "tnt_vinyl_memory_tuple_cache{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3702,7 +3702,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_page_index{job=~\"tarantool\"}",
+                     "expr": "tnt_vinyl_memory_page_index{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3792,7 +3792,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_bloom_filter{job=~\"tarantool\"}",
+                     "expr": "tnt_vinyl_memory_bloom_filter{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3882,7 +3882,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_dump_bandwidth{job=~\"tarantool\"}",
+                     "expr": "tnt_vinyl_regulator_dump_bandwidth{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3972,7 +3972,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_write_rate{job=~\"tarantool\"}",
+                     "expr": "tnt_vinyl_regulator_write_rate{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4062,7 +4062,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_rate_limit{job=~\"tarantool\"}",
+                     "expr": "tnt_vinyl_regulator_rate_limit{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4152,7 +4152,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_level0{job=~\"tarantool\"}",
+                     "expr": "tnt_vinyl_memory_level0{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4242,7 +4242,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_dump_watermark{job=~\"tarantool\"}",
+                     "expr": "tnt_vinyl_regulator_dump_watermark{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4332,7 +4332,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_blocked_writers{job=~\"tarantool\"}",
+                     "expr": "tnt_vinyl_regulator_blocked_writers{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4422,7 +4422,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_commit{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_tx_commit{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4512,7 +4512,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_rollback{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_tx_rollback{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4602,7 +4602,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_conflict{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_tx_conflict{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4692,7 +4692,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_tx_read_views{job=~\"tarantool\"}",
+                     "expr": "tnt_vinyl_tx_read_views{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4782,7 +4782,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_scheduler_tasks{job=~\"tarantool\", status=\"inprogress\"}",
+                     "expr": "tnt_vinyl_scheduler_tasks{job=~\"tarantool\", alias=~\".*\", status=\"inprogress\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4872,7 +4872,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_tasks{job=~\"tarantool\",status=\"failed\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_scheduler_tasks{job=~\"tarantool\",alias=~\".*\",status=\"failed\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4962,7 +4962,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_dump_time{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_scheduler_dump_time{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5052,7 +5052,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_dump_total{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_scheduler_dump_total{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5162,7 +5162,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_cpu_user_time{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tnt_cpu_user_time{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5252,7 +5252,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_cpu_system_time{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tnt_cpu_system_time{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5342,7 +5342,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_cpu_thread{job=~\"tarantool\",kind=\"user\"}[$__rate_interval])",
+                     "expr": "rate(tnt_cpu_thread{job=~\"tarantool\",alias=~\".*\",kind=\"user\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{thread_name}}",
@@ -5432,7 +5432,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_cpu_thread{job=~\"tarantool\",kind=\"system\"}[$__rate_interval])",
+                     "expr": "rate(tnt_cpu_thread{job=~\"tarantool\",alias=~\".*\",kind=\"system\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{thread_name}}",
@@ -5542,7 +5542,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_info_memory_lua{job=~\"tarantool\"}",
+                     "expr": "tnt_info_memory_lua{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5632,7 +5632,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_runtime_used{job=~\"tarantool\"}",
+                     "expr": "tnt_runtime_used{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5722,7 +5722,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_info_memory_tx{job=~\"tarantool\"}",
+                     "expr": "tnt_info_memory_tx{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5812,7 +5812,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_csw{job=~\"tarantool\"}",
+                     "expr": "tnt_fiber_csw{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5902,7 +5902,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_ev_loop_time{job=~\"tarantool\"}",
+                     "expr": "tnt_ev_loop_time{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5992,7 +5992,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_amount{job=~\"tarantool\"}",
+                     "expr": "tnt_fiber_amount{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6082,7 +6082,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_memused{job=~\"tarantool\"}",
+                     "expr": "tnt_fiber_memused{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6172,7 +6172,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_memalloc{job=~\"tarantool\"}",
+                     "expr": "tnt_fiber_memalloc{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6282,7 +6282,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_snap_restore{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(lj_jit_snap_restore{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6372,7 +6372,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_trace_num{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(lj_jit_trace_num{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6462,7 +6462,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_trace_abort{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(lj_jit_trace_abort{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6552,7 +6552,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_jit_mcode_size{job=~\"tarantool\"}",
+                     "expr": "lj_jit_mcode_size{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6642,7 +6642,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_strhash_hit{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(lj_strhash_hit{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6732,7 +6732,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_strhash_miss{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(lj_strhash_miss{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6822,7 +6822,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_atomic{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_atomic{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6912,7 +6912,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_sweepstring{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_sweepstring{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7002,7 +7002,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_finalize{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_finalize{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7092,7 +7092,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_sweep{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_sweep{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7182,7 +7182,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_propagate{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_propagate{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7272,7 +7272,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_pause{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_pause{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7362,7 +7362,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_strnum{job=~\"tarantool\"}",
+                     "expr": "lj_gc_strnum{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7452,7 +7452,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_tabnum{job=~\"tarantool\"}",
+                     "expr": "lj_gc_tabnum{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7542,7 +7542,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_cdatanum{job=~\"tarantool\"}",
+                     "expr": "lj_gc_cdatanum{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7632,7 +7632,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_udatanum{job=~\"tarantool\"}",
+                     "expr": "lj_gc_udatanum{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7722,7 +7722,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_memory{job=~\"tarantool\"}",
+                     "expr": "lj_gc_memory{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7812,7 +7812,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_freed{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_freed{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7902,7 +7902,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_allocated{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_allocated{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8012,7 +8012,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"select\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\".*\",operation=\"select\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8102,7 +8102,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"insert\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\".*\",operation=\"insert\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8192,7 +8192,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"replace\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\".*\",operation=\"replace\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8282,7 +8282,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"upsert\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\".*\",operation=\"upsert\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8372,7 +8372,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"update\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\".*\",operation=\"update\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8462,7 +8462,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"delete\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\".*\",operation=\"delete\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8552,7 +8552,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"call\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\".*\",operation=\"call\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8642,7 +8642,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"eval\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\".*\",operation=\"eval\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8732,7 +8732,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\".*\",operation=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8822,7 +8822,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"auth\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\".*\",operation=\"auth\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8912,7 +8912,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"prepare\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\".*\",operation=\"prepare\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9002,7 +9002,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",operation=\"execute\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\".*\",operation=\"execute\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9112,7 +9112,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_replyq{job=~\"tarantool\"}",
+                     "expr": "tdg_kafka_replyq{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -9202,7 +9202,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_msg_size{job=~\"tarantool\"}",
+                     "expr": "tdg_kafka_msg_size{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -9292,7 +9292,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_msg_cnt{job=~\"tarantool\"}",
+                     "expr": "tdg_kafka_msg_cnt{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -9382,7 +9382,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_tx{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_tx{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -9472,7 +9472,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_tx_bytes{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_tx_bytes{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -9562,7 +9562,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_rx{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_rx{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -9652,7 +9652,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_rx_bytes{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_rx_bytes{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -9742,7 +9742,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_txmsgs{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_txmsgs{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -9832,7 +9832,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_txmsg_bytes{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_txmsg_bytes{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -9922,7 +9922,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_rxmsgs{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_rxmsgs{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -10012,7 +10012,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_rxmsg_bytes{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_rxmsg_bytes{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -10122,7 +10122,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_stateage{job=~\"tarantool\"}",
+                     "expr": "tdg_kafka_broker_stateage{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -10212,7 +10212,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_connects{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_broker_connects{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -10302,7 +10302,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_disconnects{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_broker_disconnects{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -10392,7 +10392,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_wakeups{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_broker_wakeups{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -10482,7 +10482,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_outbuf_cnt{job=~\"tarantool\"}",
+                     "expr": "tdg_kafka_broker_outbuf_cnt{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -10572,7 +10572,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_outbuf_msg_cnt{job=~\"tarantool\"}",
+                     "expr": "tdg_kafka_broker_outbuf_msg_cnt{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -10662,7 +10662,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_waitresp_cnt{job=~\"tarantool\"}",
+                     "expr": "tdg_kafka_broker_waitresp_cnt{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -10752,7 +10752,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_waitresp_msg_cnt{job=~\"tarantool\"}",
+                     "expr": "tdg_kafka_broker_waitresp_msg_cnt{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -10842,7 +10842,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_tx{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_broker_tx{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -10932,7 +10932,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_txbytes{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_broker_txbytes{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -11022,7 +11022,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_txerrs{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_broker_txerrs{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -11112,7 +11112,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_txretries{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_broker_txretries{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -11202,7 +11202,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_txidle{job=~\"tarantool\"}",
+                     "expr": "tdg_kafka_broker_txidle{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -11292,7 +11292,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_req_timeouts{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_broker_req_timeouts{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -11382,7 +11382,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_rx{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_broker_rx{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -11472,7 +11472,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_rxbytes{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_broker_rxbytes{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -11562,7 +11562,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_rxerrs{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_broker_rxerrs{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -11652,7 +11652,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_rxcorriderrs{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_broker_rxcorriderrs{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -11742,7 +11742,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_rxidle{job=~\"tarantool\"}",
+                     "expr": "tdg_kafka_broker_rxidle{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -11832,7 +11832,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_rxpartial{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_broker_rxpartial{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -11922,7 +11922,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_broker_req{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_broker_req{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{request}} — {{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -12012,7 +12012,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_int_latency{job=~\"tarantool\",quantile=\"0.99\"}",
+                     "expr": "tdg_kafka_broker_int_latency{job=~\"tarantool\",alias=~\".*\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -12102,7 +12102,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_outbuf_latency{job=~\"tarantool\",quantile=\"0.99\"}",
+                     "expr": "tdg_kafka_broker_outbuf_latency{job=~\"tarantool\",alias=~\".*\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -12192,7 +12192,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_rtt{job=~\"tarantool\",quantile=\"0.99\"}",
+                     "expr": "tdg_kafka_broker_rtt{job=~\"tarantool\",alias=~\".*\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -12282,7 +12282,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_broker_throttle{job=~\"tarantool\",quantile=\"0.99\"}",
+                     "expr": "tdg_kafka_broker_throttle{job=~\"tarantool\",alias=~\".*\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -12392,7 +12392,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_age{job=~\"tarantool\"}",
+                     "expr": "tdg_kafka_topic_age{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -12482,7 +12482,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_metadata_age{job=~\"tarantool\"}",
+                     "expr": "tdg_kafka_topic_metadata_age{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -12572,7 +12572,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_batchsize{job=~\"tarantool\",quantile=\"0.99\"}",
+                     "expr": "tdg_kafka_topic_batchsize{job=~\"tarantool\",alias=~\".*\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -12662,7 +12662,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_batchcnt{job=~\"tarantool\",quantile=\"0.99\"}",
+                     "expr": "tdg_kafka_topic_batchcnt{job=~\"tarantool\",alias=~\".*\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -12752,7 +12752,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_partitions_msgq_cnt{job=~\"tarantool\"}",
+                     "expr": "tdg_kafka_topic_partitions_msgq_cnt{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -12842,7 +12842,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_partitions_xmit_msgq_cnt{job=~\"tarantool\"}",
+                     "expr": "tdg_kafka_topic_partitions_xmit_msgq_cnt{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -12932,7 +12932,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_partitions_fetchq_cnt{job=~\"tarantool\"}",
+                     "expr": "tdg_kafka_topic_partitions_fetchq_cnt{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -13022,7 +13022,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_partitions_msgq_bytes{job=~\"tarantool\"}",
+                     "expr": "tdg_kafka_topic_partitions_msgq_bytes{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -13112,7 +13112,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_partitions_xmit_msgq_bytes{job=~\"tarantool\"}",
+                     "expr": "tdg_kafka_topic_partitions_xmit_msgq_bytes{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -13202,7 +13202,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_partitions_fetchq_size{job=~\"tarantool\"}",
+                     "expr": "tdg_kafka_topic_partitions_fetchq_size{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -13292,7 +13292,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_topic_partitions_txmsgs{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_topic_partitions_txmsgs{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -13382,7 +13382,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_topic_partitions_txbytes{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_topic_partitions_txbytes{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -13472,7 +13472,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_topic_partitions_rxmsgs{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_topic_partitions_rxmsgs{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -13562,7 +13562,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_topic_partitions_rxbytes{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_topic_partitions_rxbytes{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -13652,7 +13652,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_topic_partitions_rx_ver_drops{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_topic_partitions_rx_ver_drops{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -13742,7 +13742,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_topic_partitions_msgs_inflight{job=~\"tarantool\"}",
+                     "expr": "tdg_kafka_topic_partitions_msgs_inflight{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
@@ -13852,7 +13852,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_cgrp_stateage{job=~\"tarantool\"}",
+                     "expr": "tdg_kafka_cgrp_stateage{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -13942,7 +13942,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_cgrp_rebalance_age{job=~\"tarantool\"}",
+                     "expr": "tdg_kafka_cgrp_rebalance_age{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -14032,7 +14032,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_kafka_cgrp_rebalance_cnt{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_cgrp_rebalance_cnt{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -14122,7 +14122,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_cgrp_assignment_size{job=~\"tarantool\"}",
+                     "expr": "tdg_kafka_cgrp_assignment_size{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -14232,7 +14232,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_eos_idemp_stateage{job=~\"tarantool\"}",
+                     "expr": "tdg_kafka_eos_idemp_stateage{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -14322,7 +14322,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_kafka_eos_txn_stateage{job=~\"tarantool\"}",
+                     "expr": "tdg_kafka_eos_txn_stateage{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
@@ -14432,7 +14432,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_expiration_checked_count{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_expiration_checked_count{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -14522,7 +14522,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_expiration_expired_count{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_expiration_expired_count{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -14612,7 +14612,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_expiration_restarts{job=~\"tarantool\"}",
+                     "expr": "tdg_expiration_restarts{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -14702,7 +14702,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_expiration_working_time{job=~\"tarantool\"}",
+                     "expr": "tdg_expiration_working_time{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -14992,7 +14992,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_scanned_tuples_max{job=~\"tarantool\"}",
+                     "expr": "tdg_scanned_tuples_max{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -15082,7 +15082,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_returned_tuples_max{job=~\"tarantool\"}",
+                     "expr": "tdg_returned_tuples_max{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -15192,7 +15192,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_connector_input_file_processed_count{job=~\"tarantool\"}",
+                     "expr": "tdg_connector_input_file_processed_count{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{connector_name}} — {{alias}}",
@@ -15282,7 +15282,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_connector_input_file_processed_objects_count{job=~\"tarantool\"}",
+                     "expr": "tdg_connector_input_file_processed_objects_count{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{connector_name}} — {{alias}}",
@@ -15372,7 +15372,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_connector_input_file_failed_count{job=~\"tarantool\"}",
+                     "expr": "tdg_connector_input_file_failed_count{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{connector_name}} — {{alias}}",
@@ -15462,7 +15462,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_connector_input_file_size{job=~\"tarantool\"}",
+                     "expr": "tdg_connector_input_file_size{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{connector_name}} — {{alias}}",
@@ -15552,7 +15552,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_connector_input_file_current_bytes_processed{job=~\"tarantool\"}",
+                     "expr": "tdg_connector_input_file_current_bytes_processed{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{connector_name}} — {{alias}}",
@@ -15642,7 +15642,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_connector_input_file_current_processed_objects{job=~\"tarantool\"}",
+                     "expr": "tdg_connector_input_file_current_processed_objects{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{connector_name}} — {{alias}}",
@@ -15752,7 +15752,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_graphql_query_time_count{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_graphql_query_time_count{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{operation_name}} ({{schema}}, {{entity}}) — {{alias}}",
@@ -15842,7 +15842,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_graphql_query_time_sum{job=~\"tarantool\"} /\ntdg_graphql_query_time_count{job=~\"tarantool\"}\n",
+                     "expr": "tdg_graphql_query_time_sum{job=~\"tarantool\",alias=~\".*\"} /\ntdg_graphql_query_time_count{job=~\"tarantool\",alias=~\".*\"}\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{operation_name}} ({{schema}}, {{entity}}) — {{alias}}",
@@ -15932,7 +15932,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_graphql_query_fail{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_graphql_query_fail{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{operation_name}} ({{schema}}, {{entity}}) — {{alias}}",
@@ -16022,7 +16022,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_graphql_mutation_time_count{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_graphql_mutation_time_count{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{operation_name}} ({{schema}}, {{entity}}) — {{alias}}",
@@ -16112,7 +16112,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_graphql_mutation_time_sum{job=~\"tarantool\"} /\ntdg_graphql_mutation_time_count{job=~\"tarantool\"}\n",
+                     "expr": "tdg_graphql_mutation_time_sum{job=~\"tarantool\",alias=~\".*\"} /\ntdg_graphql_mutation_time_count{job=~\"tarantool\",alias=~\".*\"}\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{operation_name}} ({{schema}}, {{entity}}) — {{alias}}",
@@ -16202,7 +16202,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_graphql_mutation_fail{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_graphql_mutation_fail{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{operation_name}} ({{schema}}, {{entity}}) — {{alias}}",
@@ -16312,7 +16312,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",method=\"repository.put\"}[$__rate_interval])",
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",alias=~\".*\",method=\"repository.put\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -16402,7 +16402,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",method=\"repository.put\",quantile=\"0.99\"}",
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",alias=~\".*\",method=\"repository.put\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -16492,7 +16492,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",method=\"repository.put_batch\"}[$__rate_interval])",
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",alias=~\".*\",method=\"repository.put_batch\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -16582,7 +16582,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",method=\"repository.put_batch\",quantile=\"0.99\"}",
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",alias=~\".*\",method=\"repository.put_batch\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -16672,7 +16672,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",method=\"repository.find\"}[$__rate_interval])",
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",alias=~\".*\",method=\"repository.find\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -16762,7 +16762,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",method=\"repository.find\",quantile=\"0.99\"}",
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",alias=~\".*\",method=\"repository.find\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -16852,7 +16852,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",method=\"repository.update\"}[$__rate_interval])",
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",alias=~\".*\",method=\"repository.update\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -16942,7 +16942,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",method=\"repository.update\",quantile=\"0.99\"}",
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",alias=~\".*\",method=\"repository.update\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -17032,7 +17032,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",method=\"repository.get\"}[$__rate_interval])",
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",alias=~\".*\",method=\"repository.get\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -17122,7 +17122,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",method=\"repository.get\",quantile=\"0.99\"}",
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",alias=~\".*\",method=\"repository.get\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -17212,7 +17212,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",method=\"repository.delete\"}[$__rate_interval])",
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",alias=~\".*\",method=\"repository.delete\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -17302,7 +17302,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",method=\"repository.delete\",quantile=\"0.99\"}",
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",alias=~\".*\",method=\"repository.delete\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -17392,7 +17392,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",method=\"repository.count\"}[$__rate_interval])",
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",alias=~\".*\",method=\"repository.count\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -17482,7 +17482,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",method=\"repository.count\",quantile=\"0.99\"}",
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",alias=~\".*\",method=\"repository.count\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -17572,7 +17572,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",method=\"repository.map_reduce\"}[$__rate_interval])",
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",alias=~\".*\",method=\"repository.map_reduce\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -17662,7 +17662,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",method=\"repository.map_reduce\",quantile=\"0.99\"}",
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",alias=~\".*\",method=\"repository.map_reduce\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -17752,7 +17752,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",method=\"repository.call_on_storage\"}[$__rate_interval])",
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",alias=~\".*\",method=\"repository.call_on_storage\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -17842,7 +17842,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",method=\"repository.call_on_storage\",quantile=\"0.99\"}",
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",alias=~\".*\",method=\"repository.call_on_storage\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} — {{alias}}",
@@ -17952,7 +17952,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool\",method=\"GET\",status_code=~\"^2\\\\d{2}$\"}[$__rate_interval])",
+                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool\",alias=~\".*\",method=\"GET\",status_code=~\"^2\\\\d{2}$\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
@@ -18042,7 +18042,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool\",method=\"GET\",status_code=~\"^4\\\\d{2}$\"}[$__rate_interval])",
+                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool\",alias=~\".*\",method=\"GET\",status_code=~\"^4\\\\d{2}$\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
@@ -18132,7 +18132,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool\",method=\"GET\",status_code=~\"^5\\\\d{2}$\"}[$__rate_interval])",
+                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool\",alias=~\".*\",method=\"GET\",status_code=~\"^5\\\\d{2}$\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
@@ -18222,7 +18222,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_rest_exec_time{job=~\"tarantool\",method=\"GET\",status_code=~\"^2\\\\d{2}$\",quantile=\"0.99\"}",
+                     "expr": "tdg_rest_exec_time{job=~\"tarantool\",alias=~\".*\",method=\"GET\",status_code=~\"^2\\\\d{2}$\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
@@ -18312,7 +18312,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_rest_exec_time{job=~\"tarantool\",method=\"GET\",status_code=~\"^4\\\\d{2}$\",quantile=\"0.99\"}",
+                     "expr": "tdg_rest_exec_time{job=~\"tarantool\",alias=~\".*\",method=\"GET\",status_code=~\"^4\\\\d{2}$\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
@@ -18402,7 +18402,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_rest_exec_time{job=~\"tarantool\",method=\"GET\",status_code=~\"^5\\\\d{2}$\",quantile=\"0.99\"}",
+                     "expr": "tdg_rest_exec_time{job=~\"tarantool\",alias=~\".*\",method=\"GET\",status_code=~\"^5\\\\d{2}$\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
@@ -18492,7 +18492,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool\",method!=\"GET\",status_code=~\"^2\\\\d{2}$\"}[$__rate_interval])",
+                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool\",alias=~\".*\",method!=\"GET\",status_code=~\"^2\\\\d{2}$\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
@@ -18582,7 +18582,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool\",method!=\"GET\",status_code=~\"^4\\\\d{2}$\"}[$__rate_interval])",
+                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool\",alias=~\".*\",method!=\"GET\",status_code=~\"^4\\\\d{2}$\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
@@ -18672,7 +18672,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool\",method!=\"GET\",status_code=~\"^5\\\\d{2}$\"}[$__rate_interval])",
+                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool\",alias=~\".*\",method!=\"GET\",status_code=~\"^5\\\\d{2}$\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
@@ -18762,7 +18762,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_rest_exec_time{job=~\"tarantool\",method!=\"GET\",status_code=~\"^2\\\\d{2}$\",quantile=\"0.99\"}",
+                     "expr": "tdg_rest_exec_time{job=~\"tarantool\",alias=~\".*\",method!=\"GET\",status_code=~\"^2\\\\d{2}$\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
@@ -18852,7 +18852,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_rest_exec_time{job=~\"tarantool\",method!=\"GET\",status_code=~\"^4\\\\d{2}$\",quantile=\"0.99\"}",
+                     "expr": "tdg_rest_exec_time{job=~\"tarantool\",alias=~\".*\",method!=\"GET\",status_code=~\"^4\\\\d{2}$\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
@@ -18942,7 +18942,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_rest_exec_time{job=~\"tarantool\",method!=\"GET\",status_code=~\"^5\\\\d{2}$\",quantile=\"0.99\"}",
+                     "expr": "tdg_rest_exec_time{job=~\"tarantool\",alias=~\".*\",method!=\"GET\",status_code=~\"^5\\\\d{2}$\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
@@ -19052,7 +19052,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_jobs_started{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_jobs_started{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -19142,7 +19142,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_jobs_failed{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_jobs_failed{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -19232,7 +19232,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_jobs_succeeded{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_jobs_succeeded{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -19322,7 +19322,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_jobs_running{job=~\"tarantool\"}",
+                     "expr": "tdg_jobs_running{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -19412,7 +19412,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_jobs_execution_time_sum{job=~\"tarantool\"} /\ntdg_jobs_execution_time_count{job=~\"tarantool\"}\n",
+                     "expr": "tdg_jobs_execution_time_sum{job=~\"tarantool\",alias=~\".*\"} /\ntdg_jobs_execution_time_count{job=~\"tarantool\",alias=~\".*\"}\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -19502,7 +19502,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_tasks_started{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_tasks_started{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
@@ -19592,7 +19592,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_tasks_failed{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_tasks_failed{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
@@ -19682,7 +19682,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_tasks_succeeded{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_tasks_succeeded{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
@@ -19772,7 +19772,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_tasks_stopped{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_tasks_stopped{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
@@ -19862,7 +19862,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_tasks_running{job=~\"tarantool\"}",
+                     "expr": "tdg_tasks_running{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
@@ -19952,7 +19952,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_tasks_execution_time_sum{job=~\"tarantool\"} /\ntdg_tasks_execution_time_count{job=~\"tarantool\"}\n",
+                     "expr": "tdg_tasks_execution_time_sum{job=~\"tarantool\",alias=~\".*\"} /\ntdg_tasks_execution_time_count{job=~\"tarantool\",alias=~\".*\"}\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
@@ -20042,7 +20042,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_system_tasks_started{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_system_tasks_started{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
@@ -20132,7 +20132,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_system_tasks_failed{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_system_tasks_failed{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
@@ -20222,7 +20222,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tdg_system_tasks_succeeded{job=~\"tarantool\"}[$__rate_interval])",
+                     "expr": "rate(tdg_system_tasks_succeeded{job=~\"tarantool\",alias=~\".*\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
@@ -20312,7 +20312,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_system_tasks_running{job=~\"tarantool\"}",
+                     "expr": "tdg_system_tasks_running{job=~\"tarantool\",alias=~\".*\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
@@ -20402,7 +20402,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tdg_system_tasks_execution_time_sum{job=~\"tarantool\"} /\ntdg_system_tasks_execution_time_count{job=~\"tarantool\"}\n",
+                     "expr": "tdg_system_tasks_execution_time_sum{job=~\"tarantool\",alias=~\".*\"} /\ntdg_system_tasks_execution_time_count{job=~\"tarantool\",alias=~\".*\"}\n",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} ({{kind}}) — {{alias}}",

--- a/tests/Prometheus/dashboard_tdg_static_with_instance_variable.sh
+++ b/tests/Prometheus/dashboard_tdg_static_with_instance_variable.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+make DATASOURCE=Prometheus \
+     JOB=tarantool \
+     WITH_INSTANCE_VARIABLE=TRUE \
+     build-static-tdg-prometheus

--- a/tests/Prometheus/dashboard_tdg_static_with_instance_variable_compiled.json
+++ b/tests/Prometheus/dashboard_tdg_static_with_instance_variable_compiled.json
@@ -1,21 +1,5 @@
 {
-   "__inputs": [
-      {
-         "description": "Prometheus Tarantool metrics bank",
-         "label": "Prometheus",
-         "name": "DS_PROMETHEUS",
-         "pluginId": "prometheus",
-         "pluginName": "Prometheus",
-         "type": "datasource"
-      },
-      {
-         "description": "Prometheus Tarantool metrics job",
-         "label": "Job",
-         "name": "PROMETHEUS_JOB",
-         "type": "constant",
-         "value": "tarantool"
-      }
-   ],
+   "__inputs": [ ],
    "__requires": [
       {
          "id": "grafana",
@@ -63,7 +47,7 @@
    "annotations": {
       "list": [ ]
    },
-   "description": "Dashboard for Tarantool application and database server monitoring, based on grafonnet library.",
+   "description": "Dashboard for Tarantool Data Grid ver. 2 application monitoring, based on grafonnet library.",
    "editable": true,
    "gnetId": null,
    "graphTooltip": 0,
@@ -84,7 +68,7 @@
          "panels": [
             {
                "columns": [ ],
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "description": "Overview of Tarantool instances observed by Prometheus job.\n\nIf instance row is *red*, it means Prometheus can't reach\nURI specified in targets or ran into error.\nIf instance row is *green*, it means instance is up and running and\nPrometheus is successfully extracting metrics from it.\n\"Uptime\" column shows time since instant start.\n",
                "gridPos": {
                   "h": 8,
@@ -149,7 +133,7 @@
                ],
                "targets": [
                   {
-                     "expr": "up{job=~\"$job\"} * on(instance) group_left(alias) tnt_info_uptime{job=~\"$job\"} or\non(instance) label_replace(up{job=~\"$job\"}, \"alias\", \"Not available\", \"instance\", \".*\")\n",
+                     "expr": "up{job=~\"tarantool\"} * on(instance) group_left(alias) tnt_info_uptime{job=~\"tarantool\"} or\non(instance) label_replace(up{job=~\"tarantool\"}, \"alias\", \"Not available\", \"instance\", \".*\")\n",
                      "format": "table",
                      "instant": true,
                      "intervalFactor": 2,
@@ -164,7 +148,7 @@
                "type": "table"
             },
             {
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "description": "Count of running Tarantool instances observed by Prometheus job.\nIf Prometheus can't reach URI specified in targets\nor ran into error, instance is not counted.\n",
                "gridPos": {
                   "h": 3,
@@ -206,7 +190,7 @@
                "pluginVersion": "6.6.0",
                "targets": [
                   {
-                     "expr": "sum(up{job=~\"$job\"})",
+                     "expr": "sum(up{job=~\"tarantool\"})",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "",
@@ -218,7 +202,7 @@
                "type": "stat"
             },
             {
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "description": "Overall value of memory used by Tarantool\nitems and indexes (*arena_used* value).\nIf Tarantool instance is not available\nfor Prometheus metrics extraction now,\nits contribution is not counted.\n",
                "gridPos": {
                   "h": 3,
@@ -260,7 +244,7 @@
                "pluginVersion": "6.6.0",
                "targets": [
                   {
-                     "expr": "sum(tnt_slab_arena_used{job=~\"$job\"})",
+                     "expr": "sum(tnt_slab_arena_used{job=~\"tarantool\"})",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "",
@@ -272,7 +256,7 @@
                "type": "stat"
             },
             {
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "description": "Overall value of memory available for Tarantool items\nand indexes allocation (*memtx_memory* or *quota_size* values).\nIf Tarantool instance is not available for Prometheus metrics\nextraction now, its contribution is not counted.\n",
                "gridPos": {
                   "h": 3,
@@ -314,7 +298,7 @@
                "pluginVersion": "6.6.0",
                "targets": [
                   {
-                     "expr": "sum(tnt_slab_quota_size{job=~\"$job\"})",
+                     "expr": "sum(tnt_slab_quota_size{job=~\"tarantool\"})",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "",
@@ -326,7 +310,7 @@
                "type": "stat"
             },
             {
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "description": "Overall rate of HTTP requests processed\non Tarantool instances (all methods and response codes).\nIf Tarantool instance is not available for Prometheus metrics\nextraction now, its contribution is not counted.\n",
                "gridPos": {
                   "h": 5,
@@ -368,7 +352,7 @@
                "pluginVersion": "6.6.0",
                "targets": [
                   {
-                     "expr": "sum(rate(http_server_request_latency_count{job=~\"$job\"}[$__rate_interval]))",
+                     "expr": "sum(rate(http_server_request_latency_count{job=~\"tarantool\"}[$__rate_interval]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "",
@@ -380,7 +364,7 @@
                "type": "stat"
             },
             {
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "description": "Overall rate of network requests processed on Tarantool instances.\nIf Tarantool instance is not available for Prometheus metrics\nextraction now, its contribution is not counted.\n",
                "gridPos": {
                   "h": 5,
@@ -422,7 +406,7 @@
                "pluginVersion": "6.6.0",
                "targets": [
                   {
-                     "expr": "sum(rate(tnt_net_requests_total{job=~\"$job\"}[$__rate_interval]))",
+                     "expr": "sum(rate(tnt_net_requests_total{job=~\"tarantool\"}[$__rate_interval]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "",
@@ -434,7 +418,7 @@
                "type": "stat"
             },
             {
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "description": "Overall rate of operations performed on Tarantool spaces\n(*select*, *insert*, *update* etc.).\nIf Tarantool instance is not available for Prometheus metrics\nextraction now, its contribution is not counted.\n",
                "gridPos": {
                   "h": 5,
@@ -476,7 +460,7 @@
                "pluginVersion": "6.6.0",
                "targets": [
                   {
-                     "expr": "sum(rate(tnt_stats_op_total{job=~\"$job\"}[$__rate_interval]))",
+                     "expr": "sum(rate(tnt_stats_op_total{job=~\"tarantool\"}[$__rate_interval]))",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "",
@@ -492,7 +476,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Number of \"warning\" issues on each cluster instance.\n\"warning\" issues includes high replication lag, replication long idle,\nfailover and switchover issues, clock issues, memory fragmentation,\nconfiguration issues and alien members warnings.\n\nPanel works with `cartridge >= 2.0.2`, `metrics >= 0.6.0`,\nwhile `metrics >= 0.9.0` is recommended for per instance display.\n",
                "fill": 0,
@@ -532,7 +516,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_cartridge_issues{job=~\"$job\",alias=~\"$alias\",level=\"warning\"}",
+                     "expr": "tnt_cartridge_issues{job=~\"tarantool\",alias=~\"$alias\",level=\"warning\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -582,7 +566,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Number of \"critical\" issues on each cluster instance.\n\"critical\" issues includes replication process critical fails and\nrunning out of available memory.\n\nPanel works with `cartridge >= 2.0.2`, `metrics >= 0.6.0`,\nwhile `metrics >= 0.9.0` is recommended for per instance display.\n",
                "fill": 0,
@@ -622,7 +606,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_cartridge_issues{job=~\"$job\",alias=~\"$alias\",level=\"critical\"}",
+                     "expr": "tnt_cartridge_issues{job=~\"tarantool\",alias=~\"$alias\",level=\"critical\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -668,7 +652,7 @@
                ]
             },
             {
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "description": "`follows` status means replication is running.\nOtherwise, `not running` is displayed.\n\nPanel works with `metrics >= 0.13.0` and Grafana 8.x.\n",
                "fieldConfig": {
                   "defaults": {
@@ -766,7 +750,7 @@
                },
                "targets": [
                   {
-                     "expr": "tnt_replication_status{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_replication_status{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} {{stream}} ({{id}})",
@@ -777,7 +761,7 @@
                "type": "timeseries"
             },
             {
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "description": "`master` status means instance is available for read and\nwrite operations. `replica` status means instance is\navailable only for read operations.\n\nPanel works with `metrics >= 0.11.0` and Grafana 8.x.\n",
                "fieldConfig": {
                   "defaults": {
@@ -875,7 +859,7 @@
                },
                "targets": [
                   {
-                     "expr": "tnt_read_only{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_read_only{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -890,7 +874,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "description": "Replication lag value for Tarantool instance.\n\nPanel works with `metrics >= 0.13.0`.\n",
                "fill": 0,
                "gridPos": {
@@ -929,7 +913,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_replication_lag{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_replication_lag{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} ({{id}})",
@@ -977,7 +961,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "description": "Clock drift across the cluster.\nmax shows difference with the fastest clock (always positive),\nmin shows difference with the slowest clock (always negative).\n\nPanel works with `metrics >= 0.10.0`.\n",
                "fill": 1,
                "gridPos": {
@@ -1016,7 +1000,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_clock_delta{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_clock_delta{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} ({{delta}})",
@@ -1084,9 +1068,9 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
-               "description": "Requests, processed with success (code 2xx) on Tarantool's side.\nGraph shows mean count per second.\n",
+               "description": "Memory used for network input/output buffers.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
@@ -1124,567 +1108,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(http_server_request_latency_count{job=~\"$job\",alias=~\"$alias\",status=~\"^2\\\\d{2}$\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Success requests (code 2xx)",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "decimals": 0,
-                     "format": "none",
-                     "label": "requests per second",
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "decimals": 3,
-                     "format": "none",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 3,
-               "description": "Requests, processed with 4xx error on Tarantool's side.\nGraph shows mean count per second.\n",
-               "fill": 0,
-               "gridPos": {
-                  "h": 8,
-                  "w": 8,
-                  "x": 8,
-                  "y": 32
-               },
-               "id": 18,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "rate(http_server_request_latency_count{job=~\"$job\",alias=~\"$alias\",status=~\"^4\\\\d{2}$\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Error requests (code 4xx)",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "decimals": 0,
-                     "format": "none",
-                     "label": "requests per second",
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "decimals": 3,
-                     "format": "none",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 3,
-               "description": "Requests, processed with 5xx error on Tarantool's side.\nGraph shows mean count per second.\n",
-               "fill": 0,
-               "gridPos": {
-                  "h": 8,
-                  "w": 8,
-                  "x": 16,
-                  "y": 32
-               },
-               "id": 19,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "rate(http_server_request_latency_count{job=~\"$job\",alias=~\"$alias\",status=~\"^5\\\\d{2}$\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Error requests (code 5xx)",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "decimals": 0,
-                     "format": "none",
-                     "label": "requests per second",
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "decimals": 3,
-                     "format": "none",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 3,
-               "description": "99th percentile of requests latency.\nIncludes only requests processed with success\n(code 2xx) on Tarantool's side.\n",
-               "fill": 0,
-               "gridPos": {
-                  "h": 8,
-                  "w": 8,
-                  "x": 0,
-                  "y": 40
-               },
-               "id": 20,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "http_server_request_latency{job=~\"$job\",alias=~\"$alias\",quantile=\"0.99\",status=~\"^2\\\\d{2}$\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Success requests latency (code 2xx)",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 3,
-               "description": "99th percentile of requests latency.\nIncludes only requests processed with\n4xx error on Tarantool's side.\n",
-               "fill": 0,
-               "gridPos": {
-                  "h": 8,
-                  "w": 8,
-                  "x": 8,
-                  "y": 40
-               },
-               "id": 21,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "http_server_request_latency{job=~\"$job\",alias=~\"$alias\",quantile=\"0.99\",status=~\"^4\\\\d{2}$\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Error requests latency (code 4xx)",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 3,
-               "description": "99th percentile of requests latency.\nIncludes only requests processed with\n5xx error on Tarantool's side.\n",
-               "fill": 0,
-               "gridPos": {
-                  "h": 8,
-                  "w": 8,
-                  "x": 16,
-                  "y": 40
-               },
-               "id": 22,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "http_server_request_latency{job=~\"$job\",alias=~\"$alias\",quantile=\"0.99\",status=~\"^5\\\\d{2}$\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{method}} {{path}} (code {{status}})",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Error requests latency (code 5xx)",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  },
-                  {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": null,
-                     "show": true
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Tarantool HTTP statistics",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "collapse": true,
-         "collapsed": true,
-         "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 48
-         },
-         "id": 23,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 3,
-               "description": "Memory used for network input/output buffers.\n",
-               "fill": 0,
-               "gridPos": {
-                  "h": 8,
-                  "w": 8,
-                  "x": 0,
-                  "y": 49
-               },
-               "id": 24,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "tnt_info_memory_net{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_info_memory_net{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1734,7 +1158,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Data received by instance from binary protocol connections.\nGraph shows average bytes per second.\n",
                "fill": 0,
@@ -1742,9 +1166,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 49
+                  "y": 32
                },
-               "id": 25,
+               "id": 18,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1774,7 +1198,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_received_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_received_total{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1824,7 +1248,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Data sent by instance with binary protocol connections.\nGraph shows average bytes per second.\n",
                "fill": 0,
@@ -1832,9 +1256,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 49
+                  "y": 32
                },
-               "id": 26,
+               "id": 19,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1864,7 +1288,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_sent_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_sent_total{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -1914,7 +1338,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Number of network requests this instance has handled.\nGraph shows mean rps.\n\nPanel will be removed in favor of \"Processed requests\"\nand \"Requests in queue (overall)\" panels.\n",
                "fill": 0,
@@ -1922,9 +1346,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 57
+                  "y": 40
                },
-               "id": 27,
+               "id": 20,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -1954,7 +1378,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_requests_total{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2004,7 +1428,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Number of pending network requests.\n\nPanel will be removed in favor of \"Requests in progress\"\nand \"Requests in queue (current)\" panels.\n",
                "fill": 0,
@@ -2012,9 +1436,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 57
+                  "y": 40
                },
-               "id": 28,
+               "id": 21,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -2044,7 +1468,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_current{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_net_requests_current{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2094,7 +1518,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average number of requests processed by tx thread per second.\n\nPanel works with `metrics >= 0.13.0` and `Tarantool >= 2.10-beta2`.\n",
                "fill": 0,
@@ -2102,9 +1526,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 65
+                  "y": 48
                },
-               "id": 29,
+               "id": 22,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -2134,7 +1558,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_in_progress_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_requests_in_progress_total{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2184,7 +1608,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Number of requests currently being processed in the tx thread.\n\nPanel works with `metrics >= 0.13.0` and `Tarantool >= 2.10-beta2`.\n",
                "fill": 0,
@@ -2192,9 +1616,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 65
+                  "y": 48
                },
-               "id": 30,
+               "id": 23,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -2224,7 +1648,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_in_progress_current{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_net_requests_in_progress_current{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2274,7 +1698,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average number of requests which was placed in queues\nof streams per second.\n\nPanel works with `metrics >= 0.13.0` and `Tarantool >= 2.10-beta2`.\n",
                "fill": 0,
@@ -2282,9 +1706,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 65
+                  "y": 48
                },
-               "id": 31,
+               "id": 24,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -2314,7 +1738,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_requests_in_stream_queue_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_requests_in_stream_queue_total{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2364,7 +1788,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Number of requests currently waiting in queues of streams.\n\nPanel works with `metrics >= 0.13.0` and `Tarantool >= 2.10-beta2`.\n",
                "fill": 0,
@@ -2372,9 +1796,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 65
+                  "y": 48
                },
-               "id": 32,
+               "id": 25,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -2404,7 +1828,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_requests_in_stream_queue_current{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_net_requests_in_stream_queue_current{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2454,7 +1878,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average number of new binary protocol connections per second.\n",
                "fill": 0,
@@ -2462,9 +1886,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 73
+                  "y": 56
                },
-               "id": 33,
+               "id": 26,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -2494,7 +1918,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_net_connections_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tnt_net_connections_total{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2544,7 +1968,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Number of current active binary protocol connections.\n",
                "fill": 0,
@@ -2552,9 +1976,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 73
+                  "y": 56
                },
-               "id": 34,
+               "id": 27,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -2584,7 +2008,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_net_connections_current{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_net_connections_current{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2645,9 +2069,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 81
+            "y": 64
          },
-         "id": 35,
+         "id": 28,
          "panels": [
             {
                "content": "`quota_used_ratio` > 90%, `arena_used_ratio` > 90%, 50% < `items_used_ratio` < 90% – your memory is highly fragmented. See [docs](https://www.tarantool.io/en/doc/1.10/reference/reference_lua/box_slab/#lua-function.box.slab.info) for more info.\n\n`quota_used_ratio` > 90%, `arena_used_ratio` > 90%, `items_used_ratio` > 90% – you are running out of memory. You should consider increasing Tarantool’s memory limit (*box.cfg.memtx_memory*).\n",
@@ -2656,9 +2080,9 @@
                   "h": 3,
                   "w": 24,
                   "x": 0,
-                  "y": 82
+                  "y": 65
                },
-               "id": 36,
+               "id": 29,
                "mode": "markdown",
                "title": "Slab allocator monitoring information",
                "type": "text"
@@ -2668,7 +2092,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "`quota_used_ratio` = `quota_used` / `quota_size`.\n\n`quota_used` – used by slab allocator (for both tuple and index slabs).\n\n`quota_size` – memory limit for slab allocator (as configured in the *memtx_memory* parameter).\n",
                "fill": 0,
@@ -2676,9 +2100,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 85
+                  "y": 68
                },
-               "id": 37,
+               "id": 30,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2708,7 +2132,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_used_ratio{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_slab_quota_used_ratio{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2758,7 +2182,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "`arena_used_ratio` = `arena_used` / `arena_size`.\n\n`arena_used` – used for both tuples and indexes.\n\n`arena_size` – allocated for both tuples and indexes.\n",
                "fill": 0,
@@ -2766,9 +2190,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 85
+                  "y": 68
                },
-               "id": 38,
+               "id": 31,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2798,7 +2222,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_used_ratio{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_slab_arena_used_ratio{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2848,7 +2272,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "`items_used_ratio` = `items_used` / `items_size`.\n\n`items_used` – used only for tuples.\n\n`items_size` – allocated only for tuples.\n",
                "fill": 0,
@@ -2856,9 +2280,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 85
+                  "y": 68
                },
-               "id": 39,
+               "id": 32,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2888,7 +2312,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_used_ratio{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_slab_items_used_ratio{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -2938,7 +2362,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Memory used by slab allocator (for both tuple and index slabs).\n",
                "fill": 0,
@@ -2946,9 +2370,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 93
+                  "y": 76
                },
-               "id": 40,
+               "id": 33,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -2978,7 +2402,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_used{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_slab_quota_used{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3028,7 +2452,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Memory used for both tuples and indexes.\n",
                "fill": 0,
@@ -3036,9 +2460,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 93
+                  "y": 76
                },
-               "id": 41,
+               "id": 34,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3068,7 +2492,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_used{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_slab_arena_used{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3118,7 +2542,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Memory used for only tuples.\n",
                "fill": 0,
@@ -3126,9 +2550,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 93
+                  "y": 76
                },
-               "id": 42,
+               "id": 35,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3158,7 +2582,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_used{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_slab_items_used{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3208,7 +2632,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Memory limit for slab allocator (as configured in the *memtx_memory* parameter).\n",
                "fill": 0,
@@ -3216,9 +2640,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 101
+                  "y": 84
                },
-               "id": 43,
+               "id": 36,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3248,7 +2672,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_quota_size{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_slab_quota_size{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3298,7 +2722,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Memory allocated for both tuples and indexes by slab allocator.\n",
                "fill": 0,
@@ -3306,9 +2730,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 101
+                  "y": 84
                },
-               "id": 44,
+               "id": 37,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3338,7 +2762,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_arena_size{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_slab_arena_size{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3388,7 +2812,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Memory allocated for only tuples by slab allocator.\n",
                "fill": 0,
@@ -3396,9 +2820,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 101
+                  "y": 84
                },
-               "id": 45,
+               "id": 38,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3428,7 +2852,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_slab_items_size{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_slab_items_size{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -3489,16 +2913,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 109
+            "y": 92
          },
-         "id": 46,
+         "id": 39,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Number of records in the space (memtx engine).\nName of space is specified after dash.\n",
                "fill": 0,
@@ -3506,9 +2930,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 110
+                  "y": 93
                },
-               "id": 47,
+               "id": 40,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3538,7 +2962,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_len{job=~\"$job\", alias=~\"$alias\", engine=\"memtx\"}",
+                     "expr": "tnt_space_len{job=~\"tarantool\", alias=~\"$alias\", engine=\"memtx\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3588,7 +3012,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Number of records in the space (vinyl engine).\nName of space is specified after dash.\nBy default this metrics is disabled,\nto enable it you must set global variable\ninclude_vinyl_count to true. Beware that\ncount() operation scans the space and may\nslow down your app. \n\nPanel works with `metrics >= 0.13.0`.\n",
                "fill": 0,
@@ -3596,9 +3020,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 110
+                  "y": 93
                },
-               "id": 48,
+               "id": 41,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3628,7 +3052,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_tuples{job=~\"$job\", alias=~\"$alias\", engine=\"vinyl\"}",
+                     "expr": "tnt_vinyl_tuples{job=~\"tarantool\", alias=~\"$alias\", engine=\"vinyl\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3678,7 +3102,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Total number of bytes in all tuples of the space (memtx engine).\nName of space is specified after dash.\n",
                "fill": 0,
@@ -3686,9 +3110,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 118
+                  "y": 101
                },
-               "id": 49,
+               "id": 42,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3718,7 +3142,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_bsize{job=~\"$job\", alias=~\"$alias\", engine=\"memtx\"}",
+                     "expr": "tnt_space_bsize{job=~\"tarantool\", alias=~\"$alias\", engine=\"memtx\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3768,7 +3192,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Total number of bytes taken by the index.\nName of space is specified after dash,\nindex name specified in parentheses.\nIncludes both memtx and vinyl spaces.\n",
                "fill": 0,
@@ -3776,9 +3200,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 118
+                  "y": 101
                },
-               "id": 50,
+               "id": 43,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3808,7 +3232,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_index_bsize{job=~\"$job\", alias=~\"$alias\"}",
+                     "expr": "tnt_space_index_bsize{job=~\"tarantool\", alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}} ({{index_name}})",
@@ -3858,7 +3282,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Total size of tuples and all indexes in the space (memtx engine).\nName of space is specified after dash.\n",
                "fill": 0,
@@ -3866,9 +3290,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 118
+                  "y": 101
                },
-               "id": 51,
+               "id": 44,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -3898,7 +3322,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_space_total_bsize{job=~\"$job\", alias=~\"$alias\", engine=\"memtx\"}",
+                     "expr": "tnt_space_total_bsize{job=~\"tarantool\", alias=~\"$alias\", engine=\"memtx\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}} — {{name}}",
@@ -3959,16 +3383,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 126
+            "y": 109
          },
-         "id": 52,
+         "id": 45,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "The amount of data stored in the `.run` files located in the `vinyl_dir` directory.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -3976,9 +3400,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 127
+                  "y": 110
                },
-               "id": 53,
+               "id": 46,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4008,7 +3432,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_disk_data_size{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_vinyl_disk_data_size{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4058,7 +3482,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "The amount of data stored in the `.index` files located in the `vinyl_dir` directory.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4066,9 +3490,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 127
+                  "y": 110
                },
-               "id": 54,
+               "id": 47,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4098,7 +3522,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_disk_index_size{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_vinyl_disk_index_size{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4148,7 +3572,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Amount of memory in bytes currently used to store tuples (data).\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4156,9 +3580,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 135
+                  "y": 118
                },
-               "id": 55,
+               "id": 48,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4188,7 +3612,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_tuple_cache{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_vinyl_memory_tuple_cache{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4238,7 +3662,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Amount of memory in bytes currently used to store indexes.\nIf the metric value is close to box.cfg.vinyl_memory, this\nindicates that vinyl_page_size was chosen incorrectly.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4246,9 +3670,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 135
+                  "y": 118
                },
-               "id": 56,
+               "id": 49,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4278,7 +3702,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_page_index{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_vinyl_memory_page_index{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4328,7 +3752,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Amount of memory in bytes used by bloom filters.\n",
                "fill": 0,
@@ -4336,9 +3760,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 135
+                  "y": 118
                },
-               "id": 57,
+               "id": 50,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4368,7 +3792,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_bloom_filter{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_vinyl_memory_bloom_filter{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4418,7 +3842,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "The estimated average rate of taking dumps, bytes per second.\nInitially, the rate value is 10 megabytes per second\nand being recalculated depending on the the actual rate.\nOnly significant dumps that are larger than one megabyte\nare used for the estimate.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4426,9 +3850,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 143
+                  "y": 126
                },
-               "id": 58,
+               "id": 51,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4458,7 +3882,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_dump_bandwidth{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_vinyl_regulator_dump_bandwidth{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4508,7 +3932,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "The actual average rate of performing the write operations, bytes per second.\nThe rate is calculated as a 5-second moving average.\nIf the metric value is gradually going down, this can indicate some disk issues.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4516,9 +3940,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 143
+                  "y": 126
                },
-               "id": 59,
+               "id": 52,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4548,7 +3972,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_write_rate{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_vinyl_regulator_write_rate{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4598,7 +4022,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "The write rate limit, bytes per second.\nThe regulator imposes the limit on transactions based on the observed dump/compaction performance.\nIf the metric value is down to approximately 100 Kbps,\nthis indicates issues with the disk or the scheduler.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4606,9 +4030,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 143
+                  "y": 126
                },
-               "id": 60,
+               "id": 53,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4638,7 +4062,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_rate_limit{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_vinyl_regulator_rate_limit{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4688,7 +4112,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "«Level 0» (L0) memory area in bytes. L0 is the area that\nvinyl can use for in-memory storage of an LSM tree.\nBy monitoring this metric, you can see when L0 is getting\nclose to its maximum (tnt_vinyl_regulator_dump_watermark),\nat which time a dump will occur. You can expect L0 = 0\nimmediately after the dump operation is completed.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4696,9 +4120,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 151
+                  "y": 134
                },
-               "id": 61,
+               "id": 54,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4728,7 +4152,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_memory_level0{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_vinyl_memory_level0{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4778,7 +4202,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "The maximum amount of memory used for in-memory storing of a vinyl LSM tree.\nWhen accessing this maximum, the dumping must occur.\nFor details, see https://www.tarantool.io/en/doc/latest/book/box/engines/#engines-algorithm-filling-lsm.\nThe value is slightly smaller than the amount of memory allocated for vinyl trees,\nwhich is the `vinyl_memory` parameter.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4786,9 +4210,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 151
+                  "y": 134
                },
-               "id": 62,
+               "id": 55,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4818,7 +4242,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_dump_watermark{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_vinyl_regulator_dump_watermark{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4868,7 +4292,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "The number of fibers that are blocked waiting for Vinyl level0 memory quota.\n\nPanel works with `metrics >= 0.13.0` and `Tarantool >= 2.8.3`.\n",
                "fill": 0,
@@ -4876,9 +4300,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 151
+                  "y": 134
                },
-               "id": 63,
+               "id": 56,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -4908,7 +4332,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_regulator_blocked_writers{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_vinyl_regulator_blocked_writers{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -4958,7 +4382,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average per second rate of commits (successful transaction ends).\nIt includes implicit commits: for example, any insert operation causes a commit\nunless it is within a `box.begin()`–`box.commit()` block.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -4966,9 +4390,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 159
+                  "y": 142
                },
-               "id": 64,
+               "id": 57,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -4998,7 +4422,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_commit{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_tx_commit{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5048,7 +4472,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average per second rate of rollbacks (unsuccessful transaction ends).\nThis is not merely a count of explicit `box.rollback()` requests — it includes requests\nthat ended with errors.\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -5056,9 +4480,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 159
+                  "y": 142
                },
-               "id": 65,
+               "id": 58,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5088,7 +4512,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_rollback{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_tx_rollback{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5138,7 +4562,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average per second rate of conflicts that caused transactions to roll back.\nThe ratio `tx conflicts` / `tx commits` above 5% indicates that vinyl is not healthy.\nAt this moment you’ll probably see a lot of other problems with vinyl.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -5146,9 +4570,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 159
+                  "y": 142
                },
-               "id": 66,
+               "id": 59,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5178,7 +4602,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_tx_conflict{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_tx_conflict{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5228,7 +4652,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Number of current read views, that is, transactions entered a read-only state\nto avoid conflict temporarily.\nIf the value stays non-zero for a long time, it indicates of a memory leak.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -5236,9 +4660,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 159
+                  "y": 142
                },
-               "id": 67,
+               "id": 60,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5268,7 +4692,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_tx_read_views{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_vinyl_tx_read_views{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5318,7 +4742,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "The number of the scheduler dump/compaction tasks in progress now.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -5326,9 +4750,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 167
+                  "y": 150
                },
-               "id": 68,
+               "id": 61,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5358,7 +4782,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_vinyl_scheduler_tasks{job=~\"$job\", alias=~\"$alias\", status=\"inprogress\"}",
+                     "expr": "tnt_vinyl_scheduler_tasks{job=~\"tarantool\", alias=~\"$alias\", status=\"inprogress\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5408,7 +4832,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Scheduler dump/compaction tasks failed.\nAverage per second rate is shown.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -5416,9 +4840,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 167
+                  "y": 150
                },
-               "id": 69,
+               "id": 62,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -5448,7 +4872,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_tasks{job=~\"$job\",alias=~\"$alias\",status=\"failed\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_scheduler_tasks{job=~\"tarantool\",alias=~\"$alias\",status=\"failed\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5498,7 +4922,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Time spent by all worker threads performing dumps.\nAverage per second rate is shown.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -5506,9 +4930,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 167
+                  "y": 150
                },
-               "id": 70,
+               "id": 63,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5538,7 +4962,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_dump_time{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_scheduler_dump_time{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5588,7 +5012,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Scheduler dumps completed average per second rate.\n\nPanel works with `metrics >= 0.13.0`.\n",
                "fill": 0,
@@ -5596,9 +5020,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 167
+                  "y": 150
                },
-               "id": 71,
+               "id": 64,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5628,7 +5052,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_vinyl_scheduler_dump_total{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tnt_vinyl_scheduler_dump_total{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5689,16 +5113,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 175
+            "y": 158
          },
-         "id": 72,
+         "id": 65,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "This is the average share of time\nspent by instance process executing in user mode.\nMetrics obtained using `getrusage()` call.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -5706,9 +5130,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 176
+                  "y": 159
                },
-               "id": 73,
+               "id": 66,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5738,7 +5162,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_cpu_user_time{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tnt_cpu_user_time{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5788,7 +5212,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "This is the average share of time\nspent by instance process executing in kernel mode.\nMetrics obtained using `getrusage()` call.\n\nPanel works with `metrics >= 0.8.0`.\n",
                "fill": 0,
@@ -5796,9 +5220,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 176
+                  "y": 159
                },
-               "id": 74,
+               "id": 67,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5828,7 +5252,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_cpu_system_time{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tnt_cpu_system_time{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5872,43 +5296,23 @@
                      "show": true
                   }
                ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "Tarantool CPU statistics",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "collapse": true,
-         "collapsed": true,
-         "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 184
-         },
-         "id": 75,
-         "panels": [
+            },
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
-               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance. \n",
+               "description": "Amount of time that each process has been scheduled\nin user mode, measured in clock ticks (divide by\nsysconf(_SC_CLK_TCK)).  This includes guest time,\nguest_time (time spent running a virtual CPU, see\nbelow), so that applications that are not aware of\nthe guest time field do not lose that time from\ntheir calculations. Average ticks per second is displayed.\n\nMetrics are obtained by parsing `/proc/self/task/[pid]/stat`.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 8,
+                  "w": 12,
                   "x": 0,
-                  "y": 185
+                  "y": 167
                },
-               "id": 76,
+               "id": 68,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5938,7 +5342,207 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_info_memory_lua{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "rate(tnt_cpu_thread{job=~\"tarantool\",alias=~\"$alias\",kind=\"user\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}} — {{thread_name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Thread user time",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": "ticks per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Amount of time that this process has been scheduled\nin kernel mode, measured in clock ticks (divide by\nsysconf(_SC_CLK_TCK)). Average ticks per second is displayed.\n\nMetrics are obtained by parsing `/proc/self/task/[pid]/stat`.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 167
+               },
+               "id": 69,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tnt_cpu_thread{job=~\"tarantool\",alias=~\"$alias\",kind=\"system\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}} — {{thread_name}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Thread system time",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": "ticks per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "Tarantool CPU statistics",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": true,
+         "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 175
+         },
+         "id": 70,
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance. \n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 176
+               },
+               "id": 71,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_info_memory_lua{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -5988,7 +5592,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Memory used by runtime arena.\nRuntime arena stores network buffers, tuples\ncreated with box.tuple.new and other objects\nallocated by application not covered by basic\nLua mechanisms (spaces data and indexes\nare not included here, see memtx/vinyl arena).\n",
                "fill": 0,
@@ -5996,9 +5600,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 185
+                  "y": 176
                },
-               "id": 77,
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6028,7 +5632,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_runtime_used{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_runtime_used{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6078,7 +5682,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Memory in use by active transactions.\nFor the vinyl storage engine, this is the total size of\nall allocated objects (struct txv, struct vy_tx, struct vy_read_interval)\nand tuples pinned for those objects. \n",
                "fill": 0,
@@ -6086,9 +5690,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 185
+                  "y": 176
                },
-               "id": 78,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6118,7 +5722,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_info_memory_tx{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_info_memory_tx{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6168,7 +5772,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Number of fiber context switches.\nContext switches are counted over all current fibers.\n",
                "fill": 0,
@@ -6176,9 +5780,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 193
+                  "y": 184
                },
-               "id": 79,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6208,7 +5812,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_csw{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_fiber_csw{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6258,7 +5862,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Duration of last event loop iteration (tx thread).\nHigh duration results in longer responses,\npossible bad health signals and may be the\nreason of \"Too long WAL write\" errors.\n\nPanel works with `metrics >= 0.13.0`.\n",
                "fill": 0,
@@ -6266,9 +5870,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 193
+                  "y": 184
                },
-               "id": 80,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6298,7 +5902,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_ev_loop_time{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_ev_loop_time{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6348,7 +5952,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Current number of fibers in tx thread. \n\nPanel works with `metrics >= 0.13.0`.\n",
                "fill": 0,
@@ -6356,9 +5960,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 201
+                  "y": 192
                },
-               "id": 81,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6388,7 +5992,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_amount{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_fiber_amount{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6438,7 +6042,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Amount of memory used by current fibers.\n",
                "fill": 0,
@@ -6446,9 +6050,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 201
+                  "y": 192
                },
-               "id": 82,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6478,7 +6082,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_memused{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_fiber_memused{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6528,7 +6132,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Amount of memory reserved for current fibers.\n",
                "fill": 0,
@@ -6536,9 +6140,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 201
+                  "y": 192
                },
-               "id": 83,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6568,7 +6172,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_fiber_memalloc{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tnt_fiber_memalloc{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6629,16 +6233,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 209
+            "y": 200
          },
-         "id": 84,
+         "id": 79,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average number of snap restores (guard assertions\nleading to stopping trace executions) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -6646,9 +6250,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 210
+                  "y": 201
                },
-               "id": 85,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6678,7 +6282,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_snap_restore{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(lj_jit_snap_restore{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6728,7 +6332,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average number of new JIT traces per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -6736,9 +6340,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 210
+                  "y": 201
                },
-               "id": 86,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6768,7 +6372,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_trace_num{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(lj_jit_trace_num{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6818,7 +6422,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average number of JIT trace aborts per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -6826,9 +6430,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 210
+                  "y": 201
                },
-               "id": 87,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6858,7 +6462,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_jit_trace_abort{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(lj_jit_trace_abort{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6908,7 +6512,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Total size of allocated machine code areas.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -6916,9 +6520,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 210
+                  "y": 201
                },
-               "id": 88,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6948,7 +6552,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_jit_mcode_size{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "lj_jit_mcode_size{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -6998,7 +6602,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average number of strings being extracted from hash instead of allocating per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7006,9 +6610,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 218
+                  "y": 209
                },
-               "id": 89,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7038,7 +6642,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_strhash_hit{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(lj_strhash_hit{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7088,7 +6692,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average number of strings being allocated due to hash miss per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7096,9 +6700,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 218
+                  "y": 209
                },
-               "id": 90,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7128,7 +6732,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_strhash_miss{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(lj_strhash_miss{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7178,7 +6782,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average count of incremental GC steps (atomic state) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7186,9 +6790,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 226
+                  "y": 217
                },
-               "id": 91,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7218,7 +6822,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_atomic{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_atomic{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7268,7 +6872,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average count of incremental GC steps (sweepstring state) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7276,9 +6880,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 226
+                  "y": 217
                },
-               "id": 92,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7308,7 +6912,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_sweepstring{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_sweepstring{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7358,7 +6962,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average count of incremental GC steps (finalize state) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7366,9 +6970,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 226
+                  "y": 217
                },
-               "id": 93,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7398,7 +7002,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_finalize{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_finalize{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7448,7 +7052,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average count of incremental GC steps (sweep state) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7456,9 +7060,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 234
+                  "y": 225
                },
-               "id": 94,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7488,7 +7092,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_sweep{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_sweep{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7538,7 +7142,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average count of incremental GC steps (propagate state) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7546,9 +7150,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 234
+                  "y": 225
                },
-               "id": 95,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7578,7 +7182,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_propagate{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_propagate{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7628,7 +7232,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average count of incremental GC steps (pause state) per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7636,9 +7240,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 234
+                  "y": 225
                },
-               "id": 96,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7668,7 +7272,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_steps_pause{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_steps_pause{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7718,7 +7322,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Number of allocated string objects.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7726,9 +7330,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 242
+                  "y": 233
                },
-               "id": 97,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7758,7 +7362,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_strnum{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "lj_gc_strnum{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7808,7 +7412,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Number of allocated table objects.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7816,9 +7420,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 242
+                  "y": 233
                },
-               "id": 98,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7848,7 +7452,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_tabnum{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "lj_gc_tabnum{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7898,7 +7502,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Number of allocated cdata objects.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7906,9 +7510,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 242
+                  "y": 233
                },
-               "id": 99,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7938,7 +7542,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_cdatanum{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "lj_gc_cdatanum{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -7988,7 +7592,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "Number of allocated userdata objects.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -7996,9 +7600,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 242
+                  "y": 233
                },
-               "id": 100,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8028,7 +7632,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_udatanum{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "lj_gc_udatanum{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8078,7 +7682,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Current allocated Lua memory.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -8086,9 +7690,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 250
+                  "y": 241
                },
-               "id": 101,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8118,7 +7722,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "lj_gc_memory{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "lj_gc_memory{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8168,7 +7772,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average amount of freed Lua memory per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -8176,9 +7780,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 250
+                  "y": 241
                },
-               "id": 102,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8208,7 +7812,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_freed{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_freed{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8258,7 +7862,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Average amount of allocated Lua memory per second.\n\n\nPanel works with `metrics >= 0.6.0` and `Tarantool >= 2.6`.",
                "fill": 0,
@@ -8266,9 +7870,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 250
+                  "y": 241
                },
-               "id": 103,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8298,7 +7902,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(lj_gc_allocated{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(lj_gc_allocated{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8359,16 +7963,16 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 258
+            "y": 249
          },
-         "id": 104,
+         "id": 99,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Total count of SELECT requests to all instance spaces.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8376,9 +7980,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 259
+                  "y": 250
                },
-               "id": 105,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8408,7 +8012,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"select\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\"$alias\",operation=\"select\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8458,7 +8062,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Total count of INSERT requests to all instance spaces.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8466,9 +8070,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 259
+                  "y": 250
                },
-               "id": 106,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8498,7 +8102,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"insert\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\"$alias\",operation=\"insert\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8548,7 +8152,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Total count of REPLACE requests to all instance spaces.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8556,9 +8160,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 259
+                  "y": 250
                },
-               "id": 107,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8588,7 +8192,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"replace\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\"$alias\",operation=\"replace\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8638,7 +8242,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Total count of UPSERT requests to all instance spaces.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8646,9 +8250,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 267
+                  "y": 258
                },
-               "id": 108,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8678,7 +8282,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"upsert\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\"$alias\",operation=\"upsert\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8728,7 +8332,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Total count of UPDATE requests to all instance spaces.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8736,9 +8340,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 267
+                  "y": 258
                },
-               "id": 109,
+               "id": 104,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8768,7 +8372,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"update\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\"$alias\",operation=\"update\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8818,7 +8422,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Total count of DELETE requests to all instance spaces.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8826,9 +8430,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 267
+                  "y": 258
                },
-               "id": 110,
+               "id": 105,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8858,7 +8462,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"delete\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\"$alias\",operation=\"delete\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8908,7 +8512,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Requests to execute stored procedures.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -8916,9 +8520,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 275
+                  "y": 266
                },
-               "id": 111,
+               "id": 106,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8948,7 +8552,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"call\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\"$alias\",operation=\"call\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -8998,7 +8602,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Calls to evaluate Lua code.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -9006,9 +8610,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 275
+                  "y": 266
                },
-               "id": 112,
+               "id": 107,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9038,7 +8642,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"eval\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\"$alias\",operation=\"eval\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9088,7 +8692,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Requests resulted in error.\nGraph shows average errors per second.\n",
                "fill": 0,
@@ -9096,9 +8700,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 275
+                  "y": 266
                },
-               "id": 113,
+               "id": 108,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9128,7 +8732,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\"$alias\",operation=\"error\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9178,7 +8782,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "Authentication requests.\nGraph shows average requests per second.\n",
                "fill": 0,
@@ -9186,9 +8790,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 283
+                  "y": 274
                },
-               "id": 114,
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9218,7 +8822,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"auth\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\"$alias\",operation=\"auth\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9268,7 +8872,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "SQL prepare calls.\nGraph shows average calls per second.\n\nPanel works with Tarantool 2.x.\n",
                "fill": 0,
@@ -9276,9 +8880,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 283
+                  "y": 274
                },
-               "id": 115,
+               "id": 110,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9308,7 +8912,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"prepare\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\"$alias\",operation=\"prepare\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9358,7 +8962,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "SQL execute calls.\nGraph shows average calls per second.\n\nPanel works with Tarantool 2.x.\n",
                "fill": 0,
@@ -9366,9 +8970,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 283
+                  "y": 274
                },
-               "id": 116,
+               "id": 111,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9398,7 +9002,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_stats_op_total{job=~\"$job\",alias=~\"$alias\",operation=\"execute\"}[$__rate_interval])",
+                     "expr": "rate(tnt_stats_op_total{job=~\"tarantool\",alias=~\"$alias\",operation=\"execute\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -9459,24 +9063,474 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 291
+            "y": 282
          },
-         "id": 117,
+         "id": 112,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of success SELECT and PAIRS requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of ops (callbacks, events, etc) waiting in queue\nfor application to serve with rd_kafka_poll().\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 283
+               },
+               "id": 113,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_kafka_replyq{job=~\"tarantool\",alias=~\"$alias\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Operations in queue",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "operations",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Current number of messages in producer queues.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 283
+               },
+               "id": 114,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_kafka_msg_size{job=~\"tarantool\",alias=~\"$alias\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Messages in queue",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "current",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Current number of messages in producer queues.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 283
+               },
+               "id": 115,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_kafka_msg_cnt{job=~\"tarantool\",alias=~\"$alias\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Size of messages in queue",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "current",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of requests sent to Kafka brokers.\nGraph shows mean requests per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 292
+                  "y": 291
+               },
+               "id": 116,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_kafka_tx{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Requests sent",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "requests per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Amount of bytes transmitted to Kafka brokers.\nGraph shows mean bytes per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 6,
+                  "y": 291
+               },
+               "id": 117,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_kafka_tx_bytes{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Bytes sent",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "bytes per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of responses received from Kafka brokers.\nGraph shows mean responses per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 12,
+                  "y": 291
                },
                "id": 118,
                "legend": {
@@ -9508,17 +9562,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"select\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_rx{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "SELECT success requests",
+               "title": "Responses received",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -9534,21 +9588,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 2,
+                     "decimals": 0,
                      "format": "none",
-                     "label": "requests per second",
+                     "label": "responses per second",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
+                     "decimals": 3,
                      "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -9558,15 +9612,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of success SELECT and PAIRS CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Amount of bytes received from Kafka brokers.\nGraph shows mean bytes per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 6,
-                  "y": 292
+                  "x": 18,
+                  "y": 291
                },
                "id": 119,
                "legend": {
@@ -9598,17 +9652,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"select\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "rate(tdg_kafka_rx_bytes{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "SELECT success requests latency",
+               "title": "Bytes received",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -9624,21 +9678,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "bytes per second",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
-                     "format": "s",
+                     "decimals": 3,
+                     "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -9648,15 +9702,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of error SELECT and PAIRS requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of messages transmitted (produced) to Kafka brokers.\nGraph shows mean messages per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 12,
-                  "y": 292
+                  "x": 0,
+                  "y": 299
                },
                "id": 120,
                "legend": {
@@ -9688,17 +9742,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"select\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_txmsgs{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "SELECT error requests",
+               "title": "Messages sent",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -9714,21 +9768,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 2,
+                     "decimals": 0,
                      "format": "none",
-                     "label": "requests per second",
+                     "label": "messages per second",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
+                     "decimals": 3,
                      "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -9738,15 +9792,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of error SELECT and PAIRS CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Amount of message bytes (including framing, such as per-Message\nframing and MessageSet/batch framing) transmitted to Kafka brokers.\nGraph shows mean bytes per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 18,
-                  "y": 292
+                  "x": 6,
+                  "y": 299
                },
                "id": 121,
                "legend": {
@@ -9778,17 +9832,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"select\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "rate(tdg_kafka_txmsg_bytes{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "SELECT error requests latency",
+               "title": "Message bytes sent",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -9804,21 +9858,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "bytes per second",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
-                     "format": "s",
+                     "decimals": 3,
+                     "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -9828,15 +9882,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
-               "description": "Average number of tuples fetched during SELECT/PAIRS request for a space.\nBoth success and error requests are taken into consideration.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "description": "Number of messages consumed, not including ignored\nmessages (due to offset, etc), from Kafka brokers.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 8,
-                  "x": 0,
-                  "y": 300
+                  "w": 6,
+                  "x": 12,
+                  "y": 299
                },
                "id": 122,
                "legend": {
@@ -9868,17 +9922,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_tuples_fetched{job=~\"$job\",alias=~\"$alias\", operation=\"select\"}[$__rate_interval]) /\n(sum without (status) (rate(tnt_crud_stats_count{job=~\"$job\",operation=\"select\"}[$__rate_interval])))\n",
+                     "expr": "rate(tdg_kafka_rxmsgs{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "SELECT tuples fetched",
+               "title": "Messages received",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -9896,10 +9950,10 @@
                   {
                      "decimals": 0,
                      "format": "none",
-                     "label": "tuples per request",
+                     "label": "messages per second",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
@@ -9908,7 +9962,7 @@
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -9918,15 +9972,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
-               "description": "Average number of tuples looked up on storages while collecting responses\nfor SELECT/PAIRS requests (including scrolls for multibatch requests)\nfor a space. Both success and error requests are taken into consideration.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "description": "Amount of message bytes (including framing) received\nfrom Kafka brokers.\nGraph shows mean bytes per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 8,
-                  "x": 8,
-                  "y": 300
+                  "w": 6,
+                  "x": 18,
+                  "y": 299
                },
                "id": 123,
                "legend": {
@@ -9958,17 +10012,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_tuples_lookup{job=~\"$job\",alias=~\"$alias\", operation=\"select\"}[$__rate_interval]) /\n(sum without (status) (rate(tnt_crud_stats_count{job=~\"$job\",operation=\"select\"}[$__rate_interval])))\n",
+                     "expr": "rate(tdg_kafka_rxmsg_bytes{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "SELECT tuples lookup",
+               "title": "Message bytes received",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -9986,10 +10040,10 @@
                   {
                      "decimals": 0,
                      "format": "none",
-                     "label": "tuples per request",
+                     "label": "bytes per second",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
@@ -9998,109 +10052,39 @@
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
-            },
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "TDG Kafka common statistics",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": true,
+         "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 307
+         },
+         "id": 124,
+         "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
-               "description": "Number of SELECT and PAIRS requests that resulted in map reduce.\nGraph shows average requests per second.\nBoth success and error requests are taken into consideration.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
-               "fill": 0,
-               "gridPos": {
-                  "h": 8,
-                  "w": 8,
-                  "x": 16,
-                  "y": 300
-               },
-               "id": 124,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "rate(tnt_crud_map_reduces{job=~\"$job\",alias=~\"$alias\",operation=\"select\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "Map reduce SELECT requests",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "decimals": 0,
-                     "format": "none",
-                     "label": "requests per second",
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "decimals": 3,
-                     "format": "none",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of success insert and insert_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "description": "Time since last broker state change.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
@@ -10111,9 +10095,9 @@
                "id": 125,
                "legend": {
                   "alignAsTable": true,
-                  "avg": true,
+                  "avg": false,
                   "current": true,
-                  "max": true,
+                  "max": false,
                   "min": false,
                   "rightSide": false,
                   "show": true,
@@ -10138,17 +10122,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"insert\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "tdg_kafka_broker_stateage{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "INSERT success requests",
+               "title": "Time since state change",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -10164,21 +10148,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 2,
-                     "format": "none",
-                     "label": "requests per second",
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "decimals": 2,
-                     "format": "none",
+                     "decimals": 0,
+                     "format": "µs",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "µs",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -10188,9 +10172,9 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of success insert and insert_object CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of connection attempts to a broker, including successful and failed,\nand name resolution failures.\nGraph shows mean attempts per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
@@ -10228,17 +10212,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"insert\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "rate(tdg_kafka_broker_connects{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "INSERT success requests latency",
+               "title": "Connection attempts",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -10254,21 +10238,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "attempts per second",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
-                     "format": "s",
+                     "decimals": 3,
+                     "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -10278,9 +10262,9 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of error insert and insert_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of disconnects from a broker (triggered by broker, network, load-balancer, etc.)\nGraph shows mean disconnects per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
@@ -10318,17 +10302,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"insert\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_broker_disconnects{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "INSERT error requests",
+               "title": "Disconnects",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -10344,21 +10328,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 2,
+                     "decimals": 0,
                      "format": "none",
-                     "label": "requests per second",
+                     "label": "disconnects per second",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
+                     "decimals": 3,
                      "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -10368,9 +10352,9 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of error insert and insert_object CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of broker thread poll wakeups.\nGraph shows mean wakeups per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
@@ -10408,17 +10392,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"insert\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "rate(tdg_kafka_broker_wakeups{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "INSERT error requests latency",
+               "title": "Poll wakeups",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -10434,21 +10418,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "wakeups per second",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
-                     "format": "s",
+                     "decimals": 3,
+                     "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -10458,9 +10442,9 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of success insert_many and insert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of requests awaiting transmission to a broker.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
@@ -10498,17 +10482,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"insert_many\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "tdg_kafka_broker_outbuf_cnt{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "INSERT_MANY success requests",
+               "title": "Requests awaiting transmission",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -10524,21 +10508,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 2,
+                     "decimals": 0,
                      "format": "none",
-                     "label": "requests per second",
+                     "label": "requests",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
+                     "decimals": 3,
                      "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -10548,9 +10532,9 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of success insert_many and insert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of messages awaiting transmission to a broker.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
@@ -10588,17 +10572,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"insert_many\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tdg_kafka_broker_outbuf_msg_cnt{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "INSERT_MANY success requests latency",
+               "title": "Messages awaiting transmission",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -10614,21 +10598,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "messages",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
-                     "format": "s",
+                     "decimals": 3,
+                     "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -10638,9 +10622,9 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of error insert_many and insert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of requests in-flight to a broker awaiting response.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
@@ -10678,17 +10662,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"insert_many\",status=\"error\"}[$__rate_interval])",
+                     "expr": "tdg_kafka_broker_waitresp_cnt{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "INSERT_MANY error requests",
+               "title": "Requests waiting response",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -10704,21 +10688,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 2,
+                     "decimals": 0,
                      "format": "none",
-                     "label": "requests per second",
+                     "label": "requests",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
+                     "decimals": 3,
                      "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -10728,9 +10712,9 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of error insert_many and insert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of messages in-flight to a broker awaiting response.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
@@ -10768,17 +10752,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"insert_many\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tdg_kafka_broker_waitresp_msg_cnt{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "INSERT_MANY error requests latency",
+               "title": "Messages awaiting response",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -10794,21 +10778,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "messages",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
-                     "format": "s",
+                     "decimals": 3,
+                     "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -10818,13 +10802,13 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of success replace and replace_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of requests sent to a broker.\nGraph shows mean attempts per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
+                  "w": 8,
                   "x": 0,
                   "y": 324
                },
@@ -10858,17 +10842,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"replace\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_broker_tx{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "REPLACE success requests",
+               "title": "Requests sent",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -10884,21 +10868,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 2,
+                     "decimals": 0,
                      "format": "none",
                      "label": "requests per second",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
+                     "decimals": 3,
                      "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -10908,14 +10892,14 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of success replace and replace_object CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Amount of bytes sent to a broker.\nGraph shows mean bytes per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 6,
+                  "w": 8,
+                  "x": 8,
                   "y": 324
                },
                "id": 134,
@@ -10948,17 +10932,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"replace\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "rate(tdg_kafka_broker_txbytes{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "REPLACE success requests latency",
+               "title": "Bytes sent",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -10974,21 +10958,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "bytes per second",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
-                     "format": "s",
+                     "decimals": 3,
+                     "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -10998,14 +10982,14 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of error replace and replace_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of transmission errors to a broker.\nGraph shows mean errors per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 324
                },
                "id": 135,
@@ -11038,17 +11022,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"replace\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_broker_txerrs{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "REPLACE error requests",
+               "title": "Transmission errors",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -11064,21 +11048,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 2,
+                     "decimals": 0,
                      "format": "none",
-                     "label": "requests per second",
+                     "label": "errors per second",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
+                     "decimals": 3,
                      "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -11088,15 +11072,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of error replace and replace_object CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of request retries to a broker.\nGraph shows mean retries per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 18,
-                  "y": 324
+                  "w": 8,
+                  "x": 0,
+                  "y": 332
                },
                "id": 136,
                "legend": {
@@ -11128,17 +11112,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"replace\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "rate(tdg_kafka_broker_txretries{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "REPLACE error requests latency",
+               "title": "Request retries",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -11154,21 +11138,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "retries per second",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
-                     "format": "s",
+                     "decimals": 3,
+                     "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -11178,22 +11162,22 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of success replace_many and replace_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Time since last socket send to a broker (or -1 if no sends yet for current connection).\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 0,
+                  "w": 8,
+                  "x": 8,
                   "y": 332
                },
                "id": 137,
                "legend": {
                   "alignAsTable": true,
-                  "avg": true,
+                  "avg": false,
                   "current": true,
-                  "max": true,
+                  "max": false,
                   "min": false,
                   "rightSide": false,
                   "show": true,
@@ -11218,17 +11202,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"replace_many\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "tdg_kafka_broker_txidle{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "REPLACE_MANY success requests",
+               "title": "Time since socket send",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -11244,21 +11228,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 2,
-                     "format": "none",
-                     "label": "requests per second",
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "decimals": 2,
-                     "format": "none",
+                     "decimals": 0,
+                     "format": "µs",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "µs",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -11268,14 +11252,14 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of success replace_many and replace_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of requests timed out for a broker.\nGraph shows mean retries per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 6,
+                  "w": 8,
+                  "x": 16,
                   "y": 332
                },
                "id": 138,
@@ -11308,17 +11292,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"replace_many\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "rate(tdg_kafka_broker_req_timeouts{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "REPLACE_MANY success requests latency",
+               "title": "Requests timed out",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -11334,21 +11318,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "requests per second",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
-                     "format": "s",
+                     "decimals": 3,
+                     "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -11358,15 +11342,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of error replace_many and replace_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of responses received from a broker.\nGraph shows mean attempts per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 12,
-                  "y": 332
+                  "w": 8,
+                  "x": 0,
+                  "y": 340
                },
                "id": 139,
                "legend": {
@@ -11398,17 +11382,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"replace_many\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_broker_rx{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "REPLACE_MANY error requests",
+               "title": "Responses received",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -11424,21 +11408,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 2,
+                     "decimals": 0,
                      "format": "none",
-                     "label": "requests per second",
+                     "label": "responses per second",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
+                     "decimals": 3,
                      "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -11448,15 +11432,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of error replace_many and replace_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Amount of bytes received from a broker.\nGraph shows mean bytes per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 18,
-                  "y": 332
+                  "w": 8,
+                  "x": 8,
+                  "y": 340
                },
                "id": 140,
                "legend": {
@@ -11488,17 +11472,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"replace_many\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "rate(tdg_kafka_broker_rxbytes{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "REPLACE_MANY error requests latency",
+               "title": "Bytes received",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -11514,21 +11498,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "bytes per second",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
-                     "format": "s",
+                     "decimals": 3,
+                     "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -11538,14 +11522,14 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of success upsert and upsert_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of errors received from a broker.\nGraph shows mean errors per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 0,
+                  "w": 8,
+                  "x": 16,
                   "y": 340
                },
                "id": 141,
@@ -11578,17 +11562,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"upsert\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_broker_rxerrs{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "UPSERT success requests",
+               "title": "Response errors",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -11604,21 +11588,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 2,
+                     "decimals": 0,
                      "format": "none",
-                     "label": "requests per second",
+                     "label": "errors per second",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
+                     "decimals": 3,
                      "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -11628,15 +11612,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of success upsert and upsert_object CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of mber of unmatched correlation ids in response\n(typically for timed out requests).\nGraph shows mean errors per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 6,
-                  "y": 340
+                  "w": 8,
+                  "x": 0,
+                  "y": 348
                },
                "id": 142,
                "legend": {
@@ -11668,17 +11652,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"upsert\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "rate(tdg_kafka_broker_rxcorriderrs{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "UPSERT success requests latency",
+               "title": "Response corellation errors",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -11694,21 +11678,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "errors per second",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
-                     "format": "s",
+                     "decimals": 3,
+                     "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -11718,22 +11702,22 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of error upsert and upsert_object requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Time since last socket receive (or -1 if no sends yet for current connection).\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 12,
-                  "y": 340
+                  "w": 8,
+                  "x": 8,
+                  "y": 348
                },
                "id": 143,
                "legend": {
                   "alignAsTable": true,
-                  "avg": true,
+                  "avg": false,
                   "current": true,
-                  "max": true,
+                  "max": false,
                   "min": false,
                   "rightSide": false,
                   "show": true,
@@ -11758,17 +11742,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"upsert\",status=\"error\"}[$__rate_interval])",
+                     "expr": "tdg_kafka_broker_rxidle{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "UPSERT error requests",
+               "title": "Time since socket receive",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -11784,21 +11768,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 2,
-                     "format": "none",
-                     "label": "requests per second",
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "decimals": 2,
-                     "format": "none",
+                     "decimals": 0,
+                     "format": "µs",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "µs",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -11808,15 +11792,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of error upsert and upsert_object CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of partial MessageSets received.\nGraph shows mean retries per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 18,
-                  "y": 340
+                  "w": 8,
+                  "x": 16,
+                  "y": 348
                },
                "id": 144,
                "legend": {
@@ -11848,17 +11832,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"upsert\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "rate(tdg_kafka_broker_rxpartial{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "UPSERT error requests latency",
+               "title": "Partial MessageSets received",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -11874,21 +11858,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "requests per second",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
-                     "format": "s",
+                     "decimals": 3,
+                     "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -11898,15 +11882,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of success upsert_many and upsert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of requests sent, separated by type.\nGraph shows mean requests per second.\n",
                "fill": 0,
                "gridPos": {
-                  "h": 8,
-                  "w": 6,
+                  "h": 10,
+                  "w": 24,
                   "x": 0,
-                  "y": 348
+                  "y": 356
                },
                "id": 145,
                "legend": {
@@ -11915,7 +11899,7 @@
                   "current": true,
                   "max": true,
                   "min": false,
-                  "rightSide": false,
+                  "rightSide": true,
                   "show": true,
                   "sideWidth": null,
                   "sort": "current",
@@ -11938,17 +11922,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"upsert_many\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_broker_req{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{request}} — {{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "UPSERT_MANY success requests",
+               "title": "Requests sent by type",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -11964,21 +11948,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 2,
+                     "decimals": 0,
                      "format": "none",
                      "label": "requests per second",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
+                     "decimals": 3,
                      "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -11988,15 +11972,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of success upsert_many and upsert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "99th percentile of internal producer queue latency.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 6,
-                  "y": 348
+                  "x": 0,
+                  "y": 366
                },
                "id": 146,
                "legend": {
@@ -12028,17 +12012,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"upsert_many\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tdg_kafka_broker_int_latency{job=~\"tarantool\",alias=~\"$alias\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "UPSERT_MANY success requests latency",
+               "title": "Producer queue latency",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -12054,21 +12038,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 3,
-                     "format": "s",
+                     "decimals": 0,
+                     "format": "µs",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
-                     "format": "s",
+                     "decimals": 3,
+                     "format": "µs",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -12078,15 +12062,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of error upsert_many and upsert_object_many requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "99th percentile of internal request queue latency.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 12,
-                  "y": 348
+                  "x": 6,
+                  "y": 366
                },
                "id": 147,
                "legend": {
@@ -12118,17 +12102,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"upsert_many\",status=\"error\"}[$__rate_interval])",
+                     "expr": "tdg_kafka_broker_outbuf_latency{job=~\"tarantool\",alias=~\"$alias\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "UPSERT_MANY error requests",
+               "title": "Request queue latency",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -12144,21 +12128,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 2,
-                     "format": "none",
-                     "label": "requests per second",
+                     "decimals": 0,
+                     "format": "µs",
+                     "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
-                     "format": "none",
+                     "decimals": 3,
+                     "format": "µs",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -12168,15 +12152,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of error upsert_many and upsert_object_many CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "99th percentile of round-trip time.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 18,
-                  "y": 348
+                  "x": 12,
+                  "y": 366
                },
                "id": 148,
                "legend": {
@@ -12208,17 +12192,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"upsert_many\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tdg_kafka_broker_rtt{job=~\"tarantool\",alias=~\"$alias\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "UPSERT_MANY error requests latency",
+               "title": "Broker latency",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -12234,21 +12218,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 3,
-                     "format": "s",
+                     "decimals": 0,
+                     "format": "µs",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
-                     "format": "s",
+                     "decimals": 3,
+                     "format": "µs",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -12258,15 +12242,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of success update requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "99th percentile of broker throttling time.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 0,
-                  "y": 356
+                  "x": 18,
+                  "y": 366
                },
                "id": 149,
                "legend": {
@@ -12298,17 +12282,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"update\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "tdg_kafka_broker_throttle{job=~\"tarantool\",alias=~\"$alias\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{broker_name}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "UPDATE success requests",
+               "title": "Broker throttle",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -12324,129 +12308,59 @@
                },
                "yaxes": [
                   {
-                     "decimals": 2,
-                     "format": "none",
-                     "label": "requests per second",
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "decimals": 2,
-                     "format": "none",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of success update CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
-               "fill": 0,
-               "gridPos": {
-                  "h": 8,
-                  "w": 6,
-                  "x": 6,
-                  "y": 356
-               },
-               "id": 150,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"update\",status=\"ok\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "UPDATE success requests latency",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "decimals": 3,
-                     "format": "s",
+                     "decimals": 0,
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
-                     "format": "s",
+                     "decimals": 3,
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
-            },
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "TDG Kafka brokers statistics",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": true,
+         "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 374
+         },
+         "id": 150,
+         "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of error update requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Age of client's topic object.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 12,
-                  "y": 356
+                  "w": 12,
+                  "x": 0,
+                  "y": 375
                },
                "id": 151,
                "legend": {
@@ -12478,17 +12392,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"update\",status=\"error\"}[$__rate_interval])",
+                     "expr": "tdg_kafka_topic_age{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{topic}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "UPDATE error requests",
+               "title": "Topic age",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -12504,21 +12418,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 2,
-                     "format": "none",
-                     "label": "requests per second",
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "decimals": 2,
-                     "format": "none",
+                     "decimals": 0,
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "ms",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -12528,15 +12442,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of error update CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Age of metadata from broker for this topic.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 18,
-                  "y": 356
+                  "w": 12,
+                  "x": 12,
+                  "y": 375
                },
                "id": 152,
                "legend": {
@@ -12568,17 +12482,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"update\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tdg_kafka_topic_metadata_age{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{topic}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "UPDATE error requests latency",
+               "title": "Topic metadata age",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -12594,21 +12508,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "decimals": 2,
-                     "format": "s",
+                     "decimals": 0,
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "ms",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -12618,15 +12532,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of success delete requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "99th percentile of batch size.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
+                  "w": 12,
                   "x": 0,
-                  "y": 364
+                  "y": 383
                },
                "id": 153,
                "legend": {
@@ -12658,17 +12572,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"delete\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "tdg_kafka_topic_batchsize{job=~\"tarantool\",alias=~\"$alias\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{topic}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "DELETE success requests",
+               "title": "Batch size",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -12684,21 +12598,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 2,
-                     "format": "none",
-                     "label": "requests per second",
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
-                     "format": "none",
+                     "decimals": 3,
+                     "format": "bytes",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -12708,15 +12622,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of success delete CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "99th percentile of batch message count.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 6,
-                  "y": 364
+                  "w": 12,
+                  "x": 12,
+                  "y": 383
                },
                "id": 154,
                "legend": {
@@ -12748,17 +12662,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"delete\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tdg_kafka_topic_batchcnt{job=~\"tarantool\",alias=~\"$alias\",quantile=\"0.99\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{topic}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "DELETE success requests latency",
+               "title": "Batch message count",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -12774,21 +12688,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 3,
-                     "format": "s",
+                     "decimals": 0,
+                     "format": "none",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
-                     "format": "s",
+                     "decimals": 3,
+                     "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -12798,15 +12712,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of error delete requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of messages waiting to be produced in first-level\nqueue of a partition.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 12,
-                  "y": 364
+                  "w": 8,
+                  "x": 0,
+                  "y": 391
                },
                "id": 155,
                "legend": {
@@ -12838,17 +12752,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"delete\",status=\"error\"}[$__rate_interval])",
+                     "expr": "tdg_kafka_topic_partitions_msgq_cnt{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "DELETE error requests",
+               "title": "Messages in partition queue",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -12864,21 +12778,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 2,
-                     "format": "none",
-                     "label": "requests per second",
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "decimals": 2,
+                     "decimals": 0,
                      "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -12888,15 +12802,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of error delete CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of messages ready to be produced in transmit\nqueue of a partition.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 18,
-                  "y": 364
+                  "w": 8,
+                  "x": 8,
+                  "y": 391
                },
                "id": 156,
                "legend": {
@@ -12928,17 +12842,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"delete\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tdg_kafka_topic_partitions_xmit_msgq_cnt{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "DELETE error requests latency",
+               "title": "Messages ready in partition queue",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -12954,21 +12868,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "decimals": 2,
-                     "format": "s",
+                     "decimals": 0,
+                     "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -12978,15 +12892,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of success count requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of pre-fetched messages in fetch\nqueue of a partition.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 0,
-                  "y": 372
+                  "w": 8,
+                  "x": 16,
+                  "y": 391
                },
                "id": 157,
                "legend": {
@@ -13018,17 +12932,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"count\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "tdg_kafka_topic_partitions_fetchq_cnt{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "COUNT success requests",
+               "title": "Messages pre-fetched in partition queue",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -13044,21 +12958,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 2,
-                     "format": "none",
-                     "label": "requests per second",
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "decimals": 2,
+                     "decimals": 0,
                      "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -13068,15 +12982,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of success count CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Amount of message bytes waiting to be produced in first-level\nqueue of a partition.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 6,
-                  "y": 372
+                  "w": 8,
+                  "x": 0,
+                  "y": 399
                },
                "id": 158,
                "legend": {
@@ -13108,17 +13022,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"count\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tdg_kafka_topic_partitions_msgq_bytes{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "COUNT success requests latency",
+               "title": "Message size in partition queue",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -13134,21 +13048,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "decimals": 2,
-                     "format": "s",
+                     "decimals": 0,
+                     "format": "bytes",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -13158,15 +13072,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of error count requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Amount of message bytes ready to be produced in transmit\nqueue of a partition.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 12,
-                  "y": 372
+                  "w": 8,
+                  "x": 8,
+                  "y": 399
                },
                "id": 159,
                "legend": {
@@ -13198,17 +13112,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"count\",status=\"error\"}[$__rate_interval])",
+                     "expr": "tdg_kafka_topic_partitions_xmit_msgq_bytes{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "COUNT error requests",
+               "title": "Ready messages size in partition queue",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -13224,21 +13138,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 2,
-                     "format": "none",
-                     "label": "requests per second",
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "decimals": 2,
-                     "format": "none",
+                     "decimals": 0,
+                     "format": "bytes",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -13248,15 +13162,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of error count CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Amount of pre-fetched messages bytes in\nfetch queue of a partition.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 18,
-                  "y": 372
+                  "w": 8,
+                  "x": 16,
+                  "y": 399
                },
                "id": 160,
                "legend": {
@@ -13288,17 +13202,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"count\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tdg_kafka_topic_partitions_fetchq_size{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "COUNT error requests latency",
+               "title": "Pre-fetched messages size in partition queue",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -13314,21 +13228,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "decimals": 2,
-                     "format": "s",
+                     "decimals": 0,
+                     "format": "bytes",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -13338,15 +13252,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of success get requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of messages transmitted (produced) of a partition topic.\nGraph shows mean messages per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 380
+                  "y": 407
                },
                "id": 161,
                "legend": {
@@ -13378,17 +13292,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"get\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_topic_partitions_txmsgs{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "GET success requests",
+               "title": "Partition messages sent",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -13404,21 +13318,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 2,
+                     "decimals": 0,
                      "format": "none",
-                     "label": "requests per second",
+                     "label": "messages per second",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
+                     "decimals": 3,
                      "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -13428,15 +13342,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of success get CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Amout of message bytes transmitted (produced) of a partition topic.\nGraph shows mean bytes per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 380
+                  "y": 407
                },
                "id": 162,
                "legend": {
@@ -13468,17 +13382,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"get\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "rate(tdg_kafka_topic_partitions_txbytes{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "GET success requests latency",
+               "title": "Partition message bytes sent",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -13494,21 +13408,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "bytes per second",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
-                     "format": "s",
+                     "decimals": 3,
+                     "format": "bytes",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -13518,15 +13432,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of error get requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of messages consumed, not including ignored messages,\nof a partition topic.\nGraph shows mean messages per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 380
+                  "y": 407
                },
                "id": 163,
                "legend": {
@@ -13558,17 +13472,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"get\",status=\"error\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_topic_partitions_rxmsgs{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "GET error requests",
+               "title": "Partition messages consumed",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -13584,21 +13498,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 2,
+                     "decimals": 0,
                      "format": "none",
-                     "label": "requests per second",
+                     "label": "messages per second",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
+                     "decimals": 3,
                      "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -13608,15 +13522,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of error get CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Amout of message bytes consumed, not including ignored messages,\nof a partition topic.\nGraph shows mean bytes per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 380
+                  "y": 407
                },
                "id": 164,
                "legend": {
@@ -13648,17 +13562,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"get\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "rate(tdg_kafka_topic_partitions_rxbytes{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "GET error requests latency",
+               "title": "Partition message bytes consumed",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -13674,21 +13588,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": "bytes per second",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
-                     "format": "s",
+                     "decimals": 3,
+                     "format": "bytes",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -13698,15 +13612,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of success MIN and MAX requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of dropped outdated messages of a partition topic.\nGraph shows mean messages per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
+                  "w": 12,
                   "x": 0,
-                  "y": 388
+                  "y": 415
                },
                "id": 165,
                "legend": {
@@ -13738,17 +13652,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"borders\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "rate(tdg_kafka_topic_partitions_rx_ver_drops{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "BORDERS success requests",
+               "title": "Partition messages dropped",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -13764,21 +13678,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 2,
+                     "decimals": 0,
                      "format": "none",
-                     "label": "requests per second",
+                     "label": "messages per second",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
+                     "decimals": 3,
                      "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -13788,15 +13702,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of success MIN and MAX CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Current number of messages in-flight to/from broker\nof a partition topic.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 6,
-                  "y": 388
+                  "w": 12,
+                  "x": 12,
+                  "y": 415
                },
                "id": 166,
                "legend": {
@@ -13828,17 +13742,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"borders\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tdg_kafka_topic_partitions_msgs_inflight{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} ({{topic}}, {{partition}}) — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "BORDERS success requests latency",
+               "title": "Partition messages in flight",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -13853,137 +13767,67 @@
                   "values": [ ]
                },
                "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "messages per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
                   {
                      "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "decimals": 2,
-                     "format": "s",
+                     "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
-            },
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "TDG Kafka topics statistics",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": true,
+         "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 423
+         },
+         "id": 167,
+         "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of error MIN and MAX requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Time elapsed since last state change.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 12,
-                  "y": 388
-               },
-               "id": 167,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"borders\",status=\"error\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "BORDERS error requests",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "decimals": 2,
-                     "format": "none",
-                     "label": "requests per second",
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "decimals": 2,
-                     "format": "none",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of error MIN and MAX CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
-               "fill": 0,
-               "gridPos": {
-                  "h": 8,
-                  "w": 6,
-                  "x": 18,
-                  "y": 388
+                  "w": 12,
+                  "x": 0,
+                  "y": 424
                },
                "id": 168,
                "legend": {
                   "alignAsTable": true,
-                  "avg": true,
+                  "avg": false,
                   "current": true,
-                  "max": true,
+                  "max": false,
                   "min": false,
                   "rightSide": false,
                   "show": true,
@@ -14008,17 +13852,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"borders\",status=\"error\",quantile=\"0.99\"}",
+                     "expr": "tdg_kafka_cgrp_stateage{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "BORDERS error requests latency",
+               "title": "Time since state change",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -14034,21 +13878,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "decimals": 2,
-                     "format": "s",
+                     "decimals": 0,
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "ms",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -14058,15 +13902,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of success len requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Time elapsed since last rebalance (assign or revoke).\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 0,
-                  "y": 396
+                  "w": 12,
+                  "x": 12,
+                  "y": 424
                },
                "id": 169,
                "legend": {
@@ -14098,17 +13942,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"len\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "tdg_kafka_cgrp_rebalance_age{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "LEN success requests",
+               "title": "Time since rebalance",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -14124,21 +13968,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 2,
-                     "format": "none",
-                     "label": "requests per second",
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "decimals": 2,
-                     "format": "none",
+                     "decimals": 0,
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "ms",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -14148,15 +13992,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of success len CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of rebalances (assign or revoke).\nGraph shows mean requests per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 6,
-                  "y": 396
+                  "w": 12,
+                  "x": 0,
+                  "y": 432
                },
                "id": 170,
                "legend": {
@@ -14188,17 +14032,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"len\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "rate(tdg_kafka_cgrp_rebalance_cnt{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "LEN success requests latency",
+               "title": "Rebalance activity",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -14214,21 +14058,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "rebalances per second",
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 2,
-                     "format": "s",
+                     "decimals": 3,
+                     "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -14238,15 +14082,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of error len requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Current assignment's partition count.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
+                  "w": 12,
                   "x": 12,
-                  "y": 396
+                  "y": 432
                },
                "id": 171,
                "legend": {
@@ -14278,17 +14122,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"len\",status=\"error\"}[$__rate_interval])",
+                     "expr": "tdg_kafka_cgrp_assignment_size{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "LEN error requests",
+               "title": "Assignment partition count",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -14304,136 +14148,66 @@
                },
                "yaxes": [
                   {
-                     "decimals": 2,
-                     "format": "none",
-                     "label": "requests per second",
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "decimals": 2,
+                     "decimals": 0,
                      "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of error len CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
-               "fill": 0,
-               "gridPos": {
-                  "h": 8,
-                  "w": 6,
-                  "x": 18,
-                  "y": 396
-               },
-               "id": 172,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"len\",status=\"error\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "LEN error requests latency",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
+                  },
                   {
                      "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "decimals": 2,
-                     "format": "s",
+                     "format": "none",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
-            },
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "TDG Kafka consumer statistics",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": true,
+         "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 440
+         },
+         "id": 172,
+         "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of success truncate requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Time elapsed since last idemp_state change.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
+                  "w": 12,
                   "x": 0,
-                  "y": 404
+                  "y": 441
                },
                "id": 173,
                "legend": {
                   "alignAsTable": true,
-                  "avg": true,
+                  "avg": false,
                   "current": true,
-                  "max": true,
+                  "max": false,
                   "min": false,
                   "rightSide": false,
                   "show": true,
@@ -14458,17 +14232,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"truncate\",status=\"ok\"}[$__rate_interval])",
+                     "expr": "tdg_kafka_eos_idemp_stateage{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "TRUNCATE success requests",
+               "title": "Time since idemp_state change",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -14484,21 +14258,21 @@
                },
                "yaxes": [
                   {
-                     "decimals": 2,
-                     "format": "none",
-                     "label": "requests per second",
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "decimals": 2,
-                     "format": "none",
+                     "decimals": 0,
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "ms",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
                      "show": true
                   }
                ]
@@ -14508,22 +14282,22 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of success truncate CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Time elapsed since last txn_state change.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 6,
-                  "y": 404
+                  "w": 12,
+                  "x": 12,
+                  "y": 441
                },
                "id": 174,
                "legend": {
                   "alignAsTable": true,
-                  "avg": true,
+                  "avg": false,
                   "current": true,
-                  "max": true,
+                  "max": false,
                   "min": false,
                   "rightSide": false,
                   "show": true,
@@ -14548,17 +14322,17 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"truncate\",status=\"ok\",quantile=\"0.99\"}",
+                     "expr": "tdg_kafka_eos_txn_stateage{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
+                     "legendFormat": "{{name}} — {{alias}} ({{type}}, {{connector_name}})",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "TRUNCATE success requests latency",
+               "title": "Time since txn_state change",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -14573,130 +14347,60 @@
                   "values": [ ]
                },
                "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "ms",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
                   {
                      "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "decimals": 2,
-                     "format": "s",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
-                     "min": 0,
+                     "min": null,
                      "show": true
                   }
                ]
-            },
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "TDG Kafka producer statistics",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": true,
+         "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 449
+         },
+         "id": 175,
+         "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "Total count of error truncate requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "A number of task tuples checked for expiration (expired + skipped).\nGraph shows mean tuples per second.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 12,
-                  "y": 404
-               },
-               "id": 175,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "rate(tnt_crud_stats_count{job=~\"$job\",alias=~\"$alias\",operation=\"truncate\",status=\"error\"}[$__rate_interval])",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "TRUNCATE error requests",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "decimals": 2,
-                     "format": "none",
-                     "label": "requests per second",
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "decimals": 2,
-                     "format": "none",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
-            },
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 2,
-               "description": "99th percentile of error truncate CRUD module requests latency with aging.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable quantiles with `crud.cfg{stats = true, stats_driver = 'metrics', stats_quantiles = true}`.\nIf `No data` displayed yet data expected, try to calibrate tolerated error with\n`crud.cfg{stats_quantile_tolerated_error=1e-4}`.\n",
-               "fill": 0,
-               "gridPos": {
-                  "h": 8,
-                  "w": 6,
-                  "x": 18,
-                  "y": 404
+                  "w": 12,
+                  "x": 0,
+                  "y": 450
                },
                "id": 176,
                "legend": {
@@ -14728,117 +14432,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_crud_stats{job=~\"$job\",alias=~\"$alias\",operation=\"truncate\",status=\"error\",quantile=\"0.99\"}",
-                     "format": "time_series",
-                     "intervalFactor": 2,
-                     "legendFormat": "{{alias}} — {{name}}",
-                     "refId": "A"
-                  }
-               ],
-               "thresholds": [ ],
-               "timeFrom": null,
-               "timeShift": null,
-               "title": "TRUNCATE error requests latency",
-               "tooltip": {
-                  "shared": true,
-                  "sort": 2,
-                  "value_type": "individual"
-               },
-               "type": "graph",
-               "xaxis": {
-                  "buckets": null,
-                  "mode": "time",
-                  "name": null,
-                  "show": true,
-                  "values": [ ]
-               },
-               "yaxes": [
-                  {
-                     "decimals": 3,
-                     "format": "s",
-                     "label": "99th percentile",
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  },
-                  {
-                     "decimals": 2,
-                     "format": "s",
-                     "label": null,
-                     "logBase": 1,
-                     "max": null,
-                     "min": 0,
-                     "show": true
-                  }
-               ]
-            }
-         ],
-         "repeat": null,
-         "repeatIteration": null,
-         "repeatRowId": null,
-         "showTitle": true,
-         "title": "CRUD module statistics",
-         "titleSize": "h6",
-         "type": "row"
-      },
-      {
-         "collapse": true,
-         "collapsed": true,
-         "gridPos": {
-            "h": 1,
-            "w": 24,
-            "x": 0,
-            "y": 412
-         },
-         "id": 177,
-         "panels": [
-            {
-               "aliasColors": { },
-               "bars": false,
-               "dashLength": 10,
-               "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 3,
-               "description": "A number of task tuples checked for expiration (expired + skipped).\nGraph shows mean tuples per second.\n",
-               "fill": 0,
-               "gridPos": {
-                  "h": 8,
-                  "w": 12,
-                  "x": 0,
-                  "y": 413
-               },
-               "id": 178,
-               "legend": {
-                  "alignAsTable": true,
-                  "avg": true,
-                  "current": true,
-                  "max": true,
-                  "min": false,
-                  "rightSide": false,
-                  "show": true,
-                  "sideWidth": null,
-                  "sort": "current",
-                  "sortDesc": true,
-                  "total": false,
-                  "values": true
-               },
-               "lines": true,
-               "linewidth": 1,
-               "links": [ ],
-               "nullPointMode": "null",
-               "percentage": false,
-               "pointradius": 5,
-               "points": false,
-               "renderer": "flot",
-               "repeat": null,
-               "seriesOverrides": [ ],
-               "spaceLength": 10,
-               "stack": false,
-               "steppedLine": false,
-               "targets": [
-                  {
-                     "expr": "rate(expirationd_checked_count{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tdg_expiration_checked_count{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -14888,7 +14482,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "A number of task expired tuples.\nGraph shows mean tuples per second.\n",
                "fill": 0,
@@ -14896,9 +14490,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 413
+                  "y": 450
                },
-               "id": 179,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14928,7 +14522,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(expirationd_expired_count{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "rate(tdg_expiration_expired_count{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -14978,7 +14572,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 0,
                "description": "A number of task restarts since start.\nFrom the start is equal to 1.\n",
                "fill": 0,
@@ -14986,9 +14580,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 421
+                  "y": 458
                },
-               "id": 180,
+               "id": 178,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15018,7 +14612,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "expirationd_restarts{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tdg_expiration_restarts{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -15068,7 +14662,7 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
                "description": "A task's operation time.\n",
                "fill": 0,
@@ -15076,9 +14670,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 421
+                  "y": 458
                },
-               "id": 181,
+               "id": 179,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15108,7 +14702,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "expirationd_working_time{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tdg_expiration_working_time{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{name}} — {{alias}}",
@@ -15158,7 +14752,7 @@
          "repeatIteration": null,
          "repeatRowId": null,
          "showTitle": true,
-         "title": "expirationd module statistics",
+         "title": "TDG expirationd statistics",
          "titleSize": "h6",
          "type": "row"
       },
@@ -15169,24 +14763,204 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 429
+            "y": 466
          },
-         "id": 182,
+         "id": 180,
          "panels": [
             {
                "aliasColors": { },
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
+               "datasource": "Prometheus",
                "decimals": 3,
-               "description": "My custom component could have 3 statuses:\ncode 2 is OK, code 1 is suspended process, code 0 means issues in component.\n",
+               "description": "Amount of tuples scanned in request.\nData resets between each collect.\nGraph shows average per request.\n",
                "fill": 0,
                "gridPos": {
-                  "h": 6,
-                  "w": 24,
+                  "h": 8,
+                  "w": 12,
                   "x": 0,
-                  "y": 430
+                  "y": 467
+               },
+               "id": 181,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_scanned_tuples_sum{job=~\"tarantool\"} /\ntdg_scanned_tuples_count{job=~\"tarantool\"}\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type_name}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Tuples scanned (average)",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "tuples per request",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Amount of tuples returned in request.\nData resets between each collect.\nGraph shows average per request.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 467
+               },
+               "id": 182,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_returned_tuples_sum{job=~\"tarantool\"} /\ntdg_returned_tuples_count{job=~\"tarantool\"}\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type_name}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Tuples returned (average)",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "tuples per request",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 0,
+               "description": "Amount of tuples scanned in request.\nData resets between each collect.\nGraph shows maximum observation.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 475
                },
                "id": 183,
                "legend": {
@@ -15218,7 +14992,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "my_component_status{job=~\"$job\",alias=~\"$alias\"}",
+                     "expr": "tdg_scanned_tuples_max{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -15228,7 +15002,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "My custom component status",
+               "title": "Tuples scanned (max)",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -15246,14 +15020,14 @@
                   {
                      "decimals": 0,
                      "format": "none",
-                     "label": "requests per second",
+                     "label": "tuples per request",
                      "logBase": 1,
                      "max": null,
                      "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 3,
+                     "decimals": 0,
                      "format": "none",
                      "label": null,
                      "logBase": 1,
@@ -15268,15 +15042,15 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 3,
-               "description": "My custom component processes requests\nand collects info on process to summary collector\n'my_component_load_metric'.\n",
+               "datasource": "Prometheus",
+               "decimals": 0,
+               "description": "Amount of tuples returned in request.\nData resets between each collect.\nGraph shows maximum observation.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 12,
-                  "x": 0,
-                  "y": 436
+                  "x": 12,
+                  "y": 475
                },
                "id": 184,
                "legend": {
@@ -15308,7 +15082,7 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "rate(my_component_load_metric_count{job=~\"$job\",alias=~\"$alias\"}[$__rate_interval])",
+                     "expr": "tdg_returned_tuples_max{job=~\"tarantool\",alias=~\"$alias\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
@@ -15318,7 +15092,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "My custom component load",
+               "title": "Tuples returned (max)",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -15336,14 +15110,124 @@
                   {
                      "decimals": 0,
                      "format": "none",
-                     "label": "requests per second",
+                     "label": "tuples per request",
                      "logBase": 1,
                      "max": null,
                      "min": null,
                      "show": true
                   },
                   {
-                     "decimals": 3,
+                     "decimals": 0,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "TDG tuples statistics",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": true,
+         "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 483
+         },
+         "id": 185,
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 0,
+               "description": "A number of files processed.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 484
+               },
+               "id": 186,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_connector_input_file_processed_count{job=~\"tarantool\",alias=~\"$alias\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{connector_name}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total files processed",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "files",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 0,
                      "format": "none",
                      "label": null,
                      "logBase": 1,
@@ -15358,17 +15242,487 @@
                "bars": false,
                "dashLength": 10,
                "dashes": false,
-               "datasource": "${DS_PROMETHEUS}",
-               "decimals": 3,
-               "description": "My custom component processes requests\nand collects info on process to summary collector\n'my_component_load_metric'.\n",
+               "datasource": "Prometheus",
+               "decimals": 0,
+               "description": "A number of objects processed over all files.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
-                  "y": 436
+                  "w": 8,
+                  "x": 8,
+                  "y": 484
                },
-               "id": 185,
+               "id": 187,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_connector_input_file_processed_objects_count{job=~\"tarantool\",alias=~\"$alias\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{connector_name}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total objects processed",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "objects per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 0,
+               "description": "A number of files failed to process.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 484
+               },
+               "id": 188,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_connector_input_file_failed_count{job=~\"tarantool\",alias=~\"$alias\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{connector_name}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Files failed to processed",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "files",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Current file size.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 492
+               },
+               "id": 189,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_connector_input_file_size{job=~\"tarantool\",alias=~\"$alias\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{connector_name}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Current file size",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Processed bytes count from the current file.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 492
+               },
+               "id": 190,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_connector_input_file_current_bytes_processed{job=~\"tarantool\",alias=~\"$alias\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{connector_name}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Current file bytes processed",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 0,
+               "description": "Processed objects count from the current file.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 492
+               },
+               "id": 191,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_connector_input_file_current_processed_objects{job=~\"tarantool\",alias=~\"$alias\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{connector_name}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Current file objects processed",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "objects",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "TDG file connector statistics",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": true,
+         "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 500
+         },
+         "id": 192,
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "A number of successfully executed GraphQL queries.\nGraph shows mean requests per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 501
+               },
+               "id": 193,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15398,17 +15752,3677 @@
                "steppedLine": false,
                "targets": [
                   {
-                     "expr": "my_component_load_metric{job=~\"$job\",alias=~\"$alias\",quantile=\"0.99\"}",
+                     "expr": "rate(tdg_graphql_query_time_count{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
                      "format": "time_series",
                      "intervalFactor": 2,
-                     "legendFormat": "{{alias}}",
+                     "legendFormat": "{{operation_name}} ({{schema}}, {{entity}}) — {{alias}}",
                      "refId": "A"
                   }
                ],
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "My custom component process",
+               "title": "Success queries",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "request per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Average time of GraphQL query execution.\nOnly success requests are count.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 501
+               },
+               "id": 194,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_graphql_query_time_sum{job=~\"tarantool\",alias=~\"$alias\"} /\ntdg_graphql_query_time_count{job=~\"tarantool\",alias=~\"$alias\"}\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{operation_name}} ({{schema}}, {{entity}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Success query latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "µs",
+                     "label": "average",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "µs",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "A number of GraphQL queries failed to execute.\nGraph shows mean requests per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 501
+               },
+               "id": 195,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_graphql_query_fail{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{operation_name}} ({{schema}}, {{entity}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Error queries",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "request per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "A number of successfully executed GraphQL mutations.\nGraph shows mean requests per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 509
+               },
+               "id": 196,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_graphql_mutation_time_count{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{operation_name}} ({{schema}}, {{entity}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Success mutations",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "request per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Average time of GraphQL mutation execution.\nOnly success requests are count.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 509
+               },
+               "id": 197,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_graphql_mutation_time_sum{job=~\"tarantool\",alias=~\"$alias\"} /\ntdg_graphql_mutation_time_count{job=~\"tarantool\",alias=~\"$alias\"}\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{operation_name}} ({{schema}}, {{entity}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Success mutation latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "µs",
+                     "label": "average",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "µs",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "A number of GraphQL mutations failed to execute.\nGraph shows mean requests per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 509
+               },
+               "id": 198,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_graphql_mutation_fail{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{operation_name}} ({{schema}}, {{entity}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Error mutations",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "request per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "TDG GraphQL requests",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": true,
+         "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 517
+         },
+         "id": 199,
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of repository.put method calls through IProto.\nGraph shows mean requests per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 0,
+                  "y": 518
+               },
+               "id": 200,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",alias=~\"$alias\",method=\"repository.put\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "put requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "request per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "99th percentile of repository.put IProto call execution time.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 6,
+                  "y": 518
+               },
+               "id": 201,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",alias=~\"$alias\",method=\"repository.put\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "put request latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "µs",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "µs",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of repository.put_batch method calls through IProto.\nGraph shows mean requests per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 12,
+                  "y": 518
+               },
+               "id": 202,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",alias=~\"$alias\",method=\"repository.put_batch\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "put_batch requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "request per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "99th percentile of repository.put_batch IProto call execution time.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 18,
+                  "y": 518
+               },
+               "id": 203,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",alias=~\"$alias\",method=\"repository.put_batch\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "put_batch request latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "µs",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "µs",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of repository.find method calls through IProto.\nGraph shows mean requests per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 526
+               },
+               "id": 204,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",alias=~\"$alias\",method=\"repository.find\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "find requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "request per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "99th percentile of repository.find IProto call execution time.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 526
+               },
+               "id": 205,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",alias=~\"$alias\",method=\"repository.find\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "find request latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "µs",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "µs",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of repository.update method calls through IProto.\nGraph shows mean requests per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 0,
+                  "y": 534
+               },
+               "id": 206,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",alias=~\"$alias\",method=\"repository.update\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "update requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "request per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "99th percentile of repository.update IProto call execution time.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 6,
+                  "y": 534
+               },
+               "id": 207,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",alias=~\"$alias\",method=\"repository.update\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "update request latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "µs",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "µs",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of repository.get method calls through IProto.\nGraph shows mean requests per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 12,
+                  "y": 534
+               },
+               "id": 208,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",alias=~\"$alias\",method=\"repository.get\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "get requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "request per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "99th percentile of repository.get IProto call execution time.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 18,
+                  "y": 534
+               },
+               "id": 209,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",alias=~\"$alias\",method=\"repository.get\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "get request latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "µs",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "µs",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of repository.delete method calls through IProto.\nGraph shows mean requests per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 0,
+                  "y": 542
+               },
+               "id": 210,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",alias=~\"$alias\",method=\"repository.delete\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "delete requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "request per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "99th percentile of repository.delete IProto call execution time.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 6,
+                  "y": 542
+               },
+               "id": 211,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",alias=~\"$alias\",method=\"repository.delete\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "delete request latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "µs",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "µs",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of repository.count method calls through IProto.\nGraph shows mean requests per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 12,
+                  "y": 542
+               },
+               "id": 212,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",alias=~\"$alias\",method=\"repository.count\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "count requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "request per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "99th percentile of repository.count IProto call execution time.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 18,
+                  "y": 542
+               },
+               "id": 213,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",alias=~\"$alias\",method=\"repository.count\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "count request latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "µs",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "µs",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of repository.map_reduce method calls through IProto.\nGraph shows mean requests per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 0,
+                  "y": 550
+               },
+               "id": 214,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",alias=~\"$alias\",method=\"repository.map_reduce\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "map_reduce requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "request per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "99th percentile of repository.map_reduce IProto call execution time.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 6,
+                  "y": 550
+               },
+               "id": 215,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",alias=~\"$alias\",method=\"repository.map_reduce\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "map_reduce request latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "µs",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "µs",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of repository.call_on_storage method calls through IProto.\nGraph shows mean requests per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 12,
+                  "y": 550
+               },
+               "id": 216,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_iproto_data_query_exec_time_count{job=~\"tarantool\",alias=~\"$alias\",method=\"repository.call_on_storage\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "call_on_storage requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "request per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "99th percentile of repository.call_on_storage IProto call execution time.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 18,
+                  "y": 550
+               },
+               "id": 217,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_iproto_data_query_exec_time{job=~\"tarantool\",alias=~\"$alias\",method=\"repository.call_on_storage\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "call_on_storage request latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "µs",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "µs",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "TDG IProto requests",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": true,
+         "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 558
+         },
+         "id": 218,
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of TDG REST API GET requests processed with code 2xx.\nGraph shows mean requests per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 559
+               },
+               "id": 219,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool\",alias=~\"$alias\",method=\"GET\",status_code=~\"^2\\\\d{2}$\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Success read requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "request per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of TDG REST API GET requests processed with code 4xx.\nGraph shows mean requests per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 559
+               },
+               "id": 220,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool\",alias=~\"$alias\",method=\"GET\",status_code=~\"^4\\\\d{2}$\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Error read requests (code 4xx)",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "request per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of TDG REST API GET requests processed with code 5xx.\nGraph shows mean requests per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 559
+               },
+               "id": 221,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool\",alias=~\"$alias\",method=\"GET\",status_code=~\"^5\\\\d{2}$\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Error read requests (code 5xx)",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "request per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "99th percentile of TDG REST API request execution time.\nOnly GET requests processed with code 2xx are displayed.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 567
+               },
+               "id": 222,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_rest_exec_time{job=~\"tarantool\",alias=~\"$alias\",method=\"GET\",status_code=~\"^2\\\\d{2}$\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Success read request latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "µs",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "µs",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "99th percentile of TDG REST API request execution time.\nOnly GET requests processed with code 4xx are displayed.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 567
+               },
+               "id": 223,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_rest_exec_time{job=~\"tarantool\",alias=~\"$alias\",method=\"GET\",status_code=~\"^4\\\\d{2}$\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Error read request latency (code 4xx)",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "µs",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "µs",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "99th percentile of TDG REST API request execution time.\nOnly GET requests processed with code 5xx are displayed.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 567
+               },
+               "id": 224,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_rest_exec_time{job=~\"tarantool\",alias=~\"$alias\",method=\"GET\",status_code=~\"^5\\\\d{2}$\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Error read request latency (code 5xx)",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "µs",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "µs",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of TDG REST API POST/PUT/DELETE requests\nprocessed with code 2xx.\nGraph shows mean requests per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 575
+               },
+               "id": 225,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool\",alias=~\"$alias\",method!=\"GET\",status_code=~\"^2\\\\d{2}$\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Success write requests",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "request per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of TDG REST API POST/PUT/DELETE requests\nprocessed with code 4xx.\nGraph shows mean requests per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 575
+               },
+               "id": 226,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool\",alias=~\"$alias\",method!=\"GET\",status_code=~\"^4\\\\d{2}$\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Error write requests (code 4xx)",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "request per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of TDG REST API POST/PUT/DELETE requests\nprocessed with code 5xx.\nGraph shows mean requests per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 575
+               },
+               "id": 227,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_rest_exec_time_count{job=~\"tarantool\",alias=~\"$alias\",method!=\"GET\",status_code=~\"^5\\\\d{2}$\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Error write requests (code 5xx)",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "request per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "99th percentile of TDG REST API request execution time.\nOnly POST/PUT/DELETE requests processed with code 2xx\nare displayed.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 583
+               },
+               "id": 228,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_rest_exec_time{job=~\"tarantool\",alias=~\"$alias\",method!=\"GET\",status_code=~\"^2\\\\d{2}$\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Success write request latency",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "µs",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "µs",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "99th percentile of TDG REST API request execution time.\nOnly POST/PUT/DELETE requests processed with code 4xx\nare displayed.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 583
+               },
+               "id": 229,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_rest_exec_time{job=~\"tarantool\",alias=~\"$alias\",method!=\"GET\",status_code=~\"^4\\\\d{2}$\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Error write request latency (code 4xx)",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "µs",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "µs",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "99th percentile of TDG REST API request execution time.\nOnly POST/PUT/DELETE requests processed with code 5xx\nare displayed.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 583
+               },
+               "id": 230,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_rest_exec_time{job=~\"tarantool\",alias=~\"$alias\",method!=\"GET\",status_code=~\"^5\\\\d{2}$\",quantile=\"0.99\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{type}} (code {{status_code}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Error read request latency (code 5xx)",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "µs",
+                     "label": "99th percentile",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "µs",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            }
+         ],
+         "repeat": null,
+         "repeatIteration": null,
+         "repeatRowId": null,
+         "showTitle": true,
+         "title": "TDG REST API requests",
+         "titleSize": "h6",
+         "type": "row"
+      },
+      {
+         "collapse": true,
+         "collapsed": true,
+         "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 591
+         },
+         "id": 231,
+         "panels": [
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of TDG jobs started.\nGraph shows mean jobs per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 592
+               },
+               "id": 232,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_jobs_started{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{name}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Jobs started",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "jobs per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of TDG jobs failed.\nGraph shows mean jobs per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 592
+               },
+               "id": 233,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_jobs_failed{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{name}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Jobs failed",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "jobs per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of TDG jobs succeeded.\nGraph shows mean jobs per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 592
+               },
+               "id": 234,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_jobs_succeeded{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{name}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Jobs succeeded",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "jobs per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of TDG jobs running now.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 600
+               },
+               "id": 235,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_jobs_running{job=~\"tarantool\",alias=~\"$alias\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{name}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Jobs running",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "current",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Average time of TDG job execution.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 600
+               },
+               "id": 236,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_jobs_execution_time_sum{job=~\"tarantool\",alias=~\"$alias\"} /\ntdg_jobs_execution_time_count{job=~\"tarantool\",alias=~\"$alias\"}\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{name}} — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Jobs execution time",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -15426,7 +19440,997 @@
                   {
                      "decimals": 0,
                      "format": "s",
-                     "label": "process time",
+                     "label": "average",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of TDG tasks started.\nGraph shows mean tasks per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 0,
+                  "y": 608
+               },
+               "id": 237,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_tasks_started{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Tasks started",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "tasks per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of TDG tasks failed.\nGraph shows mean tasks per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 6,
+                  "y": 608
+               },
+               "id": 238,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_tasks_failed{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Tasks failed",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "tasks per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of TDG tasks succeeded.\nGraph shows mean tasks per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 12,
+                  "y": 608
+               },
+               "id": 239,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_tasks_succeeded{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Tasks succeeded",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "tasks per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of TDG tasks stopped.\nGraph shows mean tasks per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 6,
+                  "x": 18,
+                  "y": 608
+               },
+               "id": 240,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_tasks_stopped{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Tasks stopped",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "tasks per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of TDG tasks running now.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 616
+               },
+               "id": 241,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_tasks_running{job=~\"tarantool\",alias=~\"$alias\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Tasks running",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "current",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Average time of TDG task execution.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 616
+               },
+               "id": 242,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_tasks_execution_time_sum{job=~\"tarantool\",alias=~\"$alias\"} /\ntdg_tasks_execution_time_count{job=~\"tarantool\",alias=~\"$alias\"}\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Tasks execution time",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "s",
+                     "label": "average",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "s",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of TDG system tasks started.\nGraph shows mean tasks per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 624
+               },
+               "id": 243,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_system_tasks_started{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "System tasks started",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "tasks per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of TDG system tasks failed.\nGraph shows mean tasks per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 624
+               },
+               "id": 244,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_system_tasks_failed{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "System tasks failed",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "tasks per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of TDG system tasks succeeded.\nGraph shows mean tasks per second.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 624
+               },
+               "id": 245,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tdg_system_tasks_succeeded{job=~\"tarantool\",alias=~\"$alias\"}[$__rate_interval])",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "System tasks succeeded",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "tasks per second",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Number of TDG system tasks running now.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 0,
+                  "y": 632
+               },
+               "id": 246,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_system_tasks_running{job=~\"tarantool\",alias=~\"$alias\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "System tasks running",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "none",
+                     "label": "current",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "decimals": 3,
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "Prometheus",
+               "decimals": 3,
+               "description": "Average time of TDG system task execution.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 632
+               },
+               "id": 247,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tdg_system_tasks_execution_time_sum{job=~\"tarantool\",alias=~\"$alias\"} /\ntdg_system_tasks_execution_time_count{job=~\"tarantool\",alias=~\"$alias\"}\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{name}} ({{kind}}) — {{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Tasks execution time",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "s",
+                     "label": "average",
                      "logBase": 1,
                      "max": null,
                      "min": null,
@@ -15448,7 +20452,7 @@
          "repeatIteration": null,
          "repeatRowId": null,
          "showTitle": true,
-         "title": "Tarantool network activity",
+         "title": "TDG tasks statistics",
          "titleSize": "h6",
          "type": "row"
       }
@@ -15458,45 +20462,25 @@
    "schemaVersion": 21,
    "style": "dark",
    "tags": [
-      "tarantool"
+      "tarantool",
+      "TDG"
    ],
    "templating": {
       "list": [
          {
             "allValue": null,
             "current": {
-               "text": "${PROMETHEUS_JOB}",
-               "value": "${PROMETHEUS_JOB}"
-            },
-            "hide": 2,
-            "includeAll": false,
-            "label": "Prometheus job",
-            "multi": false,
-            "name": "job",
-            "options": [
-               {
-                  "text": "${PROMETHEUS_JOB}",
-                  "value": "${PROMETHEUS_JOB}"
-               }
-            ],
-            "query": "${PROMETHEUS_JOB}",
-            "refresh": 0,
-            "type": "custom"
-         },
-         {
-            "allValue": null,
-            "current": {
                "text": "all",
                "value": "$__all"
             },
-            "datasource": "${DS_PROMETHEUS}",
+            "datasource": "Prometheus",
             "hide": 0,
             "includeAll": true,
             "label": "Instances",
             "multi": true,
             "name": "alias",
             "options": [ ],
-            "query": "label_values(tnt_info_uptime{job=~\"$job\"},alias)",
+            "query": "label_values(tnt_info_uptime{job=\"tarantool\"},alias)",
             "refresh": 2,
             "regex": "",
             "sort": 0,
@@ -15538,6 +20522,6 @@
       ]
    },
    "timezone": "browser",
-   "title": "Tarantool dashboard",
+   "title": "Tarantool Data Grid dashboard",
    "version": 0
 }

--- a/tests/Prometheus/dashboard_with_custom_panels.jsonnet
+++ b/tests/Prometheus/dashboard_with_custom_panels.jsonnet
@@ -21,6 +21,7 @@ dashboard.addPanels([
     datasource_type=variable.datasource_type.prometheus,
     metric_name='my_component_status',
     job=variable.prometheus.job,
+    alias=variable.prometheus.alias,
     converter='last',
   )),
 
@@ -38,6 +39,7 @@ dashboard.addPanels([
     datasource_type=variable.datasource_type.prometheus,
     metric_name='my_component_load_metric_count',
     job=variable.prometheus.job,
+    alias=variable.prometheus.alias,
   )),
 
   common.default_graph(
@@ -52,7 +54,8 @@ dashboard.addPanels([
     labelY1='process time',
     panel_width=12,
   ).addTarget(grafana.prometheus.target(
-    expr=std.format('my_component_load_metric{job=~"%s",quantile="0.99"}', [variable.prometheus.job]),
+    expr=std.format('my_component_load_metric{job=~"%s",alias=~"%s",quantile="0.99"}',
+                    [variable.prometheus.job, variable.prometheus.alias]),
     legendFormat='{{alias}}',
   )),
 ]).build()


### PR DESCRIPTION
Instance alias variable can be used to select displayed cluster instances for a dashboard. For InfluxDB dashboards, set of instances is based on available in database label_pairs_alias values. For Prometheus dashboards, set of instances is based on available in database alias labels of tnt_uptime_info metric.

After this patch, each panel (except for Prometheus cluster aggregation panels) include instance filters in queries.

After this patch, there are two different forms of static build dashboards are available: with or without instance variable.

Closes #181

![image](https://user-images.githubusercontent.com/20455996/191769912-c68e2ec0-196a-45be-9ec8-698f000f41cc.png)

This pull request do not introduces support for new metrics.

Do not forget to
- [x] link an issue,
- [x] add a CHANGELOG entry.
