### PR TITLE
dashboard: fill with none for InfluxDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   It affects all custom-built dashboards which had used `replication` (#224)
 - Remove deprecated `build-static-*` targets from `make` (#224)
 - Make default template use Tarantool 3 sections (#224)
+- Use `fill(none)` in InfluxQL requests (PR #229)
 
 ### Fixed
 - Removed extra quotation mark for TDG jobs_average_panel query (#220)

--- a/dashboard/panels/common.libsonnet
+++ b/dashboard/panels/common.libsonnet
@@ -102,7 +102,7 @@ local influxdb_query_filters(filters) = std.join(' AND ', std.map(
           measurement=cfg.measurement,
           group_tags=group_tags,
           alias=legend[cfg.type],
-          fill='null',
+          fill='none',
         ).where('metric_name', '=', std.format('%s%s', [cfg.metrics_prefix, metric_name]))
       ).selectField('value').addConverter(converter);
       if rate then target.addConverter('non_negative_derivative', ['1s']) else target,

--- a/dashboard/panels/tdg/graphql.libsonnet
+++ b/dashboard/panels/tdg/graphql.libsonnet
@@ -62,7 +62,7 @@ local prometheus = grafana.prometheus;
           WHERE ("metric_name" = '%(metrics_prefix)s%(metric_name_count)s' %(filters)s)
           AND $timeFilter)
           GROUP BY time($__interval), "label_pairs_alias", "label_pairs_operation_name",
-          "label_pairs_schema", "label_pairs_entity" fill(null)
+          "label_pairs_schema", "label_pairs_entity" fill(none)
         |||, {
           metrics_prefix: cfg.metrics_prefix,
           metric_name_sum: std.join('_', [metric_name, 'sum']),

--- a/dashboard/panels/tdg/tasks.libsonnet
+++ b/dashboard/panels/tdg/tasks.libsonnet
@@ -107,7 +107,7 @@ local prometheus = grafana.prometheus;
           (SELECT "value" as "%(metrics_prefix)s%(metric_name_count)s" FROM %(policy_prefix)s"%(measurement)s"
           WHERE ("metric_name" = '%(metrics_prefix)s%(metric_name_count)s' %(filters)s)
           AND $timeFilter)
-          GROUP BY time($__interval), "label_pairs_alias", "label_pairs_name" fill(null)
+          GROUP BY time($__interval), "label_pairs_alias", "label_pairs_name" fill(none)
         |||, {
           metrics_prefix: cfg.metrics_prefix,
           metric_name_sum: std.join('_', [metric_name, 'sum']),
@@ -221,7 +221,7 @@ local prometheus = grafana.prometheus;
           WHERE ("metric_name" = '%(metrics_prefix)s%(metric_name_count)s' %(filters)s)
           AND $timeFilter)
           GROUP BY time($__interval), "label_pairs_alias", "label_pairs_name",
-          "label_pairs_kind" fill(null)
+          "label_pairs_kind" fill(none)
         |||, {
           metrics_prefix: cfg.metrics_prefix,
           metric_name_sum: std.join('_', [metric_name, 'sum']),

--- a/dashboard/panels/tdg/tuples.libsonnet
+++ b/dashboard/panels/tdg/tuples.libsonnet
@@ -40,7 +40,7 @@ local prometheus = grafana.prometheus;
           WHERE ("metric_name" = '%(metrics_prefix)s%(metric_name_sum)s' %(filters)s) AND $timeFilter),
           (SELECT "value" as "%(metrics_prefix)s%(metric_name_count)s" FROM %(policy_prefix)s"%(measurement)s"
           WHERE ("metric_name" = '%(metrics_prefix)s%(metric_name_count)s' %(filters)s) AND $timeFilter)
-          GROUP BY time($__interval), "label_pairs_alias", "label_pairs_type_name" fill(null)
+          GROUP BY time($__interval), "label_pairs_alias", "label_pairs_type_name" fill(none)
         |||, {
           metrics_prefix: cfg.metrics_prefix,
           metric_name_sum: std.join('_', [metric_name, 'sum']),

--- a/docker-compose.cartridge.yml
+++ b/docker-compose.cartridge.yml
@@ -72,12 +72,8 @@ services:
     volumes:
       - ./example_cluster/grafana/provisioning:/etc/grafana/provisioning
       # Map to different folders to prevent name collision.
-      - ./tests/Prometheus/dashboard_compiled.json:/usr/lib/dashboards/Prometheus-common/dashboard.json
-      - ./tests/Prometheus/dashboard_static_compiled.json:/usr/lib/dashboards/Prometheus-static/dashboard.json
-      - ./tests/Prometheus/dashboard_static_with_instance_variable_compiled.json:/usr/lib/dashboards/Prometheus-static-var/dashboard.json
-      - ./tests/InfluxDB/dashboard_compiled.json:/usr/lib/dashboards/InfluxDB-common/dashboard.json
-      - ./tests/InfluxDB/dashboard_static_compiled.json:/usr/lib/dashboards/InfluxDB-static/dashboard.json
-      - ./tests/InfluxDB/dashboard_static_with_instance_variable_compiled.json:/usr/lib/dashboards/InfluxDB-static-var/dashboard.json
+      - ./tests/Prometheus/dashboard_cartridge_compiled.json:/usr/lib/dashboards/Prometheus-common/dashboard.json
+      - ./tests/InfluxDB/dashboard_cartridge_compiled.json:/usr/lib/dashboards/InfluxDB-common/dashboard.json
 
 networks:
   tarantool_dashboard_dev:

--- a/docker-compose.tdg.yml
+++ b/docker-compose.tdg.yml
@@ -80,11 +80,7 @@ services:
       - ./example_cluster/grafana/provisioning:/etc/grafana/provisioning
       # Map to different folders to prevent name collision.
       - ./tests/Prometheus/dashboard_tdg_compiled.json:/usr/lib/dashboards/Prometheus-common/dashboard.json
-      - ./tests/Prometheus/dashboard_tdg_static_compiled.json:/usr/lib/dashboards/Prometheus-static/dashboard.json
-      - ./tests/Prometheus/dashboard_tdg_static_with_instance_variable_compiled.json:/usr/lib/dashboards/Prometheus-static-var/dashboard.json
       - ./tests/InfluxDB/dashboard_tdg_compiled.json:/usr/lib/dashboards/InfluxDB-common/dashboard.json
-      - ./tests/InfluxDB/dashboard_tdg_static_compiled.json:/usr/lib/dashboards/InfluxDB-static/dashboard.json
-      - ./tests/InfluxDB/dashboard_tdg_static_with_instance_variable_compiled.json:/usr/lib/dashboards/InfluxDB-static-var/dashboard.json
 
 networks:
   tarantool_dashboard_dev:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,12 +72,8 @@ services:
     volumes:
       - ./example_cluster/grafana/provisioning:/etc/grafana/provisioning
       # Map to different folders to prevent name collision.
-      - ./tests/Prometheus/dashboard_compiled.json:/usr/lib/dashboards/Prometheus-common/dashboard.json
-      - ./tests/Prometheus/dashboard_static_compiled.json:/usr/lib/dashboards/Prometheus-static/dashboard.json
-      - ./tests/Prometheus/dashboard_static_with_instance_variable_compiled.json:/usr/lib/dashboards/Prometheus-static-var/dashboard.json
-      - ./tests/InfluxDB/dashboard_compiled.json:/usr/lib/dashboards/InfluxDB-common/dashboard.json
-      - ./tests/InfluxDB/dashboard_static_compiled.json:/usr/lib/dashboards/InfluxDB-static/dashboard.json
-      - ./tests/InfluxDB/dashboard_static_with_instance_variable_compiled.json:/usr/lib/dashboards/InfluxDB-static-var/dashboard.json
+      - ./tests/Prometheus/dashboard_tarantool3_compiled.json:/usr/lib/dashboards/Prometheus-common/dashboard.json
+      - ./tests/InfluxDB/dashboard_tarantool3_compiled.json:/usr/lib/dashboards/InfluxDB-common/dashboard.json
 
 networks:
   tarantool_dashboard_dev:

--- a/tests/InfluxDB/dashboard_cartridge_compiled.json
+++ b/tests/InfluxDB/dashboard_cartridge_compiled.json
@@ -114,7 +114,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -254,7 +254,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -394,7 +394,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -589,7 +589,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -766,7 +766,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -868,7 +868,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1005,7 +1005,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1142,7 +1142,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1365,7 +1365,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1472,7 +1472,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1612,7 +1612,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1747,7 +1747,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1884,7 +1884,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2020,7 +2020,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2209,7 +2209,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2348,7 +2348,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2512,7 +2512,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2676,7 +2676,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2840,7 +2840,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3004,7 +3004,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3168,7 +3168,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3334,7 +3334,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3468,7 +3468,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3608,7 +3608,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3748,7 +3748,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3889,7 +3889,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4025,7 +4025,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4166,7 +4166,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4302,7 +4302,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4443,7 +4443,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4579,7 +4579,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4720,7 +4720,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4862,7 +4862,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5008,7 +5008,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5154,7 +5154,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5301,7 +5301,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5443,7 +5443,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5589,7 +5589,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5735,7 +5735,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5882,7 +5882,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6025,7 +6025,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6168,7 +6168,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6338,7 +6338,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6472,7 +6472,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6606,7 +6606,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6740,7 +6740,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6874,7 +6874,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7008,7 +7008,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7142,7 +7142,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7276,7 +7276,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7410,7 +7410,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7564,7 +7564,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7704,7 +7704,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7844,7 +7844,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7984,7 +7984,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8124,7 +8124,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8264,7 +8264,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8404,7 +8404,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8544,7 +8544,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8684,7 +8684,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8824,7 +8824,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8964,7 +8964,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9104,7 +9104,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9244,7 +9244,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9384,7 +9384,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9524,7 +9524,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9665,7 +9665,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9807,7 +9807,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9948,7 +9948,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10090,7 +10090,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10231,7 +10231,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10373,7 +10373,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10514,7 +10514,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10656,7 +10656,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10797,7 +10797,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10939,7 +10939,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11080,7 +11080,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11222,7 +11222,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11389,7 +11389,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11538,7 +11538,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11686,7 +11686,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11838,7 +11838,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11978,7 +11978,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12138,7 +12138,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12272,7 +12272,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12406,7 +12406,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12540,7 +12540,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12674,7 +12674,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12808,7 +12808,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12942,7 +12942,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13076,7 +13076,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13210,7 +13210,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13344,7 +13344,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13478,7 +13478,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13612,7 +13612,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13752,7 +13752,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13892,7 +13892,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14033,7 +14033,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14169,7 +14169,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14309,7 +14309,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14455,7 +14455,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14595,7 +14595,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14755,7 +14755,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14896,7 +14896,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15057,7 +15057,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15191,7 +15191,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15325,7 +15325,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15459,7 +15459,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15593,7 +15593,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15728,7 +15728,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15864,7 +15864,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15998,7 +15998,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16152,7 +16152,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16292,7 +16292,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16432,7 +16432,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16572,7 +16572,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16706,7 +16706,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16846,7 +16846,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16986,7 +16986,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17126,7 +17126,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17266,7 +17266,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17406,7 +17406,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17546,7 +17546,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17686,7 +17686,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17827,7 +17827,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17964,7 +17964,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18101,7 +18101,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18238,7 +18238,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18374,7 +18374,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18508,7 +18508,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18648,7 +18648,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18808,7 +18808,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18954,7 +18954,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -19100,7 +19100,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -19246,7 +19246,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -19392,7 +19392,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -19538,7 +19538,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -19684,7 +19684,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -19830,7 +19830,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -19976,7 +19976,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20122,7 +20122,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20268,7 +20268,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20414,7 +20414,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20560,7 +20560,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20706,7 +20706,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20852,7 +20852,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -21024,7 +21024,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -21182,7 +21182,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -21340,7 +21340,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -21498,7 +21498,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -21864,7 +21864,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -22016,7 +22016,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -22174,7 +22174,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -22332,7 +22332,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -22490,7 +22490,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -22648,7 +22648,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -22806,7 +22806,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -22964,7 +22964,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -23122,7 +23122,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -23280,7 +23280,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -23438,7 +23438,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -23596,7 +23596,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -23754,7 +23754,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -23912,7 +23912,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -24070,7 +24070,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -24228,7 +24228,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -24386,7 +24386,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -24544,7 +24544,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -24702,7 +24702,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -24860,7 +24860,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -25018,7 +25018,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -25176,7 +25176,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -25334,7 +25334,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -25492,7 +25492,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -25650,7 +25650,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -25808,7 +25808,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -25966,7 +25966,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -26124,7 +26124,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -26282,7 +26282,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -26440,7 +26440,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -26598,7 +26598,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -26756,7 +26756,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -26914,7 +26914,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -27072,7 +27072,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -27230,7 +27230,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -27388,7 +27388,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -27546,7 +27546,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -27704,7 +27704,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -27862,7 +27862,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -28020,7 +28020,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -28178,7 +28178,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -28336,7 +28336,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -28494,7 +28494,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -28652,7 +28652,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -28810,7 +28810,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -28968,7 +28968,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -29126,7 +29126,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -29284,7 +29284,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -29442,7 +29442,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -29600,7 +29600,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -29758,7 +29758,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -29916,7 +29916,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -30074,7 +30074,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -30252,7 +30252,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -30398,7 +30398,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -30545,7 +30545,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -30687,7 +30687,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }

--- a/tests/InfluxDB/dashboard_custom_compiled.json
+++ b/tests/InfluxDB/dashboard_custom_compiled.json
@@ -169,7 +169,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -352,7 +352,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -460,7 +460,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -603,7 +603,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -746,7 +746,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -975,7 +975,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1088,7 +1088,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1229,7 +1229,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1372,7 +1372,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1514,7 +1514,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1709,7 +1709,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1854,7 +1854,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2024,7 +2024,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2194,7 +2194,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2364,7 +2364,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2534,7 +2534,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2704,7 +2704,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2876,7 +2876,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3016,7 +3016,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3162,7 +3162,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3308,7 +3308,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3455,7 +3455,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3597,7 +3597,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3744,7 +3744,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3886,7 +3886,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4033,7 +4033,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4175,7 +4175,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4322,7 +4322,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4470,7 +4470,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4622,7 +4622,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4774,7 +4774,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4927,7 +4927,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5075,7 +5075,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5227,7 +5227,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5379,7 +5379,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5532,7 +5532,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5681,7 +5681,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5830,7 +5830,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6006,7 +6006,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6146,7 +6146,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6286,7 +6286,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6426,7 +6426,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6566,7 +6566,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6706,7 +6706,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6846,7 +6846,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6986,7 +6986,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7126,7 +7126,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7293,7 +7293,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7448,7 +7448,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7602,7 +7602,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7760,7 +7760,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7906,7 +7906,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8072,7 +8072,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8212,7 +8212,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8352,7 +8352,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8492,7 +8492,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8632,7 +8632,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8773,7 +8773,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8915,7 +8915,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9055,7 +9055,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9215,7 +9215,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9361,7 +9361,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9507,7 +9507,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9653,7 +9653,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9793,7 +9793,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9939,7 +9939,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10085,7 +10085,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10231,7 +10231,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10377,7 +10377,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10523,7 +10523,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10669,7 +10669,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10815,7 +10815,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10962,7 +10962,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11105,7 +11105,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11248,7 +11248,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11391,7 +11391,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11533,7 +11533,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11673,7 +11673,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11819,7 +11819,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11985,7 +11985,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12137,7 +12137,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12289,7 +12289,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12441,7 +12441,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12593,7 +12593,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12745,7 +12745,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12897,7 +12897,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13049,7 +13049,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13201,7 +13201,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13353,7 +13353,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13505,7 +13505,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13657,7 +13657,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13809,7 +13809,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13961,7 +13961,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14113,7 +14113,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }

--- a/tests/InfluxDB/dashboard_tarantool3_compiled.json
+++ b/tests/InfluxDB/dashboard_tarantool3_compiled.json
@@ -169,7 +169,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -346,7 +346,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -448,7 +448,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -585,7 +585,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -722,7 +722,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -945,7 +945,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1052,7 +1052,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1187,7 +1187,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1324,7 +1324,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1460,7 +1460,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1649,7 +1649,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1788,7 +1788,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1952,7 +1952,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2116,7 +2116,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2280,7 +2280,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2444,7 +2444,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2608,7 +2608,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2774,7 +2774,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2908,7 +2908,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3048,7 +3048,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3188,7 +3188,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3329,7 +3329,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3465,7 +3465,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3606,7 +3606,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3742,7 +3742,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3883,7 +3883,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4019,7 +4019,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4160,7 +4160,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4302,7 +4302,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4448,7 +4448,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4594,7 +4594,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4741,7 +4741,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4883,7 +4883,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5029,7 +5029,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5175,7 +5175,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5322,7 +5322,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5465,7 +5465,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5608,7 +5608,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5778,7 +5778,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5912,7 +5912,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6046,7 +6046,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6180,7 +6180,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6314,7 +6314,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6448,7 +6448,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6582,7 +6582,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6716,7 +6716,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6850,7 +6850,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7004,7 +7004,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7144,7 +7144,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7284,7 +7284,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7424,7 +7424,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7564,7 +7564,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7704,7 +7704,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7844,7 +7844,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7984,7 +7984,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8124,7 +8124,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8264,7 +8264,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8404,7 +8404,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8544,7 +8544,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8684,7 +8684,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8824,7 +8824,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8964,7 +8964,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9105,7 +9105,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9247,7 +9247,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9388,7 +9388,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9530,7 +9530,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9671,7 +9671,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9813,7 +9813,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9954,7 +9954,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10096,7 +10096,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10237,7 +10237,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10379,7 +10379,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10520,7 +10520,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10662,7 +10662,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10829,7 +10829,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10978,7 +10978,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11126,7 +11126,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11278,7 +11278,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11418,7 +11418,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11578,7 +11578,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11712,7 +11712,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11846,7 +11846,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11980,7 +11980,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12114,7 +12114,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12248,7 +12248,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12382,7 +12382,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12516,7 +12516,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12650,7 +12650,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12784,7 +12784,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12918,7 +12918,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13052,7 +13052,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13192,7 +13192,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13332,7 +13332,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13473,7 +13473,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13609,7 +13609,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13749,7 +13749,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13895,7 +13895,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14035,7 +14035,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14195,7 +14195,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14336,7 +14336,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14497,7 +14497,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14631,7 +14631,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14765,7 +14765,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14899,7 +14899,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15033,7 +15033,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15168,7 +15168,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15304,7 +15304,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15438,7 +15438,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15592,7 +15592,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15732,7 +15732,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15872,7 +15872,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16012,7 +16012,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16146,7 +16146,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16286,7 +16286,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16426,7 +16426,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16566,7 +16566,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16706,7 +16706,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16846,7 +16846,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16986,7 +16986,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17126,7 +17126,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17267,7 +17267,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17404,7 +17404,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17541,7 +17541,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17678,7 +17678,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17814,7 +17814,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17948,7 +17948,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18088,7 +18088,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18248,7 +18248,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18394,7 +18394,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18540,7 +18540,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18686,7 +18686,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18832,7 +18832,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18978,7 +18978,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -19124,7 +19124,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -19270,7 +19270,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -19416,7 +19416,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -19562,7 +19562,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -19708,7 +19708,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -19854,7 +19854,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20000,7 +20000,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20146,7 +20146,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20292,7 +20292,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20464,7 +20464,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20622,7 +20622,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20780,7 +20780,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20938,7 +20938,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -21304,7 +21304,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -21456,7 +21456,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -21614,7 +21614,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -21772,7 +21772,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -21930,7 +21930,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -22088,7 +22088,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -22246,7 +22246,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -22404,7 +22404,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -22562,7 +22562,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -22720,7 +22720,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -22878,7 +22878,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -23036,7 +23036,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -23194,7 +23194,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -23352,7 +23352,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -23510,7 +23510,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -23668,7 +23668,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -23826,7 +23826,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -23984,7 +23984,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -24142,7 +24142,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -24300,7 +24300,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -24458,7 +24458,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -24616,7 +24616,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -24774,7 +24774,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -24932,7 +24932,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -25090,7 +25090,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -25248,7 +25248,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -25406,7 +25406,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -25564,7 +25564,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -25722,7 +25722,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -25880,7 +25880,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -26038,7 +26038,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -26196,7 +26196,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -26354,7 +26354,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -26512,7 +26512,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -26670,7 +26670,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -26828,7 +26828,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -26986,7 +26986,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -27144,7 +27144,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -27302,7 +27302,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -27460,7 +27460,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -27618,7 +27618,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -27776,7 +27776,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -27934,7 +27934,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -28092,7 +28092,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -28250,7 +28250,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -28408,7 +28408,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -28566,7 +28566,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -28724,7 +28724,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -28882,7 +28882,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -29040,7 +29040,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -29198,7 +29198,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -29356,7 +29356,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -29514,7 +29514,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -29692,7 +29692,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -29838,7 +29838,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -29985,7 +29985,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -30127,7 +30127,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }

--- a/tests/InfluxDB/dashboard_tdg_compiled.json
+++ b/tests/InfluxDB/dashboard_tdg_compiled.json
@@ -114,7 +114,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -254,7 +254,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -394,7 +394,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -589,7 +589,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -766,7 +766,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -868,7 +868,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1005,7 +1005,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1142,7 +1142,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1365,7 +1365,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1472,7 +1472,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1612,7 +1612,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1747,7 +1747,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1884,7 +1884,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2020,7 +2020,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2209,7 +2209,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2330,7 +2330,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2464,7 +2464,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2604,7 +2604,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2744,7 +2744,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2885,7 +2885,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3021,7 +3021,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3162,7 +3162,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3298,7 +3298,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3439,7 +3439,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3575,7 +3575,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3716,7 +3716,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3858,7 +3858,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4004,7 +4004,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4150,7 +4150,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4297,7 +4297,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4439,7 +4439,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4585,7 +4585,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4731,7 +4731,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4878,7 +4878,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5021,7 +5021,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5164,7 +5164,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5334,7 +5334,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5468,7 +5468,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5602,7 +5602,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5736,7 +5736,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5870,7 +5870,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6004,7 +6004,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6138,7 +6138,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6272,7 +6272,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6406,7 +6406,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6560,7 +6560,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6700,7 +6700,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6840,7 +6840,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6980,7 +6980,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7120,7 +7120,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7260,7 +7260,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7400,7 +7400,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7540,7 +7540,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7680,7 +7680,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7820,7 +7820,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7960,7 +7960,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8100,7 +8100,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8240,7 +8240,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8380,7 +8380,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8520,7 +8520,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8661,7 +8661,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8803,7 +8803,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8944,7 +8944,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9086,7 +9086,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9227,7 +9227,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9369,7 +9369,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9510,7 +9510,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9652,7 +9652,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9793,7 +9793,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9935,7 +9935,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10076,7 +10076,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10218,7 +10218,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10385,7 +10385,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10534,7 +10534,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10682,7 +10682,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10834,7 +10834,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10974,7 +10974,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11134,7 +11134,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11268,7 +11268,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11402,7 +11402,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11536,7 +11536,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11670,7 +11670,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11804,7 +11804,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11938,7 +11938,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12072,7 +12072,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12206,7 +12206,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12340,7 +12340,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12474,7 +12474,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12608,7 +12608,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12748,7 +12748,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12888,7 +12888,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13029,7 +13029,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13165,7 +13165,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13305,7 +13305,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13451,7 +13451,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13591,7 +13591,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13751,7 +13751,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13892,7 +13892,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14039,7 +14039,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14191,7 +14191,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14357,7 +14357,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14491,7 +14491,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14625,7 +14625,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14759,7 +14759,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14893,7 +14893,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15028,7 +15028,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15164,7 +15164,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15298,7 +15298,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15452,7 +15452,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15592,7 +15592,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15732,7 +15732,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15872,7 +15872,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16006,7 +16006,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16146,7 +16146,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16286,7 +16286,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16426,7 +16426,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16566,7 +16566,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16706,7 +16706,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16846,7 +16846,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16986,7 +16986,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17127,7 +17127,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17264,7 +17264,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17401,7 +17401,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17538,7 +17538,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17674,7 +17674,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17808,7 +17808,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17948,7 +17948,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18108,7 +18108,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18254,7 +18254,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18400,7 +18400,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18546,7 +18546,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18692,7 +18692,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18838,7 +18838,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18984,7 +18984,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -19130,7 +19130,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -19276,7 +19276,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -19422,7 +19422,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -19568,7 +19568,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -19714,7 +19714,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -19860,7 +19860,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20006,7 +20006,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20152,7 +20152,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20336,7 +20336,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20488,7 +20488,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20640,7 +20640,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20792,7 +20792,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20950,7 +20950,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -21108,7 +21108,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -21266,7 +21266,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -21424,7 +21424,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -21582,7 +21582,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -21740,7 +21740,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -21898,7 +21898,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -22082,7 +22082,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -22240,7 +22240,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -22404,7 +22404,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -22568,7 +22568,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -22732,7 +22732,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -22890,7 +22890,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -23048,7 +23048,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -23206,7 +23206,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -23364,7 +23364,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -23528,7 +23528,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -23692,7 +23692,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -23856,7 +23856,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -24020,7 +24020,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -24178,7 +24178,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -24342,7 +24342,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -24506,7 +24506,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -24670,7 +24670,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -24834,7 +24834,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -24998,7 +24998,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -25156,7 +25156,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -25326,7 +25326,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -25490,7 +25490,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -25654,7 +25654,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -25818,7 +25818,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -25982,7 +25982,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -26166,7 +26166,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -26324,7 +26324,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -26482,7 +26482,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -26646,7 +26646,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -26816,7 +26816,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -26980,7 +26980,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -27144,7 +27144,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -27308,7 +27308,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -27472,7 +27472,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -27636,7 +27636,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -27800,7 +27800,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -27970,7 +27970,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -28140,7 +28140,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -28310,7 +28310,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -28480,7 +28480,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -28650,7 +28650,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -28822,7 +28822,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -28974,7 +28974,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -29126,7 +29126,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -29284,7 +29284,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -29456,7 +29456,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -29608,7 +29608,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -29768,7 +29768,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -29914,7 +29914,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -30061,7 +30061,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -30203,7 +30203,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -30357,7 +30357,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_scanned_tuples_sum\") / mean(\"tdg_scanned_tuples_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_scanned_tuples_sum\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_scanned_tuples_sum' AND \"label_pairs_alias\" =~ /^$alias$/) AND $timeFilter),\n(SELECT \"value\" as \"tdg_scanned_tuples_count\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_scanned_tuples_count' AND \"label_pairs_alias\" =~ /^$alias$/) AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_type_name\" fill(null)\n",
+                     "query": "SELECT mean(\"tdg_scanned_tuples_sum\") / mean(\"tdg_scanned_tuples_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_scanned_tuples_sum\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_scanned_tuples_sum' AND \"label_pairs_alias\" =~ /^$alias$/) AND $timeFilter),\n(SELECT \"value\" as \"tdg_scanned_tuples_count\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_scanned_tuples_count' AND \"label_pairs_alias\" =~ /^$alias$/) AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_type_name\" fill(none)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -30461,7 +30461,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_returned_tuples_sum\") / mean(\"tdg_returned_tuples_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_returned_tuples_sum\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_returned_tuples_sum' AND \"label_pairs_alias\" =~ /^$alias$/) AND $timeFilter),\n(SELECT \"value\" as \"tdg_returned_tuples_count\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_returned_tuples_count' AND \"label_pairs_alias\" =~ /^$alias$/) AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_type_name\" fill(null)\n",
+                     "query": "SELECT mean(\"tdg_returned_tuples_sum\") / mean(\"tdg_returned_tuples_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_returned_tuples_sum\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_returned_tuples_sum' AND \"label_pairs_alias\" =~ /^$alias$/) AND $timeFilter),\n(SELECT \"value\" as \"tdg_returned_tuples_count\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_returned_tuples_count' AND \"label_pairs_alias\" =~ /^$alias$/) AND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_type_name\" fill(none)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -30566,7 +30566,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -30703,7 +30703,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -30866,7 +30866,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -31009,7 +31009,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -31152,7 +31152,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -31294,7 +31294,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -31434,7 +31434,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -31575,7 +31575,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -31749,7 +31749,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -31889,7 +31889,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_graphql_query_time_sum\") / mean(\"tdg_graphql_query_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_graphql_query_time_sum\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_graphql_query_time_sum' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter),\n(SELECT \"value\" as \"tdg_graphql_query_time_count\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_graphql_query_time_count' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_operation_name\",\n\"label_pairs_schema\", \"label_pairs_entity\" fill(null)\n",
+                     "query": "SELECT mean(\"tdg_graphql_query_time_sum\") / mean(\"tdg_graphql_query_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_graphql_query_time_sum\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_graphql_query_time_sum' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter),\n(SELECT \"value\" as \"tdg_graphql_query_time_count\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_graphql_query_time_count' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_operation_name\",\n\"label_pairs_schema\", \"label_pairs_entity\" fill(none)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -32011,7 +32011,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -32169,7 +32169,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -32309,7 +32309,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_graphql_mutation_time_sum\") / mean(\"tdg_graphql_mutation_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_graphql_mutation_time_sum\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_graphql_mutation_time_sum' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter),\n(SELECT \"value\" as \"tdg_graphql_mutation_time_count\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_graphql_mutation_time_count' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_operation_name\",\n\"label_pairs_schema\", \"label_pairs_entity\" fill(null)\n",
+                     "query": "SELECT mean(\"tdg_graphql_mutation_time_sum\") / mean(\"tdg_graphql_mutation_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_graphql_mutation_time_sum\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_graphql_mutation_time_sum' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter),\n(SELECT \"value\" as \"tdg_graphql_mutation_time_count\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_graphql_mutation_time_count' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_operation_name\",\n\"label_pairs_schema\", \"label_pairs_entity\" fill(none)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -32431,7 +32431,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -32597,7 +32597,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -32749,7 +32749,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -32901,7 +32901,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -33053,7 +33053,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -33205,7 +33205,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -33357,7 +33357,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -33509,7 +33509,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -33661,7 +33661,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -33813,7 +33813,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -33965,7 +33965,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -34117,7 +34117,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -34269,7 +34269,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -34421,7 +34421,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -34573,7 +34573,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -34725,7 +34725,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -34877,7 +34877,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -35029,7 +35029,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -35181,7 +35181,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -35365,7 +35365,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -35535,7 +35535,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -35705,7 +35705,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -35875,7 +35875,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -36045,7 +36045,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -36215,7 +36215,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -36385,7 +36385,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -36555,7 +36555,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -36725,7 +36725,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -36895,7 +36895,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -37065,7 +37065,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -37235,7 +37235,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -37413,7 +37413,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -37559,7 +37559,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -37705,7 +37705,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -37851,7 +37851,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -37985,7 +37985,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_jobs_execution_time_sum\") / mean(\"tdg_jobs_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_jobs_execution_time_sum\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_jobs_execution_time_sum' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter),\n(SELECT \"value\" as \"tdg_jobs_execution_time_count\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_jobs_execution_time_count' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\" fill(null)\n",
+                     "query": "SELECT mean(\"tdg_jobs_execution_time_sum\") / mean(\"tdg_jobs_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_jobs_execution_time_sum\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_jobs_execution_time_sum' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter),\n(SELECT \"value\" as \"tdg_jobs_execution_time_count\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_jobs_execution_time_count' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\" fill(none)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -38101,7 +38101,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -38253,7 +38253,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -38405,7 +38405,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -38557,7 +38557,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -38709,7 +38709,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -38843,7 +38843,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_tasks_execution_time_sum\") / mean(\"tdg_tasks_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_tasks_execution_time_sum\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_tasks_execution_time_sum' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter),\n(SELECT \"value\" as \"tdg_tasks_execution_time_count\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_tasks_execution_time_count' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\",\n\"label_pairs_kind\" fill(null)\n",
+                     "query": "SELECT mean(\"tdg_tasks_execution_time_sum\") / mean(\"tdg_tasks_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_tasks_execution_time_sum\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_tasks_execution_time_sum' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter),\n(SELECT \"value\" as \"tdg_tasks_execution_time_count\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_tasks_execution_time_count' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\",\n\"label_pairs_kind\" fill(none)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",
@@ -38959,7 +38959,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -39111,7 +39111,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -39263,7 +39263,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -39415,7 +39415,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -39549,7 +39549,7 @@
                         }
                      ],
                      "policy": "default",
-                     "query": "SELECT mean(\"tdg_system_tasks_execution_time_sum\") / mean(\"tdg_system_tasks_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_system_tasks_execution_time_sum\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_system_tasks_execution_time_sum' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter),\n(SELECT \"value\" as \"tdg_system_tasks_execution_time_count\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_system_tasks_execution_time_count' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\",\n\"label_pairs_kind\" fill(null)\n",
+                     "query": "SELECT mean(\"tdg_system_tasks_execution_time_sum\") / mean(\"tdg_system_tasks_execution_time_count\")\nas \"average\" FROM\n(SELECT \"value\" as \"tdg_system_tasks_execution_time_sum\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_system_tasks_execution_time_sum' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter),\n(SELECT \"value\" as \"tdg_system_tasks_execution_time_count\" FROM \"$policy\".\"$measurement\"\nWHERE (\"metric_name\" = 'tdg_system_tasks_execution_time_count' AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter)\nGROUP BY time($__interval), \"label_pairs_alias\", \"label_pairs_name\",\n\"label_pairs_kind\" fill(none)\n",
                      "rawQuery": true,
                      "refId": "A",
                      "resultFormat": "time_series",

--- a/tests/InfluxDB/dashboard_with_custom_panels.jsonnet
+++ b/tests/InfluxDB/dashboard_with_custom_panels.jsonnet
@@ -59,7 +59,7 @@ dashboard(cfg).addPanels([
       measurement=cfg.measurement,
       group_tags=['label_pairs_alias'],
       alias='$tag_label_pairs_alias',
-      fill='null',
+      fill='none',
     ).where('metric_name', '=', 'my_component_load_metric')
     .where('label_pairs_alias', '=~', cfg.filters.label_pairs_alias[1])
     .where('label_pairs_quantile', '=', '0.99')

--- a/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
+++ b/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
@@ -169,7 +169,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -346,7 +346,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -448,7 +448,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -585,7 +585,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -722,7 +722,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -945,7 +945,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1052,7 +1052,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1187,7 +1187,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1324,7 +1324,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1460,7 +1460,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1649,7 +1649,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1788,7 +1788,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -1952,7 +1952,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2116,7 +2116,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2280,7 +2280,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2444,7 +2444,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2608,7 +2608,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2774,7 +2774,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -2908,7 +2908,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3048,7 +3048,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3188,7 +3188,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3329,7 +3329,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3465,7 +3465,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3606,7 +3606,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3742,7 +3742,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -3883,7 +3883,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4019,7 +4019,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4160,7 +4160,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4302,7 +4302,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4448,7 +4448,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4594,7 +4594,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4741,7 +4741,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -4883,7 +4883,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5029,7 +5029,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5175,7 +5175,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5322,7 +5322,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5465,7 +5465,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5608,7 +5608,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5778,7 +5778,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -5912,7 +5912,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6046,7 +6046,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6180,7 +6180,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6314,7 +6314,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6448,7 +6448,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6582,7 +6582,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6716,7 +6716,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -6850,7 +6850,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7004,7 +7004,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7144,7 +7144,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7284,7 +7284,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7424,7 +7424,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7564,7 +7564,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7704,7 +7704,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7844,7 +7844,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -7984,7 +7984,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8124,7 +8124,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8264,7 +8264,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8404,7 +8404,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8544,7 +8544,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8684,7 +8684,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8824,7 +8824,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -8964,7 +8964,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9105,7 +9105,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9247,7 +9247,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9388,7 +9388,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9530,7 +9530,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9671,7 +9671,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9813,7 +9813,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -9954,7 +9954,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10096,7 +10096,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10237,7 +10237,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10379,7 +10379,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10520,7 +10520,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10662,7 +10662,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10829,7 +10829,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -10978,7 +10978,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11126,7 +11126,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11278,7 +11278,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11418,7 +11418,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11578,7 +11578,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11712,7 +11712,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11846,7 +11846,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -11980,7 +11980,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12114,7 +12114,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12248,7 +12248,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12382,7 +12382,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12516,7 +12516,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12650,7 +12650,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12784,7 +12784,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -12918,7 +12918,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13052,7 +13052,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13192,7 +13192,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13332,7 +13332,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13473,7 +13473,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13609,7 +13609,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13749,7 +13749,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -13895,7 +13895,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14035,7 +14035,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14195,7 +14195,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14336,7 +14336,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14497,7 +14497,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14631,7 +14631,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14765,7 +14765,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -14899,7 +14899,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15033,7 +15033,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15168,7 +15168,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15304,7 +15304,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15438,7 +15438,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15592,7 +15592,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15732,7 +15732,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -15872,7 +15872,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16012,7 +16012,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16146,7 +16146,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16286,7 +16286,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16426,7 +16426,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16566,7 +16566,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16706,7 +16706,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16846,7 +16846,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -16986,7 +16986,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17126,7 +17126,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17267,7 +17267,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17404,7 +17404,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17541,7 +17541,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17678,7 +17678,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17814,7 +17814,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -17948,7 +17948,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18088,7 +18088,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18248,7 +18248,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18394,7 +18394,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18540,7 +18540,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18686,7 +18686,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18832,7 +18832,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -18978,7 +18978,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -19124,7 +19124,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -19270,7 +19270,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -19416,7 +19416,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -19562,7 +19562,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -19708,7 +19708,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -19854,7 +19854,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20000,7 +20000,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20146,7 +20146,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20292,7 +20292,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20464,7 +20464,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20622,7 +20622,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20780,7 +20780,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -20938,7 +20938,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -21304,7 +21304,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -21456,7 +21456,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -21614,7 +21614,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -21772,7 +21772,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -21930,7 +21930,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -22088,7 +22088,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -22246,7 +22246,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -22404,7 +22404,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -22562,7 +22562,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -22720,7 +22720,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -22878,7 +22878,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -23036,7 +23036,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -23194,7 +23194,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -23352,7 +23352,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -23510,7 +23510,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -23668,7 +23668,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -23826,7 +23826,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -23984,7 +23984,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -24142,7 +24142,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -24300,7 +24300,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -24458,7 +24458,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -24616,7 +24616,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -24774,7 +24774,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -24932,7 +24932,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -25090,7 +25090,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -25248,7 +25248,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -25406,7 +25406,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -25564,7 +25564,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -25722,7 +25722,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -25880,7 +25880,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -26038,7 +26038,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -26196,7 +26196,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -26354,7 +26354,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -26512,7 +26512,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -26670,7 +26670,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -26828,7 +26828,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -26986,7 +26986,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -27144,7 +27144,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -27302,7 +27302,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -27460,7 +27460,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -27618,7 +27618,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -27776,7 +27776,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -27934,7 +27934,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -28092,7 +28092,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -28250,7 +28250,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -28408,7 +28408,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -28566,7 +28566,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -28724,7 +28724,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -28882,7 +28882,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -29040,7 +29040,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -29198,7 +29198,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -29356,7 +29356,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -29514,7 +29514,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -29692,7 +29692,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -29838,7 +29838,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -29985,7 +29985,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -30127,7 +30127,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -30281,7 +30281,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -30415,7 +30415,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }
@@ -30555,7 +30555,7 @@
                         },
                         {
                            "params": [
-                              "null"
+                              "none"
                            ],
                            "type": "fill"
                         }


### PR DESCRIPTION
On lower timescales data with `fill(null)` seems like a scattered set of dots. Data with `fill(none)` seems fine like a line string. I don't remember these issues on older Grafana versions, so it is possible that something had changed with visualization even for deprecated graph panels.

### Before

![image](https://github.com/tarantool/grafana-dashboard/assets/20455996/0c589769-dabb-4a04-97c9-f0eb2b464951)

### After

![image](https://github.com/tarantool/grafana-dashboard/assets/20455996/7679c431-844b-467b-afb5-2995ffe54f61)
