### PR TITLE
dashboard: fix cluster overview for Grafana 11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Use Grafana 11 color scheme for Prometheus cluster overview panel (#234)
+- Drop Grafana 8 support (#234)
+- Bump recommended requirements to Grafana 11 (#234)
+
 ### Fixed
 - Prometheus cluster overview panel not works for Grafana 11+ (#234)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Prometheus cluster overview panel not works for Grafana 11+ (#234)
+
+
 ## [3.1.0] - 2024-07-09
 Grafana revisions:
 - Tarantool 3:

--- a/dashboard/build/dashboard.libsonnet
+++ b/dashboard/build/dashboard.libsonnet
@@ -170,7 +170,7 @@ function(cfg) std.foldl(
         type='grafana',
         id='grafana',
         name='Grafana',
-        version='8.0.0'
+        version='9.0.0'
       ).addRequired(
         type='panel',
         id='graph',

--- a/dashboard/panels/cluster.libsonnet
+++ b/dashboard/panels/cluster.libsonnet
@@ -64,13 +64,31 @@ local prometheus = grafana.prometheus;
         type: 'number',
         unit: 's',
       },
+      {
+        alias: 'job',
+        pattern: 'job',
+        thresholds: [],
+        type: 'hidden',
+      },
+      {
+        alias: 'Time',
+        pattern: 'Time',
+        thresholds: [],
+        type: 'hidden',
+      },
+      {
+        alias: '__name__',
+        pattern: '__name__',
+        thresholds: [],
+        type: 'hidden',
+      },
     ],
     sort={
       col: 2,
       desc: false,
     },
     transform='table',
-  ).hideColumn('job').hideColumn('/.*/').addTarget(
+  ).addTarget(
     if cfg.type == variable.datasource_type.prometheus then
       prometheus.target(
         expr=if std.objectHas(cfg.filters, 'job') then

--- a/dashboard/panels/cluster.libsonnet
+++ b/dashboard/panels/cluster.libsonnet
@@ -27,62 +27,17 @@ local prometheus = grafana.prometheus;
       Instance alias filtering is disabled here.
 
       If Prometheus job filter is not specified, displays running instances
-      and ignores unreachable instances (we have no specific source to fetch)
+      and ignores unreachable instances (we have no specific source to fetch).
+
+      Color scheme is expected to work properly only for Grafana 11+.
     |||),
   ):: tablePanel.new(
     title=title,
     description=description,
     datasource=cfg.datasource,
 
-    styles=[
-      {
-        alias: 'Instance alias',
-        pattern: 'alias',
-        thresholds: [],
-        type: 'string',
-        mappingType: 1,
-      },
-      {
-        alias: 'Instance URI',
-        pattern: 'instance',
-        thresholds: [],
-        type: 'string',
-        mappingType: 1,
-      },
-      {
-        alias: 'Uptime',
-        colorMode: 'row',
-        colors: [
-          'rgba(245, 54, 54, 0.9)',
-          'rgba(237, 129, 40, 0.89)',
-          'rgba(50, 172, 45, 0.97)',
-        ],
-        decimals: 0,
-        mappingType: 1,
-        pattern: 'Value',
-        thresholds: ['0.1', '0.1'],
-        type: 'number',
-        unit: 's',
-      },
-      {
-        alias: 'job',
-        pattern: 'job',
-        thresholds: [],
-        type: 'hidden',
-      },
-      {
-        alias: 'Time',
-        pattern: 'Time',
-        thresholds: [],
-        type: 'hidden',
-      },
-      {
-        alias: '__name__',
-        pattern: '__name__',
-        thresholds: [],
-        type: 'hidden',
-      },
-    ],
+    styles=null,
+
     sort={
       col: 2,
       desc: false,
@@ -114,7 +69,163 @@ local prometheus = grafana.prometheus;
       )
     else if cfg.type == variable.datasource_type.influxdb then
       error 'InfluxDB target is not supported yet'
-  ) { gridPos: { w: 12, h: 8 } },
+  ) {
+    // Workaround is expected to be removed after migrating to
+    // https://github.com/tarantool/grafana-dashboard/issues/215
+    fieldConfig: {
+      defaults: {
+        custom: {
+          cellOptions: {
+            type: 'auto',
+          },
+          inspect: false,
+        },
+        mappings: [],
+        thresholds: {
+          mode: 'absolute',
+          steps: [
+            {
+              color: 'green',
+              value: null,
+            },
+            {
+              color: 'red',
+              value: 80,
+            },
+          ],
+        },
+      },
+      overrides: [
+        {
+          matcher: {
+            id: 'byName',
+            options: 'alias',
+          },
+          properties: [
+            {
+              id: 'displayName',
+              value: 'Instance alias',
+            },
+            {
+              id: 'custom.align',
+            },
+          ],
+        },
+        {
+          matcher: {
+            id: 'byName',
+            options: 'instance',
+          },
+          properties: [
+            {
+              id: 'displayName',
+              value: 'Instance URI',
+            },
+            {
+              id: 'custom.align',
+            },
+          ],
+        },
+        {
+          matcher: {
+            id: 'byName',
+            options: 'Value',
+          },
+          properties: [
+            {
+              id: 'displayName',
+              value: 'Uptime',
+            },
+            {
+              id: 'unit',
+              value: 's',
+            },
+            {
+              id: 'custom.cellOptions',
+              value: {
+                applyToRow: true,
+                type: 'color-background',
+              },
+            },
+            {
+              id: 'custom.align',
+            },
+            {
+              id: 'thresholds',
+              value: {
+                mode: 'absolute',
+                steps: [
+                  {
+                    color: 'rgba(245, 54, 54, 0.9)',
+                    value: null,
+                  },
+                  {
+                    color: 'rgba(50, 172, 45, 0.97)',
+                    value: 0.1,
+                  },
+                ],
+              },
+            },
+          ],
+        },
+        {
+          matcher: {
+            id: 'byName',
+            options: 'job',
+          },
+          properties: [
+            {
+              id: 'displayName',
+              value: 'job',
+            },
+            {
+              id: 'custom.hidden',
+              value: true,
+            },
+            {
+              id: 'custom.align',
+            },
+          ],
+        },
+        {
+          matcher: {
+            id: 'byName',
+            options: 'job',
+          },
+          properties: [
+            {
+              id: 'custom.hidden',
+              value: true,
+            },
+          ],
+        },
+        {
+          matcher: {
+            id: 'byName',
+            options: 'Time',
+          },
+          properties: [
+            {
+              id: 'custom.hidden',
+              value: true,
+            },
+          ],
+        },
+        {
+          matcher: {
+            id: 'byName',
+            options: '__name__',
+          },
+          properties: [
+            {
+              id: 'custom.hidden',
+              value: true,
+            },
+          ],
+        },
+      ],
+    },
+  } { gridPos: { w: 12, h: 8 } },
 
   local title_workaround(  // Workaround for missing options.fieldOptions.defaults.title https://github.com/grafana/grafonnet-lib/pull/260
     stat_panel,

--- a/docker-compose.cartridge.yml
+++ b/docker-compose.cartridge.yml
@@ -58,7 +58,7 @@ services:
       - ./example_cluster/prometheus/alerts.yml:/etc/prometheus/cartridge_alerts.yml
 
   grafana:
-    image: grafana/grafana:8.1.3
+    image: grafana/grafana:11.2.2
     environment: 
       GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION: "true"
       GF_AUTH_ANONYMOUS_ENABLED: "true"

--- a/docker-compose.cartridge.yml
+++ b/docker-compose.cartridge.yml
@@ -48,7 +48,7 @@ services:
       - 8086:8086
 
   prometheus:
-    image: prom/prometheus:v2.17.2
+    image: prom/prometheus:v2.53.1
     networks:
       tarantool_dashboard_dev:
     ports:

--- a/docker-compose.localapp.yml
+++ b/docker-compose.localapp.yml
@@ -37,7 +37,7 @@ services:
       - ./example_cluster/prometheus/alerts.yml:/etc/prometheus/alerts.yml
 
   grafana:
-    image: grafana/grafana:8.1.5
+    image: grafana/grafana:11.2.2
     environment: 
       GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION: "true"
       GF_AUTH_ANONYMOUS_ENABLED: "true"

--- a/docker-compose.localapp.yml
+++ b/docker-compose.localapp.yml
@@ -25,7 +25,7 @@ services:
       - 8086:8086
 
   prometheus:
-    image: prom/prometheus:v2.17.2
+    image: prom/prometheus:v2.53.1
     networks:
       tarantool_dashboard_dev:
     extra_hosts:

--- a/docker-compose.tdg.yml
+++ b/docker-compose.tdg.yml
@@ -56,7 +56,7 @@ services:
       - 8086:8086
 
   prometheus:
-    image: prom/prometheus:v2.17.2
+    image: prom/prometheus:v2.53.1
     networks:
       tarantool_dashboard_dev:
     ports:

--- a/docker-compose.tdg.yml
+++ b/docker-compose.tdg.yml
@@ -65,7 +65,7 @@ services:
       - ./example_cluster/prometheus/prometheus.tdg.yml:/etc/prometheus/prometheus.yml
 
   grafana:
-    image: grafana/grafana:8.1.5
+    image: grafana/grafana:11.2.2
     environment: 
       GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION: "true"
       GF_AUTH_ANONYMOUS_ENABLED: "true"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       - 8086:8086
 
   prometheus:
-    image: prom/prometheus:v2.17.2
+    image: prom/prometheus:v2.53.1
     networks:
       tarantool_dashboard_dev:
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       - ./example_cluster/prometheus/alerts.yml:/etc/prometheus/alerts.yml
 
   grafana:
-    image: grafana/grafana:8.1.3
+    image: grafana/grafana:11.2.2
     environment: 
       GF_SECURITY_DISABLE_INITIAL_ADMIN_CREATION: "true"
       GF_AUTH_ANONYMOUS_ENABLED: "true"

--- a/example_cluster/tarantool3_project/app.Dockerfile
+++ b/example_cluster/tarantool3_project/app.Dockerfile
@@ -17,7 +17,7 @@ RUN curl -L https://tarantool.io/release/3/installer.sh | bash
 RUN DEBIAN_FRONTEND=noninteractive apt install -y tarantool tarantool-dev tt
 
 RUN tt init
-# Need tt log
+# Need tt start -i
 RUN DEBIAN_FRONTEND=noninteractive apt install -y git patch
 RUN git clone https://github.com/magefile/mage && \
     cd mage && \
@@ -25,4 +25,4 @@ RUN git clone https://github.com/magefile/mage && \
 RUN tt install tt master
 
 RUN tt rocks make
-ENTRYPOINT tt start && tt log -f
+ENTRYPOINT tt start -i

--- a/tests/InfluxDB/dashboard_cartridge_compiled.json
+++ b/tests/InfluxDB/dashboard_cartridge_compiled.json
@@ -5,7 +5,7 @@
          "id": "grafana",
          "name": "Grafana",
          "type": "grafana",
-         "version": "8.0.0"
+         "version": "9.0.0"
       },
       {
          "id": "graph",

--- a/tests/InfluxDB/dashboard_custom_compiled.json
+++ b/tests/InfluxDB/dashboard_custom_compiled.json
@@ -5,7 +5,7 @@
          "id": "grafana",
          "name": "Grafana",
          "type": "grafana",
-         "version": "8.0.0"
+         "version": "9.0.0"
       },
       {
          "id": "graph",

--- a/tests/InfluxDB/dashboard_tarantool3_compiled.json
+++ b/tests/InfluxDB/dashboard_tarantool3_compiled.json
@@ -5,7 +5,7 @@
          "id": "grafana",
          "name": "Grafana",
          "type": "grafana",
-         "version": "8.0.0"
+         "version": "9.0.0"
       },
       {
          "id": "graph",

--- a/tests/InfluxDB/dashboard_tdg_compiled.json
+++ b/tests/InfluxDB/dashboard_tdg_compiled.json
@@ -5,7 +5,7 @@
          "id": "grafana",
          "name": "Grafana",
          "type": "grafana",
-         "version": "8.0.0"
+         "version": "9.0.0"
       },
       {
          "id": "graph",

--- a/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
+++ b/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
@@ -5,7 +5,7 @@
          "id": "grafana",
          "name": "Grafana",
          "type": "grafana",
-         "version": "8.0.0"
+         "version": "9.0.0"
       },
       {
          "id": "graph",

--- a/tests/Prometheus/dashboard_cartridge_compiled.json
+++ b/tests/Prometheus/dashboard_cartridge_compiled.json
@@ -118,11 +118,19 @@
                   {
                      "alias": "job",
                      "pattern": "job",
+                     "thresholds": [ ],
                      "type": "hidden"
                   },
                   {
-                     "alias": "/.*/",
-                     "pattern": "/.*/",
+                     "alias": "Time",
+                     "pattern": "Time",
+                     "thresholds": [ ],
+                     "type": "hidden"
+                  },
+                  {
+                     "alias": "__name__",
+                     "pattern": "__name__",
+                     "thresholds": [ ],
                      "type": "hidden"
                   }
                ],

--- a/tests/Prometheus/dashboard_cartridge_compiled.json
+++ b/tests/Prometheus/dashboard_cartridge_compiled.json
@@ -5,7 +5,7 @@
          "id": "grafana",
          "name": "Grafana",
          "type": "grafana",
-         "version": "8.0.0"
+         "version": "9.0.0"
       },
       {
          "id": "graph",
@@ -69,7 +69,160 @@
             {
                "columns": [ ],
                "datasource": "$prometheus",
-               "description": "Overview of Tarantool instances observed by Prometheus job.\n\nIf instance row is *red*, it means Prometheus can't reach\nURI specified in targets or ran into error.\nIf instance row is *green*, it means instance is up and running and\nPrometheus is successfully extracting metrics from it.\n\"Uptime\" column shows time since instant start.\n\nInstance alias filtering is disabled here.\n\nIf Prometheus job filter is not specified, displays running instances\nand ignores unreachable instances (we have no specific source to fetch)\n\nThis panel is designed to work with Prometheus client\nset up to have each Tarantool instance as a separate pull target.\n",
+               "description": "Overview of Tarantool instances observed by Prometheus job.\n\nIf instance row is *red*, it means Prometheus can't reach\nURI specified in targets or ran into error.\nIf instance row is *green*, it means instance is up and running and\nPrometheus is successfully extracting metrics from it.\n\"Uptime\" column shows time since instant start.\n\nInstance alias filtering is disabled here.\n\nIf Prometheus job filter is not specified, displays running instances\nand ignores unreachable instances (we have no specific source to fetch).\n\nColor scheme is expected to work properly only for Grafana 11+.\n\nThis panel is designed to work with Prometheus client\nset up to have each Tarantool instance as a separate pull target.\n",
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "cellOptions": {
+                           "type": "auto"
+                        },
+                        "inspect": false
+                     },
+                     "mappings": [ ],
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                           {
+                              "color": "green",
+                              "value": null
+                           },
+                           {
+                              "color": "red",
+                              "value": 80
+                           }
+                        ]
+                     }
+                  },
+                  "overrides": [
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "alias"
+                        },
+                        "properties": [
+                           {
+                              "id": "displayName",
+                              "value": "Instance alias"
+                           },
+                           {
+                              "id": "custom.align"
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "instance"
+                        },
+                        "properties": [
+                           {
+                              "id": "displayName",
+                              "value": "Instance URI"
+                           },
+                           {
+                              "id": "custom.align"
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "Value"
+                        },
+                        "properties": [
+                           {
+                              "id": "displayName",
+                              "value": "Uptime"
+                           },
+                           {
+                              "id": "unit",
+                              "value": "s"
+                           },
+                           {
+                              "id": "custom.cellOptions",
+                              "value": {
+                                 "applyToRow": true,
+                                 "type": "color-background"
+                              }
+                           },
+                           {
+                              "id": "custom.align"
+                           },
+                           {
+                              "id": "thresholds",
+                              "value": {
+                                 "mode": "absolute",
+                                 "steps": [
+                                    {
+                                       "color": "rgba(245, 54, 54, 0.9)",
+                                       "value": null
+                                    },
+                                    {
+                                       "color": "rgba(50, 172, 45, 0.97)",
+                                       "value": 0.10000000000000001
+                                    }
+                                 ]
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "job"
+                        },
+                        "properties": [
+                           {
+                              "id": "displayName",
+                              "value": "job"
+                           },
+                           {
+                              "id": "custom.hidden",
+                              "value": true
+                           },
+                           {
+                              "id": "custom.align"
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "job"
+                        },
+                        "properties": [
+                           {
+                              "id": "custom.hidden",
+                              "value": true
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "Time"
+                        },
+                        "properties": [
+                           {
+                              "id": "custom.hidden",
+                              "value": true
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "__name__"
+                        },
+                        "properties": [
+                           {
+                              "id": "custom.hidden",
+                              "value": true
+                           }
+                        ]
+                     }
+                  ]
+               },
                "gridPos": {
                   "h": 8,
                   "w": 12,
@@ -82,58 +235,7 @@
                   "col": 2,
                   "desc": false
                },
-               "styles": [
-                  {
-                     "alias": "Instance alias",
-                     "mappingType": 1,
-                     "pattern": "alias",
-                     "thresholds": [ ],
-                     "type": "string"
-                  },
-                  {
-                     "alias": "Instance URI",
-                     "mappingType": 1,
-                     "pattern": "instance",
-                     "thresholds": [ ],
-                     "type": "string"
-                  },
-                  {
-                     "alias": "Uptime",
-                     "colorMode": "row",
-                     "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                     ],
-                     "decimals": 0,
-                     "mappingType": 1,
-                     "pattern": "Value",
-                     "thresholds": [
-                        "0.1",
-                        "0.1"
-                     ],
-                     "type": "number",
-                     "unit": "s"
-                  },
-                  {
-                     "alias": "job",
-                     "pattern": "job",
-                     "thresholds": [ ],
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "Time",
-                     "pattern": "Time",
-                     "thresholds": [ ],
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "__name__",
-                     "pattern": "__name__",
-                     "thresholds": [ ],
-                     "type": "hidden"
-                  }
-               ],
+               "styles": null,
                "targets": [
                   {
                      "expr": "up{job=~\"$job\"} * on(instance) group_left(alias) tnt_info_uptime{job=~\"$job\"} or\non(instance) label_replace(up{job=~\"$job\"}, \"alias\", \"Not available\", \"instance\", \".*\")\n",

--- a/tests/Prometheus/dashboard_custom_compiled.json
+++ b/tests/Prometheus/dashboard_custom_compiled.json
@@ -118,11 +118,19 @@
                   {
                      "alias": "job",
                      "pattern": "job",
+                     "thresholds": [ ],
                      "type": "hidden"
                   },
                   {
-                     "alias": "/.*/",
-                     "pattern": "/.*/",
+                     "alias": "Time",
+                     "pattern": "Time",
+                     "thresholds": [ ],
+                     "type": "hidden"
+                  },
+                  {
+                     "alias": "__name__",
+                     "pattern": "__name__",
+                     "thresholds": [ ],
                      "type": "hidden"
                   }
                ],

--- a/tests/Prometheus/dashboard_custom_compiled.json
+++ b/tests/Prometheus/dashboard_custom_compiled.json
@@ -5,7 +5,7 @@
          "id": "grafana",
          "name": "Grafana",
          "type": "grafana",
-         "version": "8.0.0"
+         "version": "9.0.0"
       },
       {
          "id": "graph",
@@ -69,7 +69,160 @@
             {
                "columns": [ ],
                "datasource": "$prometheus",
-               "description": "Overview of Tarantool instances observed by Prometheus job.\n\nIf instance row is *red*, it means Prometheus can't reach\nURI specified in targets or ran into error.\nIf instance row is *green*, it means instance is up and running and\nPrometheus is successfully extracting metrics from it.\n\"Uptime\" column shows time since instant start.\n\nInstance alias filtering is disabled here.\n\nIf Prometheus job filter is not specified, displays running instances\nand ignores unreachable instances (we have no specific source to fetch)\n\nThis panel is designed to work with Prometheus client\nset up to have each Tarantool instance as a separate pull target.\n",
+               "description": "Overview of Tarantool instances observed by Prometheus job.\n\nIf instance row is *red*, it means Prometheus can't reach\nURI specified in targets or ran into error.\nIf instance row is *green*, it means instance is up and running and\nPrometheus is successfully extracting metrics from it.\n\"Uptime\" column shows time since instant start.\n\nInstance alias filtering is disabled here.\n\nIf Prometheus job filter is not specified, displays running instances\nand ignores unreachable instances (we have no specific source to fetch).\n\nColor scheme is expected to work properly only for Grafana 11+.\n\nThis panel is designed to work with Prometheus client\nset up to have each Tarantool instance as a separate pull target.\n",
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "cellOptions": {
+                           "type": "auto"
+                        },
+                        "inspect": false
+                     },
+                     "mappings": [ ],
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                           {
+                              "color": "green",
+                              "value": null
+                           },
+                           {
+                              "color": "red",
+                              "value": 80
+                           }
+                        ]
+                     }
+                  },
+                  "overrides": [
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "alias"
+                        },
+                        "properties": [
+                           {
+                              "id": "displayName",
+                              "value": "Instance alias"
+                           },
+                           {
+                              "id": "custom.align"
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "instance"
+                        },
+                        "properties": [
+                           {
+                              "id": "displayName",
+                              "value": "Instance URI"
+                           },
+                           {
+                              "id": "custom.align"
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "Value"
+                        },
+                        "properties": [
+                           {
+                              "id": "displayName",
+                              "value": "Uptime"
+                           },
+                           {
+                              "id": "unit",
+                              "value": "s"
+                           },
+                           {
+                              "id": "custom.cellOptions",
+                              "value": {
+                                 "applyToRow": true,
+                                 "type": "color-background"
+                              }
+                           },
+                           {
+                              "id": "custom.align"
+                           },
+                           {
+                              "id": "thresholds",
+                              "value": {
+                                 "mode": "absolute",
+                                 "steps": [
+                                    {
+                                       "color": "rgba(245, 54, 54, 0.9)",
+                                       "value": null
+                                    },
+                                    {
+                                       "color": "rgba(50, 172, 45, 0.97)",
+                                       "value": 0.10000000000000001
+                                    }
+                                 ]
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "job"
+                        },
+                        "properties": [
+                           {
+                              "id": "displayName",
+                              "value": "job"
+                           },
+                           {
+                              "id": "custom.hidden",
+                              "value": true
+                           },
+                           {
+                              "id": "custom.align"
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "job"
+                        },
+                        "properties": [
+                           {
+                              "id": "custom.hidden",
+                              "value": true
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "Time"
+                        },
+                        "properties": [
+                           {
+                              "id": "custom.hidden",
+                              "value": true
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "__name__"
+                        },
+                        "properties": [
+                           {
+                              "id": "custom.hidden",
+                              "value": true
+                           }
+                        ]
+                     }
+                  ]
+               },
                "gridPos": {
                   "h": 8,
                   "w": 12,
@@ -82,58 +235,7 @@
                   "col": 2,
                   "desc": false
                },
-               "styles": [
-                  {
-                     "alias": "Instance alias",
-                     "mappingType": 1,
-                     "pattern": "alias",
-                     "thresholds": [ ],
-                     "type": "string"
-                  },
-                  {
-                     "alias": "Instance URI",
-                     "mappingType": 1,
-                     "pattern": "instance",
-                     "thresholds": [ ],
-                     "type": "string"
-                  },
-                  {
-                     "alias": "Uptime",
-                     "colorMode": "row",
-                     "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                     ],
-                     "decimals": 0,
-                     "mappingType": 1,
-                     "pattern": "Value",
-                     "thresholds": [
-                        "0.1",
-                        "0.1"
-                     ],
-                     "type": "number",
-                     "unit": "s"
-                  },
-                  {
-                     "alias": "job",
-                     "pattern": "job",
-                     "thresholds": [ ],
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "Time",
-                     "pattern": "Time",
-                     "thresholds": [ ],
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "__name__",
-                     "pattern": "__name__",
-                     "thresholds": [ ],
-                     "type": "hidden"
-                  }
-               ],
+               "styles": null,
                "targets": [
                   {
                      "expr": "vendor_tt_tnt_info_uptime{vendor_app_label=\"MyCacheApplication\"}",

--- a/tests/Prometheus/dashboard_tarantool3_compiled.json
+++ b/tests/Prometheus/dashboard_tarantool3_compiled.json
@@ -118,11 +118,19 @@
                   {
                      "alias": "job",
                      "pattern": "job",
+                     "thresholds": [ ],
                      "type": "hidden"
                   },
                   {
-                     "alias": "/.*/",
-                     "pattern": "/.*/",
+                     "alias": "Time",
+                     "pattern": "Time",
+                     "thresholds": [ ],
+                     "type": "hidden"
+                  },
+                  {
+                     "alias": "__name__",
+                     "pattern": "__name__",
+                     "thresholds": [ ],
                      "type": "hidden"
                   }
                ],

--- a/tests/Prometheus/dashboard_tarantool3_compiled.json
+++ b/tests/Prometheus/dashboard_tarantool3_compiled.json
@@ -5,7 +5,7 @@
          "id": "grafana",
          "name": "Grafana",
          "type": "grafana",
-         "version": "8.0.0"
+         "version": "9.0.0"
       },
       {
          "id": "graph",
@@ -69,7 +69,160 @@
             {
                "columns": [ ],
                "datasource": "$prometheus",
-               "description": "Overview of Tarantool instances observed by Prometheus job.\n\nIf instance row is *red*, it means Prometheus can't reach\nURI specified in targets or ran into error.\nIf instance row is *green*, it means instance is up and running and\nPrometheus is successfully extracting metrics from it.\n\"Uptime\" column shows time since instant start.\n\nInstance alias filtering is disabled here.\n\nIf Prometheus job filter is not specified, displays running instances\nand ignores unreachable instances (we have no specific source to fetch)\n\nThis panel is designed to work with Prometheus client\nset up to have each Tarantool instance as a separate pull target.\n",
+               "description": "Overview of Tarantool instances observed by Prometheus job.\n\nIf instance row is *red*, it means Prometheus can't reach\nURI specified in targets or ran into error.\nIf instance row is *green*, it means instance is up and running and\nPrometheus is successfully extracting metrics from it.\n\"Uptime\" column shows time since instant start.\n\nInstance alias filtering is disabled here.\n\nIf Prometheus job filter is not specified, displays running instances\nand ignores unreachable instances (we have no specific source to fetch).\n\nColor scheme is expected to work properly only for Grafana 11+.\n\nThis panel is designed to work with Prometheus client\nset up to have each Tarantool instance as a separate pull target.\n",
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "cellOptions": {
+                           "type": "auto"
+                        },
+                        "inspect": false
+                     },
+                     "mappings": [ ],
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                           {
+                              "color": "green",
+                              "value": null
+                           },
+                           {
+                              "color": "red",
+                              "value": 80
+                           }
+                        ]
+                     }
+                  },
+                  "overrides": [
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "alias"
+                        },
+                        "properties": [
+                           {
+                              "id": "displayName",
+                              "value": "Instance alias"
+                           },
+                           {
+                              "id": "custom.align"
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "instance"
+                        },
+                        "properties": [
+                           {
+                              "id": "displayName",
+                              "value": "Instance URI"
+                           },
+                           {
+                              "id": "custom.align"
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "Value"
+                        },
+                        "properties": [
+                           {
+                              "id": "displayName",
+                              "value": "Uptime"
+                           },
+                           {
+                              "id": "unit",
+                              "value": "s"
+                           },
+                           {
+                              "id": "custom.cellOptions",
+                              "value": {
+                                 "applyToRow": true,
+                                 "type": "color-background"
+                              }
+                           },
+                           {
+                              "id": "custom.align"
+                           },
+                           {
+                              "id": "thresholds",
+                              "value": {
+                                 "mode": "absolute",
+                                 "steps": [
+                                    {
+                                       "color": "rgba(245, 54, 54, 0.9)",
+                                       "value": null
+                                    },
+                                    {
+                                       "color": "rgba(50, 172, 45, 0.97)",
+                                       "value": 0.10000000000000001
+                                    }
+                                 ]
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "job"
+                        },
+                        "properties": [
+                           {
+                              "id": "displayName",
+                              "value": "job"
+                           },
+                           {
+                              "id": "custom.hidden",
+                              "value": true
+                           },
+                           {
+                              "id": "custom.align"
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "job"
+                        },
+                        "properties": [
+                           {
+                              "id": "custom.hidden",
+                              "value": true
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "Time"
+                        },
+                        "properties": [
+                           {
+                              "id": "custom.hidden",
+                              "value": true
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "__name__"
+                        },
+                        "properties": [
+                           {
+                              "id": "custom.hidden",
+                              "value": true
+                           }
+                        ]
+                     }
+                  ]
+               },
                "gridPos": {
                   "h": 8,
                   "w": 12,
@@ -82,58 +235,7 @@
                   "col": 2,
                   "desc": false
                },
-               "styles": [
-                  {
-                     "alias": "Instance alias",
-                     "mappingType": 1,
-                     "pattern": "alias",
-                     "thresholds": [ ],
-                     "type": "string"
-                  },
-                  {
-                     "alias": "Instance URI",
-                     "mappingType": 1,
-                     "pattern": "instance",
-                     "thresholds": [ ],
-                     "type": "string"
-                  },
-                  {
-                     "alias": "Uptime",
-                     "colorMode": "row",
-                     "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                     ],
-                     "decimals": 0,
-                     "mappingType": 1,
-                     "pattern": "Value",
-                     "thresholds": [
-                        "0.1",
-                        "0.1"
-                     ],
-                     "type": "number",
-                     "unit": "s"
-                  },
-                  {
-                     "alias": "job",
-                     "pattern": "job",
-                     "thresholds": [ ],
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "Time",
-                     "pattern": "Time",
-                     "thresholds": [ ],
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "__name__",
-                     "pattern": "__name__",
-                     "thresholds": [ ],
-                     "type": "hidden"
-                  }
-               ],
+               "styles": null,
                "targets": [
                   {
                      "expr": "up{job=~\"$job\"} * on(instance) group_left(alias) tnt_info_uptime{job=~\"$job\"} or\non(instance) label_replace(up{job=~\"$job\"}, \"alias\", \"Not available\", \"instance\", \".*\")\n",

--- a/tests/Prometheus/dashboard_tdg_compiled.json
+++ b/tests/Prometheus/dashboard_tdg_compiled.json
@@ -118,11 +118,19 @@
                   {
                      "alias": "job",
                      "pattern": "job",
+                     "thresholds": [ ],
                      "type": "hidden"
                   },
                   {
-                     "alias": "/.*/",
-                     "pattern": "/.*/",
+                     "alias": "Time",
+                     "pattern": "Time",
+                     "thresholds": [ ],
+                     "type": "hidden"
+                  },
+                  {
+                     "alias": "__name__",
+                     "pattern": "__name__",
+                     "thresholds": [ ],
                      "type": "hidden"
                   }
                ],

--- a/tests/Prometheus/dashboard_tdg_compiled.json
+++ b/tests/Prometheus/dashboard_tdg_compiled.json
@@ -5,7 +5,7 @@
          "id": "grafana",
          "name": "Grafana",
          "type": "grafana",
-         "version": "8.0.0"
+         "version": "9.0.0"
       },
       {
          "id": "graph",
@@ -69,7 +69,160 @@
             {
                "columns": [ ],
                "datasource": "$prometheus",
-               "description": "Overview of Tarantool instances observed by Prometheus job.\n\nIf instance row is *red*, it means Prometheus can't reach\nURI specified in targets or ran into error.\nIf instance row is *green*, it means instance is up and running and\nPrometheus is successfully extracting metrics from it.\n\"Uptime\" column shows time since instant start.\n\nInstance alias filtering is disabled here.\n\nIf Prometheus job filter is not specified, displays running instances\nand ignores unreachable instances (we have no specific source to fetch)\n\nThis panel is designed to work with Prometheus client\nset up to have each Tarantool instance as a separate pull target.\n",
+               "description": "Overview of Tarantool instances observed by Prometheus job.\n\nIf instance row is *red*, it means Prometheus can't reach\nURI specified in targets or ran into error.\nIf instance row is *green*, it means instance is up and running and\nPrometheus is successfully extracting metrics from it.\n\"Uptime\" column shows time since instant start.\n\nInstance alias filtering is disabled here.\n\nIf Prometheus job filter is not specified, displays running instances\nand ignores unreachable instances (we have no specific source to fetch).\n\nColor scheme is expected to work properly only for Grafana 11+.\n\nThis panel is designed to work with Prometheus client\nset up to have each Tarantool instance as a separate pull target.\n",
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "cellOptions": {
+                           "type": "auto"
+                        },
+                        "inspect": false
+                     },
+                     "mappings": [ ],
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                           {
+                              "color": "green",
+                              "value": null
+                           },
+                           {
+                              "color": "red",
+                              "value": 80
+                           }
+                        ]
+                     }
+                  },
+                  "overrides": [
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "alias"
+                        },
+                        "properties": [
+                           {
+                              "id": "displayName",
+                              "value": "Instance alias"
+                           },
+                           {
+                              "id": "custom.align"
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "instance"
+                        },
+                        "properties": [
+                           {
+                              "id": "displayName",
+                              "value": "Instance URI"
+                           },
+                           {
+                              "id": "custom.align"
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "Value"
+                        },
+                        "properties": [
+                           {
+                              "id": "displayName",
+                              "value": "Uptime"
+                           },
+                           {
+                              "id": "unit",
+                              "value": "s"
+                           },
+                           {
+                              "id": "custom.cellOptions",
+                              "value": {
+                                 "applyToRow": true,
+                                 "type": "color-background"
+                              }
+                           },
+                           {
+                              "id": "custom.align"
+                           },
+                           {
+                              "id": "thresholds",
+                              "value": {
+                                 "mode": "absolute",
+                                 "steps": [
+                                    {
+                                       "color": "rgba(245, 54, 54, 0.9)",
+                                       "value": null
+                                    },
+                                    {
+                                       "color": "rgba(50, 172, 45, 0.97)",
+                                       "value": 0.10000000000000001
+                                    }
+                                 ]
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "job"
+                        },
+                        "properties": [
+                           {
+                              "id": "displayName",
+                              "value": "job"
+                           },
+                           {
+                              "id": "custom.hidden",
+                              "value": true
+                           },
+                           {
+                              "id": "custom.align"
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "job"
+                        },
+                        "properties": [
+                           {
+                              "id": "custom.hidden",
+                              "value": true
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "Time"
+                        },
+                        "properties": [
+                           {
+                              "id": "custom.hidden",
+                              "value": true
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "__name__"
+                        },
+                        "properties": [
+                           {
+                              "id": "custom.hidden",
+                              "value": true
+                           }
+                        ]
+                     }
+                  ]
+               },
                "gridPos": {
                   "h": 8,
                   "w": 12,
@@ -82,58 +235,7 @@
                   "col": 2,
                   "desc": false
                },
-               "styles": [
-                  {
-                     "alias": "Instance alias",
-                     "mappingType": 1,
-                     "pattern": "alias",
-                     "thresholds": [ ],
-                     "type": "string"
-                  },
-                  {
-                     "alias": "Instance URI",
-                     "mappingType": 1,
-                     "pattern": "instance",
-                     "thresholds": [ ],
-                     "type": "string"
-                  },
-                  {
-                     "alias": "Uptime",
-                     "colorMode": "row",
-                     "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                     ],
-                     "decimals": 0,
-                     "mappingType": 1,
-                     "pattern": "Value",
-                     "thresholds": [
-                        "0.1",
-                        "0.1"
-                     ],
-                     "type": "number",
-                     "unit": "s"
-                  },
-                  {
-                     "alias": "job",
-                     "pattern": "job",
-                     "thresholds": [ ],
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "Time",
-                     "pattern": "Time",
-                     "thresholds": [ ],
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "__name__",
-                     "pattern": "__name__",
-                     "thresholds": [ ],
-                     "type": "hidden"
-                  }
-               ],
+               "styles": null,
                "targets": [
                   {
                      "expr": "up{job=~\"$job\"} * on(instance) group_left(alias) tnt_info_uptime{job=~\"$job\"} or\non(instance) label_replace(up{job=~\"$job\"}, \"alias\", \"Not available\", \"instance\", \".*\")\n",

--- a/tests/Prometheus/dashboard_with_custom_panels_compiled.json
+++ b/tests/Prometheus/dashboard_with_custom_panels_compiled.json
@@ -118,11 +118,19 @@
                   {
                      "alias": "job",
                      "pattern": "job",
+                     "thresholds": [ ],
                      "type": "hidden"
                   },
                   {
-                     "alias": "/.*/",
-                     "pattern": "/.*/",
+                     "alias": "Time",
+                     "pattern": "Time",
+                     "thresholds": [ ],
+                     "type": "hidden"
+                  },
+                  {
+                     "alias": "__name__",
+                     "pattern": "__name__",
+                     "thresholds": [ ],
                      "type": "hidden"
                   }
                ],

--- a/tests/Prometheus/dashboard_with_custom_panels_compiled.json
+++ b/tests/Prometheus/dashboard_with_custom_panels_compiled.json
@@ -5,7 +5,7 @@
          "id": "grafana",
          "name": "Grafana",
          "type": "grafana",
-         "version": "8.0.0"
+         "version": "9.0.0"
       },
       {
          "id": "graph",
@@ -69,7 +69,160 @@
             {
                "columns": [ ],
                "datasource": "$prometheus",
-               "description": "Overview of Tarantool instances observed by Prometheus job.\n\nIf instance row is *red*, it means Prometheus can't reach\nURI specified in targets or ran into error.\nIf instance row is *green*, it means instance is up and running and\nPrometheus is successfully extracting metrics from it.\n\"Uptime\" column shows time since instant start.\n\nInstance alias filtering is disabled here.\n\nIf Prometheus job filter is not specified, displays running instances\nand ignores unreachable instances (we have no specific source to fetch)\n\nThis panel is designed to work with Prometheus client\nset up to have each Tarantool instance as a separate pull target.\n",
+               "description": "Overview of Tarantool instances observed by Prometheus job.\n\nIf instance row is *red*, it means Prometheus can't reach\nURI specified in targets or ran into error.\nIf instance row is *green*, it means instance is up and running and\nPrometheus is successfully extracting metrics from it.\n\"Uptime\" column shows time since instant start.\n\nInstance alias filtering is disabled here.\n\nIf Prometheus job filter is not specified, displays running instances\nand ignores unreachable instances (we have no specific source to fetch).\n\nColor scheme is expected to work properly only for Grafana 11+.\n\nThis panel is designed to work with Prometheus client\nset up to have each Tarantool instance as a separate pull target.\n",
+               "fieldConfig": {
+                  "defaults": {
+                     "custom": {
+                        "cellOptions": {
+                           "type": "auto"
+                        },
+                        "inspect": false
+                     },
+                     "mappings": [ ],
+                     "thresholds": {
+                        "mode": "absolute",
+                        "steps": [
+                           {
+                              "color": "green",
+                              "value": null
+                           },
+                           {
+                              "color": "red",
+                              "value": 80
+                           }
+                        ]
+                     }
+                  },
+                  "overrides": [
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "alias"
+                        },
+                        "properties": [
+                           {
+                              "id": "displayName",
+                              "value": "Instance alias"
+                           },
+                           {
+                              "id": "custom.align"
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "instance"
+                        },
+                        "properties": [
+                           {
+                              "id": "displayName",
+                              "value": "Instance URI"
+                           },
+                           {
+                              "id": "custom.align"
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "Value"
+                        },
+                        "properties": [
+                           {
+                              "id": "displayName",
+                              "value": "Uptime"
+                           },
+                           {
+                              "id": "unit",
+                              "value": "s"
+                           },
+                           {
+                              "id": "custom.cellOptions",
+                              "value": {
+                                 "applyToRow": true,
+                                 "type": "color-background"
+                              }
+                           },
+                           {
+                              "id": "custom.align"
+                           },
+                           {
+                              "id": "thresholds",
+                              "value": {
+                                 "mode": "absolute",
+                                 "steps": [
+                                    {
+                                       "color": "rgba(245, 54, 54, 0.9)",
+                                       "value": null
+                                    },
+                                    {
+                                       "color": "rgba(50, 172, 45, 0.97)",
+                                       "value": 0.10000000000000001
+                                    }
+                                 ]
+                              }
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "job"
+                        },
+                        "properties": [
+                           {
+                              "id": "displayName",
+                              "value": "job"
+                           },
+                           {
+                              "id": "custom.hidden",
+                              "value": true
+                           },
+                           {
+                              "id": "custom.align"
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "job"
+                        },
+                        "properties": [
+                           {
+                              "id": "custom.hidden",
+                              "value": true
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "Time"
+                        },
+                        "properties": [
+                           {
+                              "id": "custom.hidden",
+                              "value": true
+                           }
+                        ]
+                     },
+                     {
+                        "matcher": {
+                           "id": "byName",
+                           "options": "__name__"
+                        },
+                        "properties": [
+                           {
+                              "id": "custom.hidden",
+                              "value": true
+                           }
+                        ]
+                     }
+                  ]
+               },
                "gridPos": {
                   "h": 8,
                   "w": 12,
@@ -82,58 +235,7 @@
                   "col": 2,
                   "desc": false
                },
-               "styles": [
-                  {
-                     "alias": "Instance alias",
-                     "mappingType": 1,
-                     "pattern": "alias",
-                     "thresholds": [ ],
-                     "type": "string"
-                  },
-                  {
-                     "alias": "Instance URI",
-                     "mappingType": 1,
-                     "pattern": "instance",
-                     "thresholds": [ ],
-                     "type": "string"
-                  },
-                  {
-                     "alias": "Uptime",
-                     "colorMode": "row",
-                     "colors": [
-                        "rgba(245, 54, 54, 0.9)",
-                        "rgba(237, 129, 40, 0.89)",
-                        "rgba(50, 172, 45, 0.97)"
-                     ],
-                     "decimals": 0,
-                     "mappingType": 1,
-                     "pattern": "Value",
-                     "thresholds": [
-                        "0.1",
-                        "0.1"
-                     ],
-                     "type": "number",
-                     "unit": "s"
-                  },
-                  {
-                     "alias": "job",
-                     "pattern": "job",
-                     "thresholds": [ ],
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "Time",
-                     "pattern": "Time",
-                     "thresholds": [ ],
-                     "type": "hidden"
-                  },
-                  {
-                     "alias": "__name__",
-                     "pattern": "__name__",
-                     "thresholds": [ ],
-                     "type": "hidden"
-                  }
-               ],
+               "styles": null,
                "targets": [
                   {
                      "expr": "up{job=~\"$job\"} * on(instance) group_left(alias) tnt_info_uptime{job=~\"$job\"} or\non(instance) label_replace(up{job=~\"$job\"}, \"alias\", \"Not available\", \"instance\", \".*\")\n",


### PR DESCRIPTION
### dashboard: fix cluster overview for Grafana 11

grafonnet doesn't fill up empty thresholds for hidden fields. After table code rework introduced in Grafana 11, empty thresholds result in panel crush.

Thanks to @0x501D for exploring the issue.

Closes #234

### dashboard: use Grafana 11 color scheme in overview table

Before this patch, older Grafana 6 color scheme were used for overview panel. It was fine for Grafana from 8 to 10, but don't work properly with Grafana 11 [Figure 1]. After this patch, the panel works properly with Grafana 11 and newer  [Figure 2]. For Grafana 9 and 10 everything works fine, except for row coloring: only single cell is colored [1,  Figure 3]. For Grafana 8 and older, table column hiding no longer works properly so it's simpler for us to treat it as unsupported since it's EOLed 1 year and 3 months ago [2,  Figure 4].

1. https://github.com/grafana/grafana/issues/27542
2. https://endoflife.date/grafana

Figure 1:
![image](https://github.com/user-attachments/assets/a3a10790-5053-4e87-bde7-784f0dd4f3a7)

Figure 2:
![image](https://github.com/user-attachments/assets/044292d9-6af3-4da5-a2ca-1f4c6b90498e)

Figure 3:
![image](https://github.com/user-attachments/assets/16b5635f-b5f9-414d-8e48-f882b54b8352)

Figure 4:
![image](https://github.com/user-attachments/assets/37f372d3-f927-40b9-a632-5d8285ff44a2)

Follows #234 
