### PR TITLE
dashboard: release 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.2.0] - 2024-10-04
+Grafana revisions:
+- Tarantool 3:
+  - [Prometheus revision 5](https://grafana.com/api/dashboards/21474/revisions/5/download),
+  - [InfluxDB revision 5](https://grafana.com/api/dashboards/21484/revisions/5/download);
+- Tarantool Cartridge and 1.10—2.x:
+  - [Prometheus revision 21](https://grafana.com/api/dashboards/13054/revisions/21/download),
+  - [InfluxDB revision 21](https://grafana.com/api/dashboards/12567/revisions/21/download);
+- Tarantool Data Grid 2:
+  - [Prometheus revision 10](https://grafana.com/api/dashboards/16406/revisions/10/download),
+  - [InfluxDB revision 10](https://grafana.com/api/dashboards/16405/revisions/10/download).
 
 ### Changed
 - Use Grafana 11 color scheme for Prometheus cluster overview panel (#234)


### PR DESCRIPTION
## release 3.2.0: cluster overview for Grarafa 11

Grafana revisions
- Tarantool 3:
  - Prometheus revision 5 [1],
  - InfluxDB revision 5 [2];
- Tarantool Cartridge and 1.10—2.x:
  - Prometheus revision 21 [3],
  - InfluxDB revision 21 [4];
- Tarantool Data Grid 2:
  - Prometheus revision 10 [5],
  - InfluxDB revision 10 [6].

### Changed
- Use Grafana 11 color scheme for Prometheus cluster overview panel (#234)
- Drop Grafana 8 support (#234)
- Bump recommended requirements to Grafana 11 (#234)

### Fixed
- Prometheus cluster overview panel not works for Grafana 11+ (#234)

1. https://grafana.com/api/dashboards/21474/revisions/5/download
2. https://grafana.com/api/dashboards/21484/revisions/5/download
3. https://grafana.com/api/dashboards/13054/revisions/21/download
4. https://grafana.com/api/dashboards/12567/revisions/21/download
5. https://grafana.com/api/dashboards/16406/revisions/10/download
6. https://grafana.com/api/dashboards/16405/revisions/10/download