### PR TITLE
dashboard: replace config application status panel with config checksum panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Panel with Сartridge config application status (#241)
+- Panel with Сartridge configuration checksum (#242)
 
 
 ## [3.2.1] - 2024-12-06

--- a/dashboard/panels/cluster.libsonnet
+++ b/dashboard/panels/cluster.libsonnet
@@ -344,31 +344,26 @@ local prometheus = grafana.prometheus;
   else if cfg.type == variable.datasource_type.influxdb then
     error 'InfluxDB target is not supported yet',
 
-  config_applied(
+  cartridge_config_checksum(
     cfg,
-    title='Config application status',
+    title='Configuration checksum',
     description=|||
-      Indicates whether the instance has locally applied a new
-      clusterwide configuration.
+      Cartridge configuration checksum on the instance.
+      Differences indicate configuration divergence across cluster nodes.
 
-      Panel minimal requirements: cartridge 2.16.1, metrics 1.4.0.
+      Panel minimal requirements: metrics 1.5.0.
     |||,
-  ):: timeseries.new(
+  ):: common.default_graph(
+    cfg,
     title=title,
     description=description,
-    datasource=cfg.datasource,
+    min=0,
+    legend_avg=false,
+    legend_max=false,
     panel_height=6,
     panel_width=8,
-    max=1,
-    min=0,
-  ).addValueMapping(
-    0, 'yellow', 'not applied'
-  ).addValueMapping(
-    1, 'green', 'applied'
-  ).addRangeMapping(
-    0.001, 0.999, '-'
   ).addTarget(
-    common.target(cfg, 'tnt_cartridge_config_applied')
+    common.target(cfg, 'tnt_cartridge_config_checksum', converter='last'),
   ),
 
   memory_reserved_stat(

--- a/dashboard/section.libsonnet
+++ b/dashboard/section.libsonnet
@@ -67,7 +67,7 @@ local vinyl = import 'dashboard/panels/vinyl.libsonnet';
     cluster.http_rps_stat(cfg) { gridPos: { w: 4, h: 5, x: 12, y: 4 } },
     cluster.net_rps_stat(cfg) { gridPos: { w: 4, h: 5, x: 16, y: 4 } },
     cluster.space_ops_stat(cfg) { gridPos: { w: 4, h: 5, x: 20, y: 4 } },
-    cluster.config_applied(cfg),
+    cluster.cartridge_config_checksum(cfg),
     cluster.cartridge_warning_issues(cfg),
     cluster.cartridge_critical_issues(cfg),
     cluster.failovers_per_second(cfg),

--- a/supported_metrics.md
+++ b/supported_metrics.md
@@ -121,7 +121,7 @@ Based on [tarantool/metrics 1.2.0](https://github.com/tarantool/metrics/releases
 - [x] **tnt_cartridge_issues**: see *Cluster overview/Cartridge warning issues*, *Cluster overview/Cartridge critical issues* panels ([#55](https://github.com/tarantool/grafana-dashboard/pull/55))
 - **tnt_cartridge_cluster_issues**: unsupported (decided not to support: superseded by **tnt_cartridge_issues**)
 - [x] **tnt_cartridge_failover_trigger_total**: see *Cluster overview/Failovers triggered* panel ([#178](https://github.com/tarantool/grafana-dashboard/issues/178))
-- [x] **tnt_cartridge_config_applied**: see *Cluster overview/Config application status* panel ([#241](https://github.com/tarantool/grafana-dashboard/pull/241))
+- [x] **tnt_cartridge_config_checksum**: see *Cluster overview/Configuration checksum* panel ([#242](https://github.com/tarantool/grafana-dashboard/pull/242))
 - [x] **tnt_synchro_queue_owner**: see *Replication overview/Synchronous queue owner* panel ([#178](https://github.com/tarantool/grafana-dashboard/issues/178))
 - [x] **tnt_synchro_queue_term**: see *Replication overview/Synchronous queue term* panel ([#178](https://github.com/tarantool/grafana-dashboard/issues/178))
 - [x] **tnt_synchro_queue_len**: see *Replication overview/Synchronous queue transactions* panel ([#178](https://github.com/tarantool/grafana-dashboard/issues/178))

--- a/tests/Prometheus/dashboard_cartridge_compiled.json
+++ b/tests/Prometheus/dashboard_cartridge_compiled.json
@@ -577,83 +577,13 @@
                "type": "stat"
             },
             {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
                "datasource": "$prometheus",
-               "description": "Indicates whether the instance has locally applied a new\nclusterwide configuration.\n\nPanel minimal requirements: cartridge 2.16.1, metrics 1.4.0.\n",
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "drawStyle": "line",
-                        "fillOpacity": 0,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "never",
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [
-                        {
-                           "options": {
-                              "0": {
-                                 "color": "yellow",
-                                 "index": 0,
-                                 "text": "not applied"
-                              }
-                           },
-                           "type": "value"
-                        },
-                        {
-                           "options": {
-                              "1": {
-                                 "color": "green",
-                                 "index": 0,
-                                 "text": "applied"
-                              }
-                           },
-                           "type": "value"
-                        },
-                        {
-                           "options": {
-                              "from": 0.001,
-                              "result": {
-                                 "index": 0,
-                                 "text": "-"
-                              },
-                              "to": 0.999
-                           },
-                           "type": "range"
-                        }
-                     ],
-                     "max": 1,
-                     "min": 0,
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [ ]
-                     }
-                  },
-                  "overrides": [ ]
-               },
+               "description": "Cartridge configuration checksum on the instance.\nDifferences indicate configuration divergence across cluster nodes.\n\nPanel minimal requirements: metrics 1.5.0.\n",
+               "fill": 0,
                "gridPos": {
                   "h": 6,
                   "w": 8,
@@ -661,29 +591,77 @@
                   "y": 9
                },
                "id": 10,
-               "options": {
-                  "legend": {
-                     "calcs": [
-                        "last"
-                     ],
-                     "displayMode": "table",
-                     "placement": "right"
-                  },
-                  "tooltip": {
-                     "mode": "multi"
-                  }
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
                },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_cartridge_config_applied{alias=~\"$alias\",job=~\"$job\"}",
+                     "expr": "tnt_cartridge_config_checksum{alias=~\"$alias\",job=~\"$job\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
                      "refId": "A"
                   }
                ],
-               "title": "Config application status",
-               "type": "timeseries"
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Configuration checksum",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
             },
             {
                "aliasColors": { },

--- a/tests/Prometheus/dashboard_tdg_compiled.json
+++ b/tests/Prometheus/dashboard_tdg_compiled.json
@@ -577,83 +577,13 @@
                "type": "stat"
             },
             {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
                "datasource": "$prometheus",
-               "description": "Indicates whether the instance has locally applied a new\nclusterwide configuration.\n\nPanel minimal requirements: cartridge 2.16.1, metrics 1.4.0.\n",
-               "fieldConfig": {
-                  "defaults": {
-                     "color": {
-                        "mode": "palette-classic"
-                     },
-                     "custom": {
-                        "axisLabel": "",
-                        "axisPlacement": "auto",
-                        "barAlignment": 0,
-                        "drawStyle": "line",
-                        "fillOpacity": 0,
-                        "gradientMode": "none",
-                        "hideFrom": {
-                           "legend": false,
-                           "tooltip": false,
-                           "viz": false
-                        },
-                        "lineInterpolation": "linear",
-                        "lineWidth": 1,
-                        "pointSize": 5,
-                        "scaleDistribution": {
-                           "type": "linear"
-                        },
-                        "showPoints": "never",
-                        "spanNulls": false,
-                        "stacking": {
-                           "group": "A",
-                           "mode": "none"
-                        },
-                        "thresholdsStyle": {
-                           "mode": "off"
-                        }
-                     },
-                     "mappings": [
-                        {
-                           "options": {
-                              "0": {
-                                 "color": "yellow",
-                                 "index": 0,
-                                 "text": "not applied"
-                              }
-                           },
-                           "type": "value"
-                        },
-                        {
-                           "options": {
-                              "1": {
-                                 "color": "green",
-                                 "index": 0,
-                                 "text": "applied"
-                              }
-                           },
-                           "type": "value"
-                        },
-                        {
-                           "options": {
-                              "from": 0.001,
-                              "result": {
-                                 "index": 0,
-                                 "text": "-"
-                              },
-                              "to": 0.999
-                           },
-                           "type": "range"
-                        }
-                     ],
-                     "max": 1,
-                     "min": 0,
-                     "thresholds": {
-                        "mode": "absolute",
-                        "steps": [ ]
-                     }
-                  },
-                  "overrides": [ ]
-               },
+               "description": "Cartridge configuration checksum on the instance.\nDifferences indicate configuration divergence across cluster nodes.\n\nPanel minimal requirements: metrics 1.5.0.\n",
+               "fill": 0,
                "gridPos": {
                   "h": 6,
                   "w": 8,
@@ -661,29 +591,77 @@
                   "y": 9
                },
                "id": 10,
-               "options": {
-                  "legend": {
-                     "calcs": [
-                        "last"
-                     ],
-                     "displayMode": "table",
-                     "placement": "right"
-                  },
-                  "tooltip": {
-                     "mode": "multi"
-                  }
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
                },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
                "targets": [
                   {
-                     "expr": "tnt_cartridge_config_applied{alias=~\"$alias\",job=~\"$job\"}",
+                     "expr": "tnt_cartridge_config_checksum{alias=~\"$alias\",job=~\"$job\"}",
                      "format": "time_series",
                      "intervalFactor": 2,
                      "legendFormat": "{{alias}}",
                      "refId": "A"
                   }
                ],
-               "title": "Config application status",
-               "type": "timeseries"
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Configuration checksum",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "none",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
             },
             {
                "aliasColors": { },


### PR DESCRIPTION
Replace "Config application status" panel with "Configuration checksum" panel (https://github.com/tarantool/metrics/pull/516).

<img src="https://github.com/user-attachments/assets/821ebb9c-5d17-4824-9778-e06f3df661c1" width="500">

Closes TNTP-2845

If this pull request introduces support for new metrics, do not forget to
- [x] add Grafana panel;
- [x] run `make update-tests` to build new dashboard artifacts;
- [ ] add example application code to generate non-null metrics;
- [x] attach a screenshot of a new panel to the PR description;
- [ ] add new Telegraf tag key, if relevant,
  - [ ] to all `telegraf.conf` files,
  - [ ] to "Grafana dashboard" documentation page;
- [ ] add alert example, if relevant,
  - [ ] to `alerts.yml`,
  - [ ] to "Alerting" documentation page;
- [x] update `supported_metrics.md`.

In any case, do not forget to
- [x] link an issue;
- [x] add a CHANGELOG entry;
- [ ] update documentation guidelines;
- [ ] update README guidelines.
