### PR TITLE
tdg_dashboard: fix latency units

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Set InfluxDB `policy` dynamically
 - Set datasource dynamically
 
+### Fixed
+- TDG dashboard latency units (graphql, iproto, rest requests)
 
 ## [1.5.0] - 2022-09-22
 Grafana revisions: [InfluxDB revision 15](https://grafana.com/api/dashboards/12567/revisions/15/download), [Prometheus revision 15](https://grafana.com/api/dashboards/13054/revisions/15/download), [InfluxDB TDG revision 4](https://grafana.com/api/dashboards/16405/revisions/4/download), [Prometheus TDG revision 4](https://grafana.com/api/dashboards/16406/revisions/4/download).

--- a/dashboard/panels/tdg/graphql.libsonnet
+++ b/dashboard/panels/tdg/graphql.libsonnet
@@ -129,7 +129,7 @@ local prometheus = grafana.prometheus;
     description=description,
     datasource=datasource,
     labelY1='average',
-    format='µs',
+    format='ms',
   ).addTarget(average_target(
     datasource_type,
     'tdg_graphql_query_time',
@@ -208,7 +208,7 @@ local prometheus = grafana.prometheus;
     description=description,
     datasource=datasource,
     labelY1='average',
-    format='µs',
+    format='ms',
   ).addTarget(average_target(
     datasource_type,
     'tdg_graphql_mutation_time',

--- a/dashboard/panels/tdg/iproto.libsonnet
+++ b/dashboard/panels/tdg/iproto.libsonnet
@@ -88,7 +88,7 @@ local prometheus = grafana.prometheus;
       |||, method_tail),
     datasource=datasource,
     labelY1='99th percentile',
-    format='µs',
+    format='ms',
     panel_width=panel_width,
   ).addTarget(
     if datasource_type == variable.datasource_type.prometheus then

--- a/dashboard/panels/tdg/rest_api.libsonnet
+++ b/dashboard/panels/tdg/rest_api.libsonnet
@@ -74,7 +74,7 @@ local prometheus = grafana.prometheus;
     description=description,
     datasource=datasource,
     labelY1='99th percentile',
-    format='µs',
+    format='ms',
   ).addTarget(
     if datasource_type == variable.datasource_type.prometheus then
       prometheus.target(

--- a/tests/InfluxDB/dashboard_tdg_compiled.json
+++ b/tests/InfluxDB/dashboard_tdg_compiled.json
@@ -25323,7 +25323,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "average",
                      "logBase": 1,
                      "max": null,
@@ -25332,7 +25332,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -25740,7 +25740,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "average",
                      "logBase": 1,
                      "max": null,
@@ -25749,7 +25749,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -26225,7 +26225,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -26234,7 +26234,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -26535,7 +26535,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -26544,7 +26544,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -26845,7 +26845,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -26854,7 +26854,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -27155,7 +27155,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -27164,7 +27164,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -27465,7 +27465,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -27474,7 +27474,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -27775,7 +27775,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -27784,7 +27784,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -28085,7 +28085,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -28094,7 +28094,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -28395,7 +28395,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -28404,7 +28404,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -28705,7 +28705,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -28714,7 +28714,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -29417,7 +29417,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -29426,7 +29426,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -29590,7 +29590,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -29599,7 +29599,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -29763,7 +29763,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -29772,7 +29772,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -30455,7 +30455,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -30464,7 +30464,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -30628,7 +30628,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -30637,7 +30637,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -30801,7 +30801,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -30810,7 +30810,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,

--- a/tests/InfluxDB/dashboard_tdg_static_compiled.json
+++ b/tests/InfluxDB/dashboard_tdg_static_compiled.json
@@ -25323,7 +25323,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "average",
                      "logBase": 1,
                      "max": null,
@@ -25332,7 +25332,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -25740,7 +25740,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "average",
                      "logBase": 1,
                      "max": null,
@@ -25749,7 +25749,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -26225,7 +26225,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -26234,7 +26234,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -26535,7 +26535,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -26544,7 +26544,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -26845,7 +26845,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -26854,7 +26854,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -27155,7 +27155,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -27164,7 +27164,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -27465,7 +27465,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -27474,7 +27474,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -27775,7 +27775,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -27784,7 +27784,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -28085,7 +28085,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -28094,7 +28094,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -28395,7 +28395,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -28404,7 +28404,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -28705,7 +28705,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -28714,7 +28714,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -29417,7 +29417,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -29426,7 +29426,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -29590,7 +29590,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -29599,7 +29599,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -29763,7 +29763,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -29772,7 +29772,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -30455,7 +30455,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -30464,7 +30464,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -30628,7 +30628,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -30637,7 +30637,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -30801,7 +30801,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -30810,7 +30810,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,

--- a/tests/InfluxDB/dashboard_tdg_static_custom_title_compiled.json
+++ b/tests/InfluxDB/dashboard_tdg_static_custom_title_compiled.json
@@ -25323,7 +25323,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "average",
                      "logBase": 1,
                      "max": null,
@@ -25332,7 +25332,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -25740,7 +25740,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "average",
                      "logBase": 1,
                      "max": null,
@@ -25749,7 +25749,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -26225,7 +26225,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -26234,7 +26234,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -26535,7 +26535,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -26544,7 +26544,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -26845,7 +26845,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -26854,7 +26854,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -27155,7 +27155,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -27164,7 +27164,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -27465,7 +27465,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -27474,7 +27474,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -27775,7 +27775,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -27784,7 +27784,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -28085,7 +28085,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -28094,7 +28094,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -28395,7 +28395,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -28404,7 +28404,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -28705,7 +28705,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -28714,7 +28714,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -29417,7 +29417,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -29426,7 +29426,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -29590,7 +29590,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -29599,7 +29599,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -29763,7 +29763,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -29772,7 +29772,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -30455,7 +30455,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -30464,7 +30464,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -30628,7 +30628,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -30637,7 +30637,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -30801,7 +30801,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -30810,7 +30810,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,

--- a/tests/InfluxDB/dashboard_tdg_static_with_instance_variable_compiled.json
+++ b/tests/InfluxDB/dashboard_tdg_static_with_instance_variable_compiled.json
@@ -25323,7 +25323,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "average",
                      "logBase": 1,
                      "max": null,
@@ -25332,7 +25332,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -25740,7 +25740,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "average",
                      "logBase": 1,
                      "max": null,
@@ -25749,7 +25749,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -26225,7 +26225,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -26234,7 +26234,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -26535,7 +26535,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -26544,7 +26544,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -26845,7 +26845,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -26854,7 +26854,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -27155,7 +27155,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -27164,7 +27164,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -27465,7 +27465,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -27474,7 +27474,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -27775,7 +27775,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -27784,7 +27784,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -28085,7 +28085,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -28094,7 +28094,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -28395,7 +28395,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -28404,7 +28404,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -28705,7 +28705,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -28714,7 +28714,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -29417,7 +29417,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -29426,7 +29426,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -29590,7 +29590,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -29599,7 +29599,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -29763,7 +29763,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -29772,7 +29772,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -30455,7 +30455,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -30464,7 +30464,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -30628,7 +30628,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -30637,7 +30637,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -30801,7 +30801,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -30810,7 +30810,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,

--- a/tests/Prometheus/dashboard_tdg_compiled.json
+++ b/tests/Prometheus/dashboard_tdg_compiled.json
@@ -15869,7 +15869,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "average",
                      "logBase": 1,
                      "max": null,
@@ -15878,7 +15878,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -16139,7 +16139,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "average",
                      "logBase": 1,
                      "max": null,
@@ -16148,7 +16148,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -16429,7 +16429,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -16438,7 +16438,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -16609,7 +16609,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -16618,7 +16618,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -16789,7 +16789,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -16798,7 +16798,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -16969,7 +16969,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -16978,7 +16978,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -17149,7 +17149,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -17158,7 +17158,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -17329,7 +17329,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -17338,7 +17338,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -17509,7 +17509,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -17518,7 +17518,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -17689,7 +17689,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -17698,7 +17698,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -17869,7 +17869,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -17878,7 +17878,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -18249,7 +18249,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -18258,7 +18258,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -18339,7 +18339,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -18348,7 +18348,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -18429,7 +18429,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -18438,7 +18438,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -18789,7 +18789,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -18798,7 +18798,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -18879,7 +18879,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -18888,7 +18888,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -18969,7 +18969,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -18978,7 +18978,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,

--- a/tests/Prometheus/dashboard_tdg_static_compiled.json
+++ b/tests/Prometheus/dashboard_tdg_static_compiled.json
@@ -15869,7 +15869,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "average",
                      "logBase": 1,
                      "max": null,
@@ -15878,7 +15878,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -16139,7 +16139,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "average",
                      "logBase": 1,
                      "max": null,
@@ -16148,7 +16148,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -16429,7 +16429,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -16438,7 +16438,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -16609,7 +16609,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -16618,7 +16618,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -16789,7 +16789,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -16798,7 +16798,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -16969,7 +16969,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -16978,7 +16978,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -17149,7 +17149,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -17158,7 +17158,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -17329,7 +17329,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -17338,7 +17338,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -17509,7 +17509,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -17518,7 +17518,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -17689,7 +17689,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -17698,7 +17698,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -17869,7 +17869,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -17878,7 +17878,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -18249,7 +18249,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -18258,7 +18258,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -18339,7 +18339,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -18348,7 +18348,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -18429,7 +18429,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -18438,7 +18438,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -18789,7 +18789,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -18798,7 +18798,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -18879,7 +18879,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -18888,7 +18888,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -18969,7 +18969,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -18978,7 +18978,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,

--- a/tests/Prometheus/dashboard_tdg_static_custom_title_compiled.json
+++ b/tests/Prometheus/dashboard_tdg_static_custom_title_compiled.json
@@ -15869,7 +15869,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "average",
                      "logBase": 1,
                      "max": null,
@@ -15878,7 +15878,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -16139,7 +16139,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "average",
                      "logBase": 1,
                      "max": null,
@@ -16148,7 +16148,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -16429,7 +16429,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -16438,7 +16438,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -16609,7 +16609,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -16618,7 +16618,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -16789,7 +16789,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -16798,7 +16798,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -16969,7 +16969,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -16978,7 +16978,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -17149,7 +17149,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -17158,7 +17158,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -17329,7 +17329,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -17338,7 +17338,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -17509,7 +17509,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -17518,7 +17518,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -17689,7 +17689,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -17698,7 +17698,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -17869,7 +17869,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -17878,7 +17878,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -18249,7 +18249,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -18258,7 +18258,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -18339,7 +18339,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -18348,7 +18348,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -18429,7 +18429,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -18438,7 +18438,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -18789,7 +18789,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -18798,7 +18798,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -18879,7 +18879,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -18888,7 +18888,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -18969,7 +18969,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -18978,7 +18978,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,

--- a/tests/Prometheus/dashboard_tdg_static_with_instance_variable_compiled.json
+++ b/tests/Prometheus/dashboard_tdg_static_with_instance_variable_compiled.json
@@ -15869,7 +15869,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "average",
                      "logBase": 1,
                      "max": null,
@@ -15878,7 +15878,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -16139,7 +16139,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "average",
                      "logBase": 1,
                      "max": null,
@@ -16148,7 +16148,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -16429,7 +16429,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -16438,7 +16438,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -16609,7 +16609,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -16618,7 +16618,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -16789,7 +16789,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -16798,7 +16798,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -16969,7 +16969,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -16978,7 +16978,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -17149,7 +17149,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -17158,7 +17158,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -17329,7 +17329,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -17338,7 +17338,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -17509,7 +17509,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -17518,7 +17518,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -17689,7 +17689,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -17698,7 +17698,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -17869,7 +17869,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -17878,7 +17878,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -18249,7 +18249,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -18258,7 +18258,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -18339,7 +18339,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -18348,7 +18348,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -18429,7 +18429,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -18438,7 +18438,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -18789,7 +18789,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -18798,7 +18798,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -18879,7 +18879,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -18888,7 +18888,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,
@@ -18969,7 +18969,7 @@
                "yaxes": [
                   {
                      "decimals": 0,
-                     "format": "µs",
+                     "format": "ms",
                      "label": "99th percentile",
                      "logBase": 1,
                      "max": null,
@@ -18978,7 +18978,7 @@
                   },
                   {
                      "decimals": 3,
-                     "format": "µs",
+                     "format": "ms",
                      "label": null,
                      "logBase": 1,
                      "max": null,


### PR DESCRIPTION
Fix latency units for GraphQL [1], IProto [2] and REST API [3] panels.

1. https://github.com/tarantool/tdg2/blob/b283c91e17fec274d1be187fb734418a7f56a034/common/graphql.lua#L633
2. https://github.com/tarantool/tdg2/blob/7983a6a7b149ac2e9e94e052d01513076847bdff/input_processor/model_iproto.lua#L57
3. https://github.com/tarantool/tdg2/blob/98b113eb4a4f71f26a34f2522e6a93ed4e67db90/input_processor/model_rest.lua#L393

Closes #190

If this pull request introduces support for new metrics, do not forget to
- add Grafana panel;
- [x] run `make update-tests` to build new dashboard artifacts;
- add example application code to generate non-null metrics;
- attach a screenshot of a new panel to the PR description;
- add new Telegraf tag key, if relevant,
  - to all `telegraf.conf` files,
  - to "Grafana dashboard" documentation page;
- add alert example, if relevant,
  - to `alerts.yml`,
  - to "Alerting" documentation page;
- update `supported_metrics.md`.

In any case, do not forget to
- [x] link an issue;
- [x] add a CHANGELOG entry;
- update documentation guidelines;
- update README guidelines.
