### PR TITLE
release: 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+## [2.0.0] - 2023-03-03
+Grafana revisions: [InfluxDB revision 16](https://grafana.com/api/dashboards/12567/revisions/16/download), [Prometheus revision 16](https://grafana.com/api/dashboards/13054/revisions/16/download), [InfluxDB TDG revision 5](https://grafana.com/api/dashboards/16405/revisions/5/download), [Prometheus TDG revision 5](https://grafana.com/api/dashboards/16406/revisions/5/download).
 
 ### Added
 - Dashboard title customization
@@ -26,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - TDG dashboard latency units (graphql, iproto, rest requests)
+
 
 ## [1.5.0] - 2022-09-22
 Grafana revisions: [InfluxDB revision 15](https://grafana.com/api/dashboards/12567/revisions/15/download), [Prometheus revision 15](https://grafana.com/api/dashboards/13054/revisions/15/download), [InfluxDB TDG revision 4](https://grafana.com/api/dashboards/16405/revisions/4/download), [Prometheus TDG revision 4](https://grafana.com/api/dashboards/16406/revisions/4/download).


### PR DESCRIPTION
Grafana revisions:
- InfluxDB revision 16 [1],
- Prometheus revision 16 [2],
- InfluxDB TDG revision 5 [3],
- Prometheus TDG revision 5 [4].

Added:
- Dashboard title customization
- Panels for transaction operations
- Panels with net statistics per thread
- Panel with failover trigger count
- Panels with syncro replication queue statistics
- Panels with leader election statistics
- Panels with MVCC statistics

Changed:
- Replace LuaJit deprecated metrics with new ones
- Set Prometheus `job` dynamically
- Set InfluxDB `measurement` dynamically
- Set InfluxDB `policy` dynamically
- Set datasource dynamically
- Use expirationd module metrics in TDG dashboard
- Move replication panels to a separate row

Fixed:
- TDG dashboard latency units (graphql, iproto, rest requests)

1. https://grafana.com/api/dashboards/12567/revisions/16/download
2. https://grafana.com/api/dashboards/13054/revisions/16/download
3. https://grafana.com/api/dashboards/16405/revisions/5/download
4. https://grafana.com/api/dashboards/16406/revisions/5/download
