### PR TITLE
dashboard: release 3.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [3.2.1] - 2024-12-06
+Grafana revisions:
+- Tarantool 3:
+  - [Prometheus revision 5](https://grafana.com/api/dashboards/21474/revisions/5/download),
+  - [InfluxDB revision 5](https://grafana.com/api/dashboards/21484/revisions/5/download);
+- Tarantool Cartridge and 1.10—2.x:
+  - [Prometheus revision 21](https://grafana.com/api/dashboards/13054/revisions/21/download),
+  - [InfluxDB revision 21](https://grafana.com/api/dashboards/12567/revisions/21/download);
+- Tarantool Data Grid 2:
+  - [Prometheus revision 11](https://grafana.com/api/dashboards/16406/revisions/11/download),
+  - [InfluxDB revision 11](https://grafana.com/api/dashboards/16405/revisions/11/download).
 
 ### Fixed
 - Prometheus TDG average panels displaying lifetime average instead of a moving one (#237)


### PR DESCRIPTION
Grafana revisions:
- Tarantool 3:
  - [Prometheus revision 5](https://grafana.com/api/dashboards/21474/revisions/5/download),
  - [InfluxDB revision 5](https://grafana.com/api/dashboards/21484/revisions/5/download);
- Tarantool Cartridge and 1.10—2.x:
  - [Prometheus revision 21](https://grafana.com/api/dashboards/13054/revisions/21/download),
  - [InfluxDB revision 21](https://grafana.com/api/dashboards/12567/revisions/21/download);
- Tarantool Data Grid 2:
  - [Prometheus revision 11](https://grafana.com/api/dashboards/16406/revisions/11/download),
  - [InfluxDB revision 11](https://grafana.com/api/dashboards/16405/revisions/11/download).

### Fixed
- Prometheus TDG average panels displaying lifetime average instead of a moving one (#237)

