### PR TITLE
dashboard: cpu/memory/virtual memory panels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Panel with Сartridge configuration checksum (#242)
 - Panel with `need schema upgrade` status (#243)
-
+- Panels with `CPU/memory/virtual memory` utilization per instance and total (#245)
 
 ## [3.2.1] - 2024-12-06
 Grafana revisions:

--- a/dashboard/panels/cpu.libsonnet
+++ b/dashboard/panels/cpu.libsonnet
@@ -1,6 +1,7 @@
 local grafana = import 'grafonnet/grafana.libsonnet';
 
 local common = import 'dashboard/panels/common.libsonnet';
+local common_utils = import 'dashboard/panels/common.libsonnet';
 local variable = import 'dashboard/variable.libsonnet';
 
 local influxdb = grafana.influxdb;
@@ -21,14 +22,14 @@ local prometheus = grafana.prometheus;
     format='percentunit',
     decimalsY1=0,
     min=0,
-    panel_width=12,
+    panel_width=8,
   ).addTarget(
     common.target(cfg, metric_name, rate=true)
   ),
 
-  getrusage_cpu_user_time(
+  getrusage_cpu_instance_user_time(
     cfg,
-    title='CPU user time',
+    title='CPU user time per instance',
     description=|||
       This is the average share of time
       spent by instance process executing in user mode.
@@ -43,9 +44,9 @@ local prometheus = grafana.prometheus;
     metric_name='tnt_cpu_user_time',
   ),
 
-  getrusage_cpu_system_time(
+  getrusage_cpu_instance_system_time(
     cfg,
-    title='CPU system time',
+    title='CPU system time per instance',
     description=|||
       This is the average share of time
       spent by instance process executing in kernel mode.
@@ -60,6 +61,225 @@ local prometheus = grafana.prometheus;
     metric_name='tnt_cpu_system_time',
   ),
 
+  // --------------------------------------------------------------------------
+  local getrusage_cpu_total_percentage_graph(
+    cfg, title, description,
+  ) = common.default_graph(
+    cfg,
+    title=title,
+    description=description,
+    format='percentunit',
+    decimalsY1=0,
+    min=0,
+    panel_width=8,
+  ).addTarget(
+    if cfg.type == variable.datasource_type.prometheus then
+      prometheus.target(
+        expr=std.format(
+          |||
+            rate(%(metrics_prefix)stnt_cpu_user_time{%(filters)s}[$__rate_interval]) +
+            rate(%(metrics_prefix)stnt_cpu_system_time{%(filters)s}[$__rate_interval])
+          |||,
+          {
+            metrics_prefix: cfg.metrics_prefix,
+            filters: common.prometheus_query_filters(cfg.filters),
+          }
+        ),
+        legendFormat='{{alias}}'
+      )
+    else if cfg.type == variable.datasource_type.influxdb then
+      influxdb.target(
+        rawQuery=true,
+        query=std.format(|||
+          SELECT non_negative_derivative(SUM("value"), 1s)
+          FROM %(measurement_with_policy)s
+          WHERE (("metric_name" = '%(metric_user_time)s' OR "metric_name" = '%(metric_system_time)s') AND %(filters)s)
+          AND $timeFilter
+          GROUP BY time($__interval), "label_pairs_alias" fill(none)
+        |||, {
+          measurement_with_policy: std.format('%(policy_prefix)s"%(measurement)s"', {
+            policy_prefix: if cfg.policy == 'default' then '' else std.format('"%(policy)s".', cfg.policy),
+            measurement: cfg.measurement,
+          }),
+          metric_user_time: cfg.metrics_prefix + 'tnt_cpu_user_time',
+          metric_system_time: cfg.metrics_prefix + 'tnt_cpu_system_time',
+          filters: common.influxdb_query_filters(cfg.filters),
+        }),
+        alias='$tag_label_pairs_alias',
+      )
+  ),
+
+  getrusage_cpu_instance_total_time(
+    cfg,
+    title='CPU total time per instance',
+    description=|||
+      This is the average share of time spent
+      by instance process executing.
+
+      Panel minimal requirements: metrics 0.8.0.
+    |||,
+  ):: getrusage_cpu_total_percentage_graph(
+    cfg=cfg,
+    title=title,
+    description=description,
+  ),
+
+  // --------------------------------------------------------------------------
+  local getrusage_cpu_common_percentage_graph(
+    cfg,
+    title,
+    description,
+    prometheus_expr,
+    prometheus_legend,
+    influx_query,
+    influx_alias,
+  ) = common.default_graph(
+    cfg,
+    title=title,
+    description=description,
+    format='percentunit',
+    decimalsY1=0,
+    min=0,
+    panel_width=8,
+  ).addTarget(
+    if cfg.type == variable.datasource_type.prometheus then
+      prometheus.target(
+        expr=prometheus_expr,
+        legendFormat=prometheus_legend,
+      )
+    else if cfg.type == variable.datasource_type.influxdb then
+      influxdb.target(
+        rawQuery=true,
+        query=influx_query,
+        alias=influx_alias,
+      )
+  ),
+
+  getrusage_cpu_total_time(
+    cfg,
+    title='CPU total time per cluster',
+    description=|||
+      This is the total share of time spent
+      by each cluster process executing.
+
+      Panel minimal requirements: metrics 0.8.0.
+    |||,
+  ):: getrusage_cpu_common_percentage_graph(
+    cfg=cfg,
+    title=title,
+    description=description,
+    prometheus_expr=std.format(
+      |||
+        sum(rate(%(metrics_prefix)stnt_cpu_user_time{%(filters)s}[$__rate_interval])) +
+        sum(rate(%(metrics_prefix)stnt_cpu_system_time{%(filters)s}[$__rate_interval]))
+      |||,
+      {
+        metrics_prefix: cfg.metrics_prefix,
+        filters: common.prometheus_query_filters(common.remove_field(cfg.filters, 'alias')),
+      }
+    ),
+    prometheus_legend=title,
+    influx_query=std.format(|||
+      SELECT non_negative_derivative(SUM("value"), 1s)
+      FROM %(measurement_with_policy)s
+      WHERE (("metric_name" = '%(metric_user_time)s' OR "metric_name" = '%(metric_system_time)s') AND %(filters)s)
+      AND $timeFilter
+      GROUP BY time($__interval)
+    |||, {
+      measurement_with_policy: std.format('%(policy_prefix)s"%(measurement)s"', {
+        policy_prefix: if cfg.policy == 'default' then '' else std.format('"%(policy)s".', cfg.policy),
+        measurement: cfg.measurement,
+      }),
+      metric_user_time: cfg.metrics_prefix + 'tnt_cpu_user_time',
+      metric_system_time: cfg.metrics_prefix + 'tnt_cpu_system_time',
+      filters: if common.influxdb_query_filters(common.remove_field(cfg.filters, 'label_pairs_alias')) != ''
+      then common.influxdb_query_filters(common.remove_field(cfg.filters, 'label_pairs_alias'))
+      else 'true',
+    }),
+    influx_alias=title
+  ),
+
+  getrusage_cpu_total_user_time(
+    cfg,
+    title='CPU total user time per cluster',
+    description=|||
+      This is the total share of time
+      spent in user mode per cluster.
+
+      Panel minimal requirements: metrics 0.8.0.
+    |||,
+  ):: getrusage_cpu_common_percentage_graph(
+    cfg=cfg,
+    title=title,
+    description=description,
+    prometheus_expr=std.format(
+      |||
+        sum(rate(%(metrics_prefix)stnt_cpu_user_time{%(filters)s}[$__rate_interval]))
+      |||,
+      {
+        metrics_prefix: cfg.metrics_prefix,
+        filters: common.prometheus_query_filters(common.remove_field(cfg.filters, 'alias')),
+      }
+    ),
+    prometheus_legend=title,
+    influx_query=std.format(|||
+      SELECT non_negative_derivative(SUM("value"), 1s)
+      FROM %(measurement_with_policy)s
+      WHERE "metric_name" = '%(metric_user_time)s' AND %(filters)s
+      AND $timeFilter
+      GROUP BY time($__interval)
+    |||, {
+      measurement_with_policy: std.format('%(policy_prefix)s"%(measurement)s"', {
+        policy_prefix: if cfg.policy == 'default' then '' else std.format('"%(policy)s".', cfg.policy),
+        measurement: cfg.measurement,
+      }),
+      metric_user_time: cfg.metrics_prefix + 'tnt_cpu_user_time',
+      filters: common.influxdb_query_filters(cfg.filters),
+    }),
+    influx_alias=title
+  ),
+
+  getrusage_cpu_total_system_time(
+    cfg,
+    title='CPU total system time per cluster',
+    description=|||
+      This is the total share of time
+      spent in system mode per cluster.
+
+      Panel minimal requirements: metrics 0.8.0.
+    |||,
+  ):: getrusage_cpu_common_percentage_graph(
+    cfg=cfg,
+    title=title,
+    description=description,
+    prometheus_expr=std.format(
+      |||
+        sum(rate(%(metrics_prefix)stnt_cpu_system_time{%(filters)s}[$__rate_interval]))
+      |||,
+      {
+        metrics_prefix: cfg.metrics_prefix,
+        filters: common.prometheus_query_filters(common.remove_field(cfg.filters, 'alias')),
+      }
+    ),
+    prometheus_legend=title,
+    influx_query=std.format(|||
+      SELECT non_negative_derivative(SUM("value"), 1s)
+      FROM %(measurement_with_policy)s
+      WHERE "metric_name" = '%(metric_system_time)s' AND %(filters)s
+      AND $timeFilter
+      GROUP BY time($__interval)
+    |||, {
+      measurement_with_policy: std.format('%(policy_prefix)s"%(measurement)s"', {
+        policy_prefix: if cfg.policy == 'default' then '' else std.format('"%(policy)s".', cfg.policy),
+        measurement: cfg.measurement,
+      }),
+      metric_system_time: cfg.metrics_prefix + 'tnt_cpu_system_time',
+      filters: common.influxdb_query_filters(cfg.filters),
+    }),
+    influx_alias=title
+  ),
+
+  // --------------------------------------------------------------------------
   local procstat_thread_time_graph(
     cfg,
     title,

--- a/dashboard/section.libsonnet
+++ b/dashboard/section.libsonnet
@@ -227,20 +227,35 @@ local vinyl = import 'dashboard/panels/vinyl.libsonnet';
 
   cpu(cfg):: [
     cpu.row,
-    cpu.getrusage_cpu_user_time(cfg),
-    cpu.getrusage_cpu_system_time(cfg),
+    cpu.getrusage_cpu_instance_total_time(cfg),
+    cpu.getrusage_cpu_instance_user_time(cfg),
+    cpu.getrusage_cpu_instance_system_time(cfg),
+    cpu.getrusage_cpu_total_time(cfg),
+    cpu.getrusage_cpu_total_user_time(cfg),
+    cpu.getrusage_cpu_total_system_time(cfg),
+
   ],
 
   cpu_extended(cfg):: [
     cpu.row,
-    cpu.getrusage_cpu_user_time(cfg),
-    cpu.getrusage_cpu_system_time(cfg),
+    cpu.getrusage_cpu_instance_total_time(cfg),
+    cpu.getrusage_cpu_instance_user_time(cfg),
+    cpu.getrusage_cpu_instance_system_time(cfg),
+    cpu.getrusage_cpu_total_time(cfg),
+    cpu.getrusage_cpu_total_user_time(cfg),
+    cpu.getrusage_cpu_total_system_time(cfg),
     cpu.procstat_thread_user_time(cfg),
     cpu.procstat_thread_system_time(cfg),
   ],
 
   runtime(cfg):: [
     runtime.row,
+    runtime.total_memory_per_instance(cfg),
+    runtime.resident_memory_per_instance(cfg),
+    runtime.virtual_memory_per_instance(cfg),
+    runtime.total_memory(cfg),
+    runtime.total_resident_memory(cfg),
+    runtime.total_virtual_memory(cfg),
     runtime.lua_memory(cfg),
     runtime.runtime_memory(cfg),
     runtime.memory_tx(cfg),

--- a/example_cluster/tarantool3_project/app.Dockerfile
+++ b/example_cluster/tarantool3_project/app.Dockerfile
@@ -9,16 +9,18 @@ RUN DEBIAN_FRONTEND=noninteractive apt install -y git \
                                                   gcc \
                                                   g++ \
                                                   unzip \
+                                                  patch \
                                                   curl
+
 COPY . .
+
 RUN mkdir -p tmp
 
 RUN curl -L https://tarantool.io/release/3/installer.sh | bash
 RUN DEBIAN_FRONTEND=noninteractive apt install -y tarantool tarantool-dev tt
 
 RUN tt init
-# Need tt start -i
-RUN DEBIAN_FRONTEND=noninteractive apt install -y git patch
 
 RUN tt rocks make
+
 ENTRYPOINT tt start -i

--- a/supported_metrics.md
+++ b/supported_metrics.md
@@ -5,12 +5,15 @@ Format is as follows.
 
 # tarantool/metrics
 
-Based on [tarantool/metrics 1.2.0](https://github.com/tarantool/metrics/releases/tag/1.2.0).
+Based on [tarantool/metrics 1.6.1](https://github.com/tarantool/metrics/releases/tag/1.6.1).
 
+
+- [x] **tnt_memory**: see *Tarantool runtime overview/Resident memory per instance*, *Tarantool runtime overview/Total resident memory usage* panels ([#245](https://github.com/tarantool/grafana-dashboard/pull/245))
+- [x] **tnt_memory_virt**: see *Tarantool runtime overview/Virtual memory per instance*, *Tarantool runtime overview/Total virtual memory usage* panels ([#245](https://github.com/tarantool/grafana-dashboard/pull/245))
 - [x] **tnt_schema_needs_upgrade**: see *Tarantool schema need upgrade status* panel ([#243](https://github.com/tarantool/grafana-dashboard/pull/243/files))
 - [x] **tnt_clock_delta**: see *Replication overview/Instances clock delta* panel ([#133](https://github.com/tarantool/grafana-dashboard/issues/133))
-- [x] **tnt_cpu_user_time**: see *Tarantool CPU statistics/CPU user time* panel ([#71](https://github.com/tarantool/grafana-dashboard/issues/71))
-- [x] **tnt_cpu_system_time**: see *Tarantool CPU statistics/CPU system time* panel ([#71](https://github.com/tarantool/grafana-dashboard/issues/71))
+- [x] **tnt_cpu_user_time**: see *Tarantool CPU statistics/CPU user time per instance*, *Tarantool CPU statistics/CPU user time per cluster* panels ([#71](https://github.com/tarantool/grafana-dashboard/issues/71)) ([#245](https://github.com/tarantool/grafana-dashboard/pull/245))
+- [x] **tnt_cpu_system_time**: see *Tarantool CPU statistics/CPU system time per instance*, *Tarantool CPU statistics/CPU user system per cluster* panels ([#71](https://github.com/tarantool/grafana-dashboard/issues/71)) ([#245](https://github.com/tarantool/grafana-dashboard/pull/245))
 - [x] **tnt_ev_loop_time**: see *Tarantool runtime overview/Event loop time* panel ([#73](https://github.com/tarantool/grafana-dashboard/issues/73))
 - **tnt_ev_loop_prolog_time**: unsupported ([#73](https://github.com/tarantool/grafana-dashboard/issues/73), decided not to support: **tnt_ev_loop_time** covers basic monitoring)
 - **tnt_ev_loop_epilog_time**: unsupported ([#73](https://github.com/tarantool/grafana-dashboard/issues/73), decided not to support: **tnt_ev_loop_time** covers basic monitoring)

--- a/tests/InfluxDB/dashboard_cartridge_compiled.json
+++ b/tests/InfluxDB/dashboard_cartridge_compiled.json
@@ -14857,15 +14857,120 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$influxdb",
-               "description": "This is the average share of time\nspent by instance process executing in user mode.\nMetrics obtained using `getrusage()` call.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "description": "This is the average share of time spent\nby instance process executing.\n\nPanel minimal requirements: metrics 0.8.0.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 290
                },
                "id": 115,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT non_negative_derivative(SUM(\"value\"), 1s)\nFROM \"$policy\".\"$measurement\"\nWHERE ((\"metric_name\" = 'tnt_cpu_user_time' OR \"metric_name\" = 'tnt_cpu_system_time') AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter\nGROUP BY time($__interval), \"label_pairs_alias\" fill(none)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total time per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "This is the average share of time\nspent by instance process executing in user mode.\nMetrics obtained using `getrusage()` call.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 290
+               },
+               "id": 116,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14958,7 +15063,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "CPU user time",
+               "title": "CPU user time per instance",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -15002,11 +15107,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 290
                },
-               "id": 116,
+               "id": 117,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15099,7 +15204,322 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "CPU system time",
+               "title": "CPU system time per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "This is the total share of time spent\nby each cluster process executing.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 298
+               },
+               "id": 118,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "CPU total time per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT non_negative_derivative(SUM(\"value\"), 1s)\nFROM \"$policy\".\"$measurement\"\nWHERE ((\"metric_name\" = 'tnt_cpu_user_time' OR \"metric_name\" = 'tnt_cpu_system_time') AND true)\nAND $timeFilter\nGROUP BY time($__interval)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total time per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "This is the total share of time\nspent in user mode per cluster.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 298
+               },
+               "id": 119,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "CPU total user time per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT non_negative_derivative(SUM(\"value\"), 1s)\nFROM \"$policy\".\"$measurement\"\nWHERE \"metric_name\" = 'tnt_cpu_user_time' AND \"label_pairs_alias\" =~ /^$alias$/\nAND $timeFilter\nGROUP BY time($__interval)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total user time per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "This is the total share of time\nspent in system mode per cluster.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 298
+               },
+               "id": 120,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "CPU total system time per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT non_negative_derivative(SUM(\"value\"), 1s)\nFROM \"$policy\".\"$measurement\"\nWHERE \"metric_name\" = 'tnt_cpu_system_time' AND \"label_pairs_alias\" =~ /^$alias$/\nAND $timeFilter\nGROUP BY time($__interval)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total system time per cluster",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -15149,9 +15569,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 298
+            "y": 306
          },
-         "id": 117,
+         "id": 121,
          "panels": [
             {
                "aliasColors": { },
@@ -15159,15 +15579,699 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$influxdb",
-               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance. \n",
+               "description": "Total memory used by Tarantool.\n\nPanel minimal requirements: metrics 1.6.0.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 299
+                  "y": 307
                },
-               "id": 118,
+               "id": 122,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT SUM(\"value\")\nFROM \"$policy\".\"$measurement\"\nWHERE ((\"metric_name\" = 'tnt_memory' OR \"metric_name\" = 'tnt_memory_virt') AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter\nGROUP BY time($__interval), \"label_pairs_alias\" fill(none)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Resident memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 307
+               },
+               "id": 123,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "$measurement",
+                     "policy": "$policy",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_memory"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Resident memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Virtual memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 307
+               },
+               "id": 124,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "$measurement",
+                     "policy": "$policy",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_memory_virt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Virtual memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Total memory used by Tarantool.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 315
+               },
+               "id": 125,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "Total memory per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT SUM(\"value\")\nFROM \"$policy\".\"$measurement\"\nWHERE ((\"metric_name\" = 'tnt_memory' OR \"metric_name\" = 'tnt_memory_virt') AND true)\nAND $timeFilter\nGROUP BY time($__interval) fill(previous)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Resident memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 315
+               },
+               "id": 126,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "Total resident memory per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT SUM(\"value\")\nFROM \"$policy\".\"$measurement\"\nWHERE \"metric_name\" = 'tnt_memory' AND \"label_pairs_alias\" =~ /^$alias$/\nAND $timeFilter\nGROUP BY time($__interval) fill(previous)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total resident memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Virtual memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 315
+               },
+               "id": 127,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "Total virtual memory per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT SUM(\"value\")\nFROM \"$policy\".\"$measurement\"\nWHERE \"metric_name\" = 'tnt_memory_virt' AND \"label_pairs_alias\" =~ /^$alias$/\nAND $timeFilter\nGROUP BY time($__interval) fill(previous)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total virtual memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 323
+               },
+               "id": 128,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15299,9 +16403,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 299
+                  "y": 323
                },
-               "id": 119,
+               "id": 129,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15433,9 +16537,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 299
+                  "y": 323
                },
-               "id": 120,
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15567,9 +16671,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 307
+                  "y": 331
                },
-               "id": 121,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15701,9 +16805,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 307
+                  "y": 331
                },
-               "id": 122,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15836,9 +16940,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 315
+                  "y": 339
                },
-               "id": 123,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15972,9 +17076,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 315
+                  "y": 339
                },
-               "id": 124,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16106,9 +17210,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 315
+                  "y": 339
                },
-               "id": 125,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16244,9 +17348,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 323
+            "y": 347
          },
-         "id": 126,
+         "id": 136,
          "panels": [
             {
                "aliasColors": { },
@@ -16260,9 +17364,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 324
+                  "y": 348
                },
-               "id": 127,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16400,9 +17504,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 324
+                  "y": 348
                },
-               "id": 128,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16540,9 +17644,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 324
+                  "y": 348
                },
-               "id": 129,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16680,9 +17784,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 324
+                  "y": 348
                },
-               "id": 130,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16814,9 +17918,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 332
+                  "y": 356
                },
-               "id": 131,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16954,9 +18058,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 332
+                  "y": 356
                },
-               "id": 132,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17094,9 +18198,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 340
+                  "y": 364
                },
-               "id": 133,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17234,9 +18338,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 340
+                  "y": 364
                },
-               "id": 134,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17374,9 +18478,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 340
+                  "y": 364
                },
-               "id": 135,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17514,9 +18618,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 348
+                  "y": 372
                },
-               "id": 136,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17654,9 +18758,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 348
+                  "y": 372
                },
-               "id": 137,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17794,9 +18898,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 348
+                  "y": 372
                },
-               "id": 138,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17935,9 +19039,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 356
+                  "y": 380
                },
-               "id": 139,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18072,9 +19176,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 356
+                  "y": 380
                },
-               "id": 140,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18209,9 +19313,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 356
+                  "y": 380
                },
-               "id": 141,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18346,9 +19450,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 356
+                  "y": 380
                },
-               "id": 142,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18482,9 +19586,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 364
+                  "y": 388
                },
-               "id": 143,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18616,9 +19720,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 364
+                  "y": 388
                },
-               "id": 144,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18756,9 +19860,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 364
+                  "y": 388
                },
-               "id": 145,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18900,9 +20004,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 372
+            "y": 396
          },
-         "id": 146,
+         "id": 156,
          "panels": [
             {
                "aliasColors": { },
@@ -18916,9 +20020,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 373
+                  "y": 397
                },
-               "id": 147,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19062,9 +20166,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 373
+                  "y": 397
                },
-               "id": 148,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19208,9 +20312,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 373
+                  "y": 397
                },
-               "id": 149,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19354,9 +20458,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 381
+                  "y": 405
                },
-               "id": 150,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19500,9 +20604,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 381
+                  "y": 405
                },
-               "id": 151,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19646,9 +20750,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 381
+                  "y": 405
                },
-               "id": 152,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19792,9 +20896,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 389
+                  "y": 413
                },
-               "id": 153,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19938,9 +21042,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 389
+                  "y": 413
                },
-               "id": 154,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20084,9 +21188,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 389
+                  "y": 413
                },
-               "id": 155,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20230,9 +21334,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 397
+                  "y": 421
                },
-               "id": 156,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20376,9 +21480,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 397
+                  "y": 421
                },
-               "id": 157,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20522,9 +21626,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 397
+                  "y": 421
                },
-               "id": 158,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20668,9 +21772,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 405
+                  "y": 429
                },
-               "id": 159,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20814,9 +21918,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 405
+                  "y": 429
                },
-               "id": 160,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20960,9 +22064,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 405
+                  "y": 429
                },
-               "id": 161,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21110,9 +22214,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 413
+            "y": 437
          },
-         "id": 162,
+         "id": 172,
          "panels": [
             {
                "aliasColors": { },
@@ -21126,9 +22230,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 414
+                  "y": 438
                },
-               "id": 163,
+               "id": 173,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21284,9 +22388,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 414
+                  "y": 438
                },
-               "id": 164,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21442,9 +22546,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 414
+                  "y": 438
                },
-               "id": 165,
+               "id": 175,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21600,9 +22704,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 414
+                  "y": 438
                },
-               "id": 166,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21758,9 +22862,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 422
+                  "y": 446
                },
-               "id": 167,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21862,9 +22966,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 422
+                  "y": 446
                },
-               "id": 168,
+               "id": 178,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21966,9 +23070,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 422
+                  "y": 446
                },
-               "id": 169,
+               "id": 179,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22118,9 +23222,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 430
+                  "y": 454
                },
-               "id": 170,
+               "id": 180,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22276,9 +23380,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 430
+                  "y": 454
                },
-               "id": 171,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22434,9 +23538,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 430
+                  "y": 454
                },
-               "id": 172,
+               "id": 182,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22592,9 +23696,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 430
+                  "y": 454
                },
-               "id": 173,
+               "id": 183,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22750,9 +23854,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 438
+                  "y": 462
                },
-               "id": 174,
+               "id": 184,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22908,9 +24012,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 438
+                  "y": 462
                },
-               "id": 175,
+               "id": 185,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23066,9 +24170,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 438
+                  "y": 462
                },
-               "id": 176,
+               "id": 186,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23224,9 +24328,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 438
+                  "y": 462
                },
-               "id": 177,
+               "id": 187,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23382,9 +24486,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 446
+                  "y": 470
                },
-               "id": 178,
+               "id": 188,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23540,9 +24644,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 446
+                  "y": 470
                },
-               "id": 179,
+               "id": 189,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23698,9 +24802,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 446
+                  "y": 470
                },
-               "id": 180,
+               "id": 190,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23856,9 +24960,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 446
+                  "y": 470
                },
-               "id": 181,
+               "id": 191,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24014,9 +25118,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 454
+                  "y": 478
                },
-               "id": 182,
+               "id": 192,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24172,9 +25276,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 454
+                  "y": 478
                },
-               "id": 183,
+               "id": 193,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24330,9 +25434,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 454
+                  "y": 478
                },
-               "id": 184,
+               "id": 194,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24488,9 +25592,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 454
+                  "y": 478
                },
-               "id": 185,
+               "id": 195,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24646,9 +25750,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 462
+                  "y": 486
                },
-               "id": 186,
+               "id": 196,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24804,9 +25908,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 462
+                  "y": 486
                },
-               "id": 187,
+               "id": 197,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24962,9 +26066,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 462
+                  "y": 486
                },
-               "id": 188,
+               "id": 198,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25120,9 +26224,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 462
+                  "y": 486
                },
-               "id": 189,
+               "id": 199,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25278,9 +26382,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 470
+                  "y": 494
                },
-               "id": 190,
+               "id": 200,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25436,9 +26540,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 470
+                  "y": 494
                },
-               "id": 191,
+               "id": 201,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25594,9 +26698,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 470
+                  "y": 494
                },
-               "id": 192,
+               "id": 202,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25752,9 +26856,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 470
+                  "y": 494
                },
-               "id": 193,
+               "id": 203,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25910,9 +27014,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 478
+                  "y": 502
                },
-               "id": 194,
+               "id": 204,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26068,9 +27172,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 478
+                  "y": 502
                },
-               "id": 195,
+               "id": 205,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26226,9 +27330,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 478
+                  "y": 502
                },
-               "id": 196,
+               "id": 206,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26384,9 +27488,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 478
+                  "y": 502
                },
-               "id": 197,
+               "id": 207,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26542,9 +27646,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 486
+                  "y": 510
                },
-               "id": 198,
+               "id": 208,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26700,9 +27804,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 486
+                  "y": 510
                },
-               "id": 199,
+               "id": 209,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26858,9 +27962,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 486
+                  "y": 510
                },
-               "id": 200,
+               "id": 210,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27016,9 +28120,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 486
+                  "y": 510
                },
-               "id": 201,
+               "id": 211,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27174,9 +28278,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 494
+                  "y": 518
                },
-               "id": 202,
+               "id": 212,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27332,9 +28436,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 494
+                  "y": 518
                },
-               "id": 203,
+               "id": 213,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27490,9 +28594,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 494
+                  "y": 518
                },
-               "id": 204,
+               "id": 214,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27648,9 +28752,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 494
+                  "y": 518
                },
-               "id": 205,
+               "id": 215,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27806,9 +28910,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 502
+                  "y": 526
                },
-               "id": 206,
+               "id": 216,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27964,9 +29068,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 502
+                  "y": 526
                },
-               "id": 207,
+               "id": 217,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28122,9 +29226,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 502
+                  "y": 526
                },
-               "id": 208,
+               "id": 218,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28280,9 +29384,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 502
+                  "y": 526
                },
-               "id": 209,
+               "id": 219,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28438,9 +29542,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 510
+                  "y": 534
                },
-               "id": 210,
+               "id": 220,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28596,9 +29700,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 510
+                  "y": 534
                },
-               "id": 211,
+               "id": 221,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28754,9 +29858,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 510
+                  "y": 534
                },
-               "id": 212,
+               "id": 222,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28912,9 +30016,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 510
+                  "y": 534
                },
-               "id": 213,
+               "id": 223,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29070,9 +30174,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 518
+                  "y": 542
                },
-               "id": 214,
+               "id": 224,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29228,9 +30332,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 518
+                  "y": 542
                },
-               "id": 215,
+               "id": 225,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29386,9 +30490,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 518
+                  "y": 542
                },
-               "id": 216,
+               "id": 226,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29544,9 +30648,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 518
+                  "y": 542
                },
-               "id": 217,
+               "id": 227,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29702,9 +30806,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 526
+                  "y": 550
                },
-               "id": 218,
+               "id": 228,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29860,9 +30964,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 526
+                  "y": 550
                },
-               "id": 219,
+               "id": 229,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30018,9 +31122,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 526
+                  "y": 550
                },
-               "id": 220,
+               "id": 230,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30176,9 +31280,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 526
+                  "y": 550
                },
-               "id": 221,
+               "id": 231,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30338,9 +31442,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 534
+            "y": 558
          },
-         "id": 222,
+         "id": 232,
          "panels": [
             {
                "aliasColors": { },
@@ -30354,9 +31458,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 535
+                  "y": 559
                },
-               "id": 223,
+               "id": 233,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30500,9 +31604,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 535
+                  "y": 559
                },
-               "id": 224,
+               "id": 234,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30647,9 +31751,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 543
+                  "y": 567
                },
-               "id": 225,
+               "id": 235,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30789,9 +31893,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 543
+                  "y": 567
                },
-               "id": 226,
+               "id": 236,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/InfluxDB/dashboard_custom_compiled.json
+++ b/tests/InfluxDB/dashboard_custom_compiled.json
@@ -8682,7 +8682,7 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$influxdb",
-               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance. \n",
+               "description": "Total memory used by Tarantool.\n\nPanel minimal requirements: metrics 1.6.0.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
@@ -8691,6 +8691,702 @@
                   "y": 170
                },
                "id": 66,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT SUM(\"value\")\nFROM \"$measurement\"\nWHERE ((\"metric_name\" = 'vendor_tt_tnt_memory' OR \"metric_name\" = 'vendor_tt_tnt_memory_virt') AND \"label_pairs_alias\" =~ '$alias' AND \"vendor_app_tag\" = 'MyCacheApplication')\nAND $timeFilter\nGROUP BY time($__interval), \"label_pairs_alias\" fill(none)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Resident memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 170
+               },
+               "id": 67,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "$measurement",
+                     "policy": "default",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "vendor_tt_tnt_memory"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "$alias"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "vendor_app_tag",
+                           "operator": "=",
+                           "value": "MyCacheApplication"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Resident memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Virtual memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 170
+               },
+               "id": 68,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "$measurement",
+                     "policy": "default",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "vendor_tt_tnt_memory_virt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "$alias"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "vendor_app_tag",
+                           "operator": "=",
+                           "value": "MyCacheApplication"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Virtual memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Total memory used by Tarantool.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 178
+               },
+               "id": 69,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "Total memory per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT SUM(\"value\")\nFROM \"$measurement\"\nWHERE ((\"metric_name\" = 'vendor_tt_tnt_memory' OR \"metric_name\" = 'vendor_tt_tnt_memory_virt') AND \"vendor_app_tag\" = 'MyCacheApplication')\nAND $timeFilter\nGROUP BY time($__interval) fill(previous)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Resident memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 178
+               },
+               "id": 70,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "Total resident memory per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT SUM(\"value\")\nFROM \"$measurement\"\nWHERE \"metric_name\" = 'vendor_tt_tnt_memory' AND \"label_pairs_alias\" =~ '$alias' AND \"vendor_app_tag\" = 'MyCacheApplication'\nAND $timeFilter\nGROUP BY time($__interval) fill(previous)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total resident memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Virtual memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 178
+               },
+               "id": 71,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "Total virtual memory per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT SUM(\"value\")\nFROM \"$measurement\"\nWHERE \"metric_name\" = 'vendor_tt_tnt_memory_virt' AND \"label_pairs_alias\" =~ '$alias' AND \"vendor_app_tag\" = 'MyCacheApplication'\nAND $timeFilter\nGROUP BY time($__interval) fill(previous)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total virtual memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 186
+               },
+               "id": 72,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8828,9 +9524,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 170
+                  "y": 186
                },
-               "id": 67,
+               "id": 73,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -8968,9 +9664,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 170
+                  "y": 186
                },
-               "id": 68,
+               "id": 74,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9108,9 +9804,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 178
+                  "y": 194
                },
-               "id": 69,
+               "id": 75,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9248,9 +9944,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 178
+                  "y": 194
                },
-               "id": 70,
+               "id": 76,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9389,9 +10085,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 186
+                  "y": 202
                },
-               "id": 71,
+               "id": 77,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -9531,9 +10227,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 186
+                  "y": 202
                },
-               "id": 72,
+               "id": 78,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9671,9 +10367,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 186
+                  "y": 202
                },
-               "id": 73,
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9815,9 +10511,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 194
+            "y": 210
          },
-         "id": 74,
+         "id": 80,
          "panels": [
             {
                "aliasColors": { },
@@ -9831,9 +10527,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 195
+                  "y": 211
                },
-               "id": 75,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9977,9 +10673,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 195
+                  "y": 211
                },
-               "id": 76,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10123,9 +10819,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 195
+                  "y": 211
                },
-               "id": 77,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10269,9 +10965,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 195
+                  "y": 211
                },
-               "id": 78,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10409,9 +11105,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 203
+                  "y": 219
                },
-               "id": 79,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10555,9 +11251,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 203
+                  "y": 219
                },
-               "id": 80,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10701,9 +11397,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 211
+                  "y": 227
                },
-               "id": 81,
+               "id": 87,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10847,9 +11543,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 211
+                  "y": 227
                },
-               "id": 82,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10993,9 +11689,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 211
+                  "y": 227
                },
-               "id": 83,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11139,9 +11835,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 219
+                  "y": 235
                },
-               "id": 84,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11285,9 +11981,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 219
+                  "y": 235
                },
-               "id": 85,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11431,9 +12127,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 219
+                  "y": 235
                },
-               "id": 86,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11578,9 +12274,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 227
+                  "y": 243
                },
-               "id": 87,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11721,9 +12417,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 227
+                  "y": 243
                },
-               "id": 88,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11864,9 +12560,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 227
+                  "y": 243
                },
-               "id": 89,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12007,9 +12703,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 227
+                  "y": 243
                },
-               "id": 90,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12149,9 +12845,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 235
+                  "y": 251
                },
-               "id": 91,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12289,9 +12985,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 235
+                  "y": 251
                },
-               "id": 92,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12435,9 +13131,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 235
+                  "y": 251
                },
-               "id": 93,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12585,9 +13281,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 243
+            "y": 259
          },
-         "id": 94,
+         "id": 100,
          "panels": [
             {
                "aliasColors": { },
@@ -12601,9 +13297,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 244
+                  "y": 260
                },
-               "id": 95,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12753,9 +13449,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 244
+                  "y": 260
                },
-               "id": 96,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12905,9 +13601,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 244
+                  "y": 260
                },
-               "id": 97,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13057,9 +13753,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 252
+                  "y": 268
                },
-               "id": 98,
+               "id": 104,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13209,9 +13905,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 252
+                  "y": 268
                },
-               "id": 99,
+               "id": 105,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13361,9 +14057,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 252
+                  "y": 268
                },
-               "id": 100,
+               "id": 106,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13513,9 +14209,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 260
+                  "y": 276
                },
-               "id": 101,
+               "id": 107,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13665,9 +14361,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 260
+                  "y": 276
                },
-               "id": 102,
+               "id": 108,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13817,9 +14513,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 260
+                  "y": 276
                },
-               "id": 103,
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13969,9 +14665,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 268
+                  "y": 284
                },
-               "id": 104,
+               "id": 110,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14121,9 +14817,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 268
+                  "y": 284
                },
-               "id": 105,
+               "id": 111,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14273,9 +14969,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 268
+                  "y": 284
                },
-               "id": 106,
+               "id": 112,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14425,9 +15121,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 276
+                  "y": 292
                },
-               "id": 107,
+               "id": 113,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14577,9 +15273,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 276
+                  "y": 292
                },
-               "id": 108,
+               "id": 114,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14729,9 +15425,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 276
+                  "y": 292
                },
-               "id": 109,
+               "id": 115,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/InfluxDB/dashboard_tarantool3_compiled.json
+++ b/tests/InfluxDB/dashboard_tarantool3_compiled.json
@@ -14787,15 +14787,120 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$influxdb",
-               "description": "This is the average share of time\nspent by instance process executing in user mode.\nMetrics obtained using `getrusage()` call.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "description": "This is the average share of time spent\nby instance process executing.\n\nPanel minimal requirements: metrics 0.8.0.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 284
                },
                "id": 114,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT non_negative_derivative(SUM(\"value\"), 1s)\nFROM \"$policy\".\"$measurement\"\nWHERE ((\"metric_name\" = 'tnt_cpu_user_time' OR \"metric_name\" = 'tnt_cpu_system_time') AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter\nGROUP BY time($__interval), \"label_pairs_alias\" fill(none)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total time per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "This is the average share of time\nspent by instance process executing in user mode.\nMetrics obtained using `getrusage()` call.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 284
+               },
+               "id": 115,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14888,7 +14993,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "CPU user time",
+               "title": "CPU user time per instance",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -14932,11 +15037,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 284
                },
-               "id": 115,
+               "id": 116,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15029,7 +15134,322 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "CPU system time",
+               "title": "CPU system time per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "This is the total share of time spent\nby each cluster process executing.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 292
+               },
+               "id": 117,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "CPU total time per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT non_negative_derivative(SUM(\"value\"), 1s)\nFROM \"$policy\".\"$measurement\"\nWHERE ((\"metric_name\" = 'tnt_cpu_user_time' OR \"metric_name\" = 'tnt_cpu_system_time') AND true)\nAND $timeFilter\nGROUP BY time($__interval)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total time per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "This is the total share of time\nspent in user mode per cluster.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 292
+               },
+               "id": 118,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "CPU total user time per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT non_negative_derivative(SUM(\"value\"), 1s)\nFROM \"$policy\".\"$measurement\"\nWHERE \"metric_name\" = 'tnt_cpu_user_time' AND \"label_pairs_alias\" =~ /^$alias$/\nAND $timeFilter\nGROUP BY time($__interval)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total user time per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "This is the total share of time\nspent in system mode per cluster.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 292
+               },
+               "id": 119,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "CPU total system time per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT non_negative_derivative(SUM(\"value\"), 1s)\nFROM \"$policy\".\"$measurement\"\nWHERE \"metric_name\" = 'tnt_cpu_system_time' AND \"label_pairs_alias\" =~ /^$alias$/\nAND $timeFilter\nGROUP BY time($__interval)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total system time per cluster",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -15079,9 +15499,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 292
+            "y": 300
          },
-         "id": 116,
+         "id": 120,
          "panels": [
             {
                "aliasColors": { },
@@ -15089,15 +15509,699 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$influxdb",
-               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance. \n",
+               "description": "Total memory used by Tarantool.\n\nPanel minimal requirements: metrics 1.6.0.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 293
+                  "y": 301
                },
-               "id": 117,
+               "id": 121,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT SUM(\"value\")\nFROM \"$policy\".\"$measurement\"\nWHERE ((\"metric_name\" = 'tnt_memory' OR \"metric_name\" = 'tnt_memory_virt') AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter\nGROUP BY time($__interval), \"label_pairs_alias\" fill(none)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Resident memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 301
+               },
+               "id": 122,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "$measurement",
+                     "policy": "$policy",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_memory"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Resident memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Virtual memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 301
+               },
+               "id": 123,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "$measurement",
+                     "policy": "$policy",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_memory_virt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Virtual memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Total memory used by Tarantool.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 309
+               },
+               "id": 124,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "Total memory per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT SUM(\"value\")\nFROM \"$policy\".\"$measurement\"\nWHERE ((\"metric_name\" = 'tnt_memory' OR \"metric_name\" = 'tnt_memory_virt') AND true)\nAND $timeFilter\nGROUP BY time($__interval) fill(previous)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Resident memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 309
+               },
+               "id": 125,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "Total resident memory per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT SUM(\"value\")\nFROM \"$policy\".\"$measurement\"\nWHERE \"metric_name\" = 'tnt_memory' AND \"label_pairs_alias\" =~ /^$alias$/\nAND $timeFilter\nGROUP BY time($__interval) fill(previous)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total resident memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Virtual memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 309
+               },
+               "id": 126,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "Total virtual memory per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT SUM(\"value\")\nFROM \"$policy\".\"$measurement\"\nWHERE \"metric_name\" = 'tnt_memory_virt' AND \"label_pairs_alias\" =~ /^$alias$/\nAND $timeFilter\nGROUP BY time($__interval) fill(previous)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total virtual memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 317
+               },
+               "id": 127,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15229,9 +16333,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 293
+                  "y": 317
                },
-               "id": 118,
+               "id": 128,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15363,9 +16467,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 293
+                  "y": 317
                },
-               "id": 119,
+               "id": 129,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15497,9 +16601,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 301
+                  "y": 325
                },
-               "id": 120,
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15631,9 +16735,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 301
+                  "y": 325
                },
-               "id": 121,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15766,9 +16870,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 309
+                  "y": 333
                },
-               "id": 122,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15902,9 +17006,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 309
+                  "y": 333
                },
-               "id": 123,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16036,9 +17140,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 309
+                  "y": 333
                },
-               "id": 124,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16174,9 +17278,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 317
+            "y": 341
          },
-         "id": 125,
+         "id": 135,
          "panels": [
             {
                "aliasColors": { },
@@ -16190,9 +17294,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 318
+                  "y": 342
                },
-               "id": 126,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16330,9 +17434,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 318
+                  "y": 342
                },
-               "id": 127,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16470,9 +17574,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 318
+                  "y": 342
                },
-               "id": 128,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16610,9 +17714,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 318
+                  "y": 342
                },
-               "id": 129,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16744,9 +17848,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 326
+                  "y": 350
                },
-               "id": 130,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16884,9 +17988,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 326
+                  "y": 350
                },
-               "id": 131,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17024,9 +18128,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 334
+                  "y": 358
                },
-               "id": 132,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17164,9 +18268,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 334
+                  "y": 358
                },
-               "id": 133,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17304,9 +18408,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 334
+                  "y": 358
                },
-               "id": 134,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17444,9 +18548,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 342
+                  "y": 366
                },
-               "id": 135,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17584,9 +18688,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 342
+                  "y": 366
                },
-               "id": 136,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17724,9 +18828,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 342
+                  "y": 366
                },
-               "id": 137,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17865,9 +18969,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 350
+                  "y": 374
                },
-               "id": 138,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18002,9 +19106,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 350
+                  "y": 374
                },
-               "id": 139,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18139,9 +19243,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 350
+                  "y": 374
                },
-               "id": 140,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18276,9 +19380,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 350
+                  "y": 374
                },
-               "id": 141,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18412,9 +19516,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 358
+                  "y": 382
                },
-               "id": 142,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18546,9 +19650,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 358
+                  "y": 382
                },
-               "id": 143,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18686,9 +19790,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 358
+                  "y": 382
                },
-               "id": 144,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18830,9 +19934,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 366
+            "y": 390
          },
-         "id": 145,
+         "id": 155,
          "panels": [
             {
                "aliasColors": { },
@@ -18846,9 +19950,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 367
+                  "y": 391
                },
-               "id": 146,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18992,9 +20096,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 367
+                  "y": 391
                },
-               "id": 147,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19138,9 +20242,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 367
+                  "y": 391
                },
-               "id": 148,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19284,9 +20388,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 375
+                  "y": 399
                },
-               "id": 149,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19430,9 +20534,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 375
+                  "y": 399
                },
-               "id": 150,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19576,9 +20680,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 375
+                  "y": 399
                },
-               "id": 151,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19722,9 +20826,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 383
+                  "y": 407
                },
-               "id": 152,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19868,9 +20972,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 383
+                  "y": 407
                },
-               "id": 153,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20014,9 +21118,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 383
+                  "y": 407
                },
-               "id": 154,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20160,9 +21264,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 391
+                  "y": 415
                },
-               "id": 155,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20306,9 +21410,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 391
+                  "y": 415
                },
-               "id": 156,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20452,9 +21556,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 391
+                  "y": 415
                },
-               "id": 157,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20598,9 +21702,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 399
+                  "y": 423
                },
-               "id": 158,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20744,9 +21848,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 399
+                  "y": 423
                },
-               "id": 159,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20890,9 +21994,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 399
+                  "y": 423
                },
-               "id": 160,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21040,9 +22144,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 407
+            "y": 431
          },
-         "id": 161,
+         "id": 171,
          "panels": [
             {
                "aliasColors": { },
@@ -21056,9 +22160,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 408
+                  "y": 432
                },
-               "id": 162,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21214,9 +22318,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 408
+                  "y": 432
                },
-               "id": 163,
+               "id": 173,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21372,9 +22476,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 408
+                  "y": 432
                },
-               "id": 164,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21530,9 +22634,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 408
+                  "y": 432
                },
-               "id": 165,
+               "id": 175,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21688,9 +22792,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 416
+                  "y": 440
                },
-               "id": 166,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21792,9 +22896,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 416
+                  "y": 440
                },
-               "id": 167,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21896,9 +23000,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 416
+                  "y": 440
                },
-               "id": 168,
+               "id": 178,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22048,9 +23152,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 424
+                  "y": 448
                },
-               "id": 169,
+               "id": 179,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22206,9 +23310,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 424
+                  "y": 448
                },
-               "id": 170,
+               "id": 180,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22364,9 +23468,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 424
+                  "y": 448
                },
-               "id": 171,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22522,9 +23626,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 424
+                  "y": 448
                },
-               "id": 172,
+               "id": 182,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22680,9 +23784,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 432
+                  "y": 456
                },
-               "id": 173,
+               "id": 183,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22838,9 +23942,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 432
+                  "y": 456
                },
-               "id": 174,
+               "id": 184,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22996,9 +24100,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 432
+                  "y": 456
                },
-               "id": 175,
+               "id": 185,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23154,9 +24258,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 432
+                  "y": 456
                },
-               "id": 176,
+               "id": 186,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23312,9 +24416,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 440
+                  "y": 464
                },
-               "id": 177,
+               "id": 187,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23470,9 +24574,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 440
+                  "y": 464
                },
-               "id": 178,
+               "id": 188,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23628,9 +24732,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 440
+                  "y": 464
                },
-               "id": 179,
+               "id": 189,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23786,9 +24890,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 440
+                  "y": 464
                },
-               "id": 180,
+               "id": 190,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23944,9 +25048,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 448
+                  "y": 472
                },
-               "id": 181,
+               "id": 191,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24102,9 +25206,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 448
+                  "y": 472
                },
-               "id": 182,
+               "id": 192,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24260,9 +25364,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 448
+                  "y": 472
                },
-               "id": 183,
+               "id": 193,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24418,9 +25522,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 448
+                  "y": 472
                },
-               "id": 184,
+               "id": 194,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24576,9 +25680,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 456
+                  "y": 480
                },
-               "id": 185,
+               "id": 195,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24734,9 +25838,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 456
+                  "y": 480
                },
-               "id": 186,
+               "id": 196,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24892,9 +25996,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 456
+                  "y": 480
                },
-               "id": 187,
+               "id": 197,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25050,9 +26154,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 456
+                  "y": 480
                },
-               "id": 188,
+               "id": 198,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25208,9 +26312,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 464
+                  "y": 488
                },
-               "id": 189,
+               "id": 199,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25366,9 +26470,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 464
+                  "y": 488
                },
-               "id": 190,
+               "id": 200,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25524,9 +26628,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 464
+                  "y": 488
                },
-               "id": 191,
+               "id": 201,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25682,9 +26786,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 464
+                  "y": 488
                },
-               "id": 192,
+               "id": 202,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25840,9 +26944,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 472
+                  "y": 496
                },
-               "id": 193,
+               "id": 203,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25998,9 +27102,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 472
+                  "y": 496
                },
-               "id": 194,
+               "id": 204,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26156,9 +27260,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 472
+                  "y": 496
                },
-               "id": 195,
+               "id": 205,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26314,9 +27418,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 472
+                  "y": 496
                },
-               "id": 196,
+               "id": 206,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26472,9 +27576,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 480
+                  "y": 504
                },
-               "id": 197,
+               "id": 207,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26630,9 +27734,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 480
+                  "y": 504
                },
-               "id": 198,
+               "id": 208,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26788,9 +27892,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 480
+                  "y": 504
                },
-               "id": 199,
+               "id": 209,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26946,9 +28050,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 480
+                  "y": 504
                },
-               "id": 200,
+               "id": 210,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27104,9 +28208,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 488
+                  "y": 512
                },
-               "id": 201,
+               "id": 211,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27262,9 +28366,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 488
+                  "y": 512
                },
-               "id": 202,
+               "id": 212,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27420,9 +28524,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 488
+                  "y": 512
                },
-               "id": 203,
+               "id": 213,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27578,9 +28682,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 488
+                  "y": 512
                },
-               "id": 204,
+               "id": 214,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27736,9 +28840,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 496
+                  "y": 520
                },
-               "id": 205,
+               "id": 215,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27894,9 +28998,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 496
+                  "y": 520
                },
-               "id": 206,
+               "id": 216,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28052,9 +29156,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 496
+                  "y": 520
                },
-               "id": 207,
+               "id": 217,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28210,9 +29314,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 496
+                  "y": 520
                },
-               "id": 208,
+               "id": 218,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28368,9 +29472,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 504
+                  "y": 528
                },
-               "id": 209,
+               "id": 219,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28526,9 +29630,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 504
+                  "y": 528
                },
-               "id": 210,
+               "id": 220,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28684,9 +29788,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 504
+                  "y": 528
                },
-               "id": 211,
+               "id": 221,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28842,9 +29946,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 504
+                  "y": 528
                },
-               "id": 212,
+               "id": 222,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29000,9 +30104,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 512
+                  "y": 536
                },
-               "id": 213,
+               "id": 223,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29158,9 +30262,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 512
+                  "y": 536
                },
-               "id": 214,
+               "id": 224,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29316,9 +30420,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 512
+                  "y": 536
                },
-               "id": 215,
+               "id": 225,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29474,9 +30578,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 512
+                  "y": 536
                },
-               "id": 216,
+               "id": 226,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29632,9 +30736,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 520
+                  "y": 544
                },
-               "id": 217,
+               "id": 227,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29790,9 +30894,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 520
+                  "y": 544
                },
-               "id": 218,
+               "id": 228,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29948,9 +31052,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 520
+                  "y": 544
                },
-               "id": 219,
+               "id": 229,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30106,9 +31210,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 520
+                  "y": 544
                },
-               "id": 220,
+               "id": 230,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30268,9 +31372,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 528
+            "y": 552
          },
-         "id": 221,
+         "id": 231,
          "panels": [
             {
                "aliasColors": { },
@@ -30284,9 +31388,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 529
+                  "y": 553
                },
-               "id": 222,
+               "id": 232,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30430,9 +31534,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 529
+                  "y": 553
                },
-               "id": 223,
+               "id": 233,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30577,9 +31681,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 537
+                  "y": 561
                },
-               "id": 224,
+               "id": 234,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30719,9 +31823,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 537
+                  "y": 561
                },
-               "id": 225,
+               "id": 235,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/InfluxDB/dashboard_tdg_compiled.json
+++ b/tests/InfluxDB/dashboard_tdg_compiled.json
@@ -13853,15 +13853,120 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$influxdb",
-               "description": "This is the average share of time\nspent by instance process executing in user mode.\nMetrics obtained using `getrusage()` call.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "description": "This is the average share of time spent\nby instance process executing.\n\nPanel minimal requirements: metrics 0.8.0.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 273
                },
                "id": 108,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT non_negative_derivative(SUM(\"value\"), 1s)\nFROM \"$policy\".\"$measurement\"\nWHERE ((\"metric_name\" = 'tnt_cpu_user_time' OR \"metric_name\" = 'tnt_cpu_system_time') AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter\nGROUP BY time($__interval), \"label_pairs_alias\" fill(none)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total time per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "This is the average share of time\nspent by instance process executing in user mode.\nMetrics obtained using `getrusage()` call.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 273
+               },
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13954,7 +14059,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "CPU user time",
+               "title": "CPU user time per instance",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -13998,11 +14103,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 273
                },
-               "id": 109,
+               "id": 110,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14095,7 +14200,322 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "CPU system time",
+               "title": "CPU system time per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "This is the total share of time spent\nby each cluster process executing.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 281
+               },
+               "id": 111,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "CPU total time per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT non_negative_derivative(SUM(\"value\"), 1s)\nFROM \"$policy\".\"$measurement\"\nWHERE ((\"metric_name\" = 'tnt_cpu_user_time' OR \"metric_name\" = 'tnt_cpu_system_time') AND true)\nAND $timeFilter\nGROUP BY time($__interval)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total time per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "This is the total share of time\nspent in user mode per cluster.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 281
+               },
+               "id": 112,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "CPU total user time per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT non_negative_derivative(SUM(\"value\"), 1s)\nFROM \"$policy\".\"$measurement\"\nWHERE \"metric_name\" = 'tnt_cpu_user_time' AND \"label_pairs_alias\" =~ /^$alias$/\nAND $timeFilter\nGROUP BY time($__interval)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total user time per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "This is the total share of time\nspent in system mode per cluster.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 281
+               },
+               "id": 113,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "CPU total system time per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT non_negative_derivative(SUM(\"value\"), 1s)\nFROM \"$policy\".\"$measurement\"\nWHERE \"metric_name\" = 'tnt_cpu_system_time' AND \"label_pairs_alias\" =~ /^$alias$/\nAND $timeFilter\nGROUP BY time($__interval)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total system time per cluster",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -14141,9 +14561,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 281
+                  "y": 289
                },
-               "id": 110,
+               "id": 114,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14293,9 +14713,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 281
+                  "y": 289
                },
-               "id": 111,
+               "id": 115,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14449,9 +14869,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 289
+            "y": 297
          },
-         "id": 112,
+         "id": 116,
          "panels": [
             {
                "aliasColors": { },
@@ -14459,15 +14879,699 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$influxdb",
-               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance. \n",
+               "description": "Total memory used by Tarantool.\n\nPanel minimal requirements: metrics 1.6.0.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 290
+                  "y": 298
                },
-               "id": 113,
+               "id": 117,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT SUM(\"value\")\nFROM \"$policy\".\"$measurement\"\nWHERE ((\"metric_name\" = 'tnt_memory' OR \"metric_name\" = 'tnt_memory_virt') AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter\nGROUP BY time($__interval), \"label_pairs_alias\" fill(none)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Resident memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 298
+               },
+               "id": 118,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "$measurement",
+                     "policy": "$policy",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_memory"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Resident memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Virtual memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 298
+               },
+               "id": 119,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "$measurement",
+                     "policy": "$policy",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_memory_virt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Virtual memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Total memory used by Tarantool.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 306
+               },
+               "id": 120,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "Total memory per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT SUM(\"value\")\nFROM \"$policy\".\"$measurement\"\nWHERE ((\"metric_name\" = 'tnt_memory' OR \"metric_name\" = 'tnt_memory_virt') AND true)\nAND $timeFilter\nGROUP BY time($__interval) fill(previous)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Resident memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 306
+               },
+               "id": 121,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "Total resident memory per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT SUM(\"value\")\nFROM \"$policy\".\"$measurement\"\nWHERE \"metric_name\" = 'tnt_memory' AND \"label_pairs_alias\" =~ /^$alias$/\nAND $timeFilter\nGROUP BY time($__interval) fill(previous)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total resident memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Virtual memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 306
+               },
+               "id": 122,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "Total virtual memory per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT SUM(\"value\")\nFROM \"$policy\".\"$measurement\"\nWHERE \"metric_name\" = 'tnt_memory_virt' AND \"label_pairs_alias\" =~ /^$alias$/\nAND $timeFilter\nGROUP BY time($__interval) fill(previous)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total virtual memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 314
+               },
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14599,9 +15703,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 290
+                  "y": 314
                },
-               "id": 114,
+               "id": 124,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -14733,9 +15837,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 290
+                  "y": 314
                },
-               "id": 115,
+               "id": 125,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14867,9 +15971,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 298
+                  "y": 322
                },
-               "id": 116,
+               "id": 126,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15001,9 +16105,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 298
+                  "y": 322
                },
-               "id": 117,
+               "id": 127,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15136,9 +16240,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 306
+                  "y": 330
                },
-               "id": 118,
+               "id": 128,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15272,9 +16376,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 306
+                  "y": 330
                },
-               "id": 119,
+               "id": 129,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15406,9 +16510,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 306
+                  "y": 330
                },
-               "id": 120,
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15544,9 +16648,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 314
+            "y": 338
          },
-         "id": 121,
+         "id": 131,
          "panels": [
             {
                "aliasColors": { },
@@ -15560,9 +16664,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 315
+                  "y": 339
                },
-               "id": 122,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15700,9 +16804,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 315
+                  "y": 339
                },
-               "id": 123,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15840,9 +16944,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 315
+                  "y": 339
                },
-               "id": 124,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15980,9 +17084,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 315
+                  "y": 339
                },
-               "id": 125,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16114,9 +17218,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 323
+                  "y": 347
                },
-               "id": 126,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16254,9 +17358,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 323
+                  "y": 347
                },
-               "id": 127,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16394,9 +17498,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 331
+                  "y": 355
                },
-               "id": 128,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16534,9 +17638,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 331
+                  "y": 355
                },
-               "id": 129,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16674,9 +17778,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 331
+                  "y": 355
                },
-               "id": 130,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16814,9 +17918,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 339
+                  "y": 363
                },
-               "id": 131,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16954,9 +18058,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 339
+                  "y": 363
                },
-               "id": 132,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17094,9 +18198,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 339
+                  "y": 363
                },
-               "id": 133,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17235,9 +18339,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 347
+                  "y": 371
                },
-               "id": 134,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17372,9 +18476,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 347
+                  "y": 371
                },
-               "id": 135,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17509,9 +18613,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 347
+                  "y": 371
                },
-               "id": 136,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17646,9 +18750,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 347
+                  "y": 371
                },
-               "id": 137,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17782,9 +18886,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 355
+                  "y": 379
                },
-               "id": 138,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17916,9 +19020,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 355
+                  "y": 379
                },
-               "id": 139,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18056,9 +19160,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 355
+                  "y": 379
                },
-               "id": 140,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18200,9 +19304,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 363
+            "y": 387
          },
-         "id": 141,
+         "id": 151,
          "panels": [
             {
                "aliasColors": { },
@@ -18216,9 +19320,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 364
+                  "y": 388
                },
-               "id": 142,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18362,9 +19466,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 364
+                  "y": 388
                },
-               "id": 143,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18508,9 +19612,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 364
+                  "y": 388
                },
-               "id": 144,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18654,9 +19758,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 372
+                  "y": 396
                },
-               "id": 145,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18800,9 +19904,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 372
+                  "y": 396
                },
-               "id": 146,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18946,9 +20050,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 372
+                  "y": 396
                },
-               "id": 147,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19092,9 +20196,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 380
+                  "y": 404
                },
-               "id": 148,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19238,9 +20342,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 380
+                  "y": 404
                },
-               "id": 149,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19384,9 +20488,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 380
+                  "y": 404
                },
-               "id": 150,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19530,9 +20634,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 388
+                  "y": 412
                },
-               "id": 151,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19676,9 +20780,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 388
+                  "y": 412
                },
-               "id": 152,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19822,9 +20926,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 388
+                  "y": 412
                },
-               "id": 153,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19968,9 +21072,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 396
+                  "y": 420
                },
-               "id": 154,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20114,9 +21218,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 396
+                  "y": 420
                },
-               "id": 155,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20260,9 +21364,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 396
+                  "y": 420
                },
-               "id": 156,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20410,9 +21514,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 404
+            "y": 428
          },
-         "id": 157,
+         "id": 167,
          "panels": [
             {
                "aliasColors": { },
@@ -20426,9 +21530,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 405
+                  "y": 429
                },
-               "id": 158,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20578,9 +21682,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 405
+                  "y": 429
                },
-               "id": 159,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20730,9 +21834,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 405
+                  "y": 429
                },
-               "id": 160,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20882,9 +21986,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 413
+                  "y": 437
                },
-               "id": 161,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21040,9 +22144,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 413
+                  "y": 437
                },
-               "id": 162,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21198,9 +22302,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 413
+                  "y": 437
                },
-               "id": 163,
+               "id": 173,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21356,9 +22460,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 413
+                  "y": 437
                },
-               "id": 164,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21514,9 +22618,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 421
+                  "y": 445
                },
-               "id": 165,
+               "id": 175,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21672,9 +22776,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 421
+                  "y": 445
                },
-               "id": 166,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21830,9 +22934,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 421
+                  "y": 445
                },
-               "id": 167,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21988,9 +23092,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 421
+                  "y": 445
                },
-               "id": 168,
+               "id": 178,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22150,9 +23254,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 429
+            "y": 453
          },
-         "id": 169,
+         "id": 179,
          "panels": [
             {
                "aliasColors": { },
@@ -22166,9 +23270,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 430
+                  "y": 454
                },
-               "id": 170,
+               "id": 180,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -22324,9 +23428,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 430
+                  "y": 454
                },
-               "id": 171,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22488,9 +23592,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 430
+                  "y": 454
                },
-               "id": 172,
+               "id": 182,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22652,9 +23756,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 430
+                  "y": 454
                },
-               "id": 173,
+               "id": 183,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22816,9 +23920,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 438
+                  "y": 462
                },
-               "id": 174,
+               "id": 184,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22974,9 +24078,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 438
+                  "y": 462
                },
-               "id": 175,
+               "id": 185,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23132,9 +24236,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 438
+                  "y": 462
                },
-               "id": 176,
+               "id": 186,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23290,9 +24394,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 438
+                  "y": 462
                },
-               "id": 177,
+               "id": 187,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23448,9 +24552,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 446
+                  "y": 470
                },
-               "id": 178,
+               "id": 188,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23612,9 +24716,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 446
+                  "y": 470
                },
-               "id": 179,
+               "id": 189,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23776,9 +24880,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 446
+                  "y": 470
                },
-               "id": 180,
+               "id": 190,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23940,9 +25044,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 454
+                  "y": 478
                },
-               "id": 181,
+               "id": 191,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24104,9 +25208,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 454
+                  "y": 478
                },
-               "id": 182,
+               "id": 192,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -24262,9 +25366,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 454
+                  "y": 478
                },
-               "id": 183,
+               "id": 193,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24426,9 +25530,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 462
+                  "y": 486
                },
-               "id": 184,
+               "id": 194,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24590,9 +25694,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 462
+                  "y": 486
                },
-               "id": 185,
+               "id": 195,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24754,9 +25858,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 462
+                  "y": 486
                },
-               "id": 186,
+               "id": 196,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24918,9 +26022,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 470
+                  "y": 494
                },
-               "id": 187,
+               "id": 197,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25082,9 +26186,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 470
+                  "y": 494
                },
-               "id": 188,
+               "id": 198,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -25240,9 +26344,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 470
+                  "y": 494
                },
-               "id": 189,
+               "id": 199,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25404,9 +26508,9 @@
                   "h": 10,
                   "w": 24,
                   "x": 0,
-                  "y": 478
+                  "y": 502
                },
-               "id": 190,
+               "id": 200,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25574,9 +26678,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 488
+                  "y": 512
                },
-               "id": 191,
+               "id": 201,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25738,9 +26842,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 488
+                  "y": 512
                },
-               "id": 192,
+               "id": 202,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25902,9 +27006,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 488
+                  "y": 512
                },
-               "id": 193,
+               "id": 203,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26066,9 +27170,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 488
+                  "y": 512
                },
-               "id": 194,
+               "id": 204,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26234,9 +27338,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 496
+            "y": 520
          },
-         "id": 195,
+         "id": 205,
          "panels": [
             {
                "aliasColors": { },
@@ -26250,9 +27354,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 497
+                  "y": 521
                },
-               "id": 196,
+               "id": 206,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26408,9 +27512,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 497
+                  "y": 521
                },
-               "id": 197,
+               "id": 207,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26566,9 +27670,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 505
+                  "y": 529
                },
-               "id": 198,
+               "id": 208,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26730,9 +27834,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 505
+                  "y": 529
                },
-               "id": 199,
+               "id": 209,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26894,9 +27998,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 513
+                  "y": 537
                },
-               "id": 200,
+               "id": 210,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27058,9 +28162,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 513
+                  "y": 537
                },
-               "id": 201,
+               "id": 211,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27222,9 +28326,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 513
+                  "y": 537
                },
-               "id": 202,
+               "id": 212,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27386,9 +28490,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 521
+                  "y": 545
                },
-               "id": 203,
+               "id": 213,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27550,9 +28654,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 521
+                  "y": 545
                },
-               "id": 204,
+               "id": 214,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27714,9 +28818,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 521
+                  "y": 545
                },
-               "id": 205,
+               "id": 215,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27878,9 +28982,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 529
+                  "y": 553
                },
-               "id": 206,
+               "id": 216,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28048,9 +29152,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 529
+                  "y": 553
                },
-               "id": 207,
+               "id": 217,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28218,9 +29322,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 529
+                  "y": 553
                },
-               "id": 208,
+               "id": 218,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28388,9 +29492,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 529
+                  "y": 553
                },
-               "id": 209,
+               "id": 219,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28558,9 +29662,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 537
+                  "y": 561
                },
-               "id": 210,
+               "id": 220,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28728,9 +29832,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 537
+                  "y": 561
                },
-               "id": 211,
+               "id": 221,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28896,9 +30000,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 545
+            "y": 569
          },
-         "id": 212,
+         "id": 222,
          "panels": [
             {
                "aliasColors": { },
@@ -28912,9 +30016,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 546
+                  "y": 570
                },
-               "id": 213,
+               "id": 223,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -29064,9 +30168,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 546
+                  "y": 570
                },
-               "id": 214,
+               "id": 224,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29216,9 +30320,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 554
+                  "y": 578
                },
-               "id": 215,
+               "id": 225,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29374,9 +30478,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 554
+                  "y": 578
                },
-               "id": 216,
+               "id": 226,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29530,9 +30634,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 562
+            "y": 586
          },
-         "id": 217,
+         "id": 227,
          "panels": [
             {
                "aliasColors": { },
@@ -29546,9 +30650,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 563
+                  "y": 587
                },
-               "id": 218,
+               "id": 228,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -29698,9 +30802,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 563
+                  "y": 587
                },
-               "id": 219,
+               "id": 229,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -29854,9 +30958,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 571
+            "y": 595
          },
-         "id": 220,
+         "id": 230,
          "panels": [
             {
                "aliasColors": { },
@@ -29870,9 +30974,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 572
+                  "y": 596
                },
-               "id": 221,
+               "id": 231,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30016,9 +31120,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 572
+                  "y": 596
                },
-               "id": 222,
+               "id": 232,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30163,9 +31267,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 580
+                  "y": 604
                },
-               "id": 223,
+               "id": 233,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30305,9 +31409,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 580
+                  "y": 604
                },
-               "id": 224,
+               "id": 234,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30449,9 +31553,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 588
+            "y": 612
          },
-         "id": 225,
+         "id": 235,
          "panels": [
             {
                "aliasColors": { },
@@ -30465,9 +31569,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 589
+                  "y": 613
                },
-               "id": 226,
+               "id": 236,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30569,9 +31673,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 589
+                  "y": 613
                },
-               "id": 227,
+               "id": 237,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30674,9 +31778,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 597
+                  "y": 621
                },
-               "id": 228,
+               "id": 238,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30811,9 +31915,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 597
+                  "y": 621
                },
-               "id": 229,
+               "id": 239,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30951,9 +32055,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 605
+            "y": 629
          },
-         "id": 230,
+         "id": 240,
          "panels": [
             {
                "aliasColors": { },
@@ -30968,9 +32072,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 606
+                  "y": 630
                },
-               "id": 231,
+               "id": 241,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -31111,9 +32215,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 606
+                  "y": 630
                },
-               "id": 232,
+               "id": 242,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -31254,9 +32358,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 606
+                  "y": 630
                },
-               "id": 233,
+               "id": 243,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -31396,9 +32500,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 614
+                  "y": 638
                },
-               "id": 234,
+               "id": 244,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -31536,9 +32640,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 614
+                  "y": 638
                },
-               "id": 235,
+               "id": 245,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -31677,9 +32781,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 614
+                  "y": 638
                },
-               "id": 236,
+               "id": 246,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -31823,9 +32927,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 622
+            "y": 646
          },
-         "id": 237,
+         "id": 247,
          "panels": [
             {
                "aliasColors": { },
@@ -31839,9 +32943,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 623
+                  "y": 647
                },
-               "id": 238,
+               "id": 248,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31997,9 +33101,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 623
+                  "y": 647
                },
-               "id": 239,
+               "id": 249,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -32101,9 +33205,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 623
+                  "y": 647
                },
-               "id": 240,
+               "id": 250,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -32259,9 +33363,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 631
+                  "y": 655
                },
-               "id": 241,
+               "id": 251,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -32417,9 +33521,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 631
+                  "y": 655
                },
-               "id": 242,
+               "id": 252,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -32521,9 +33625,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 631
+                  "y": 655
                },
-               "id": 243,
+               "id": 253,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -32683,9 +33787,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 639
+            "y": 663
          },
-         "id": 244,
+         "id": 254,
          "panels": [
             {
                "aliasColors": { },
@@ -32699,9 +33803,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 640
+                  "y": 664
                },
-               "id": 245,
+               "id": 255,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -32851,9 +33955,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 640
+                  "y": 664
                },
-               "id": 246,
+               "id": 256,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -33003,9 +34107,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 640
+                  "y": 664
                },
-               "id": 247,
+               "id": 257,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -33155,9 +34259,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 640
+                  "y": 664
                },
-               "id": 248,
+               "id": 258,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -33307,9 +34411,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 648
+                  "y": 672
                },
-               "id": 249,
+               "id": 259,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -33459,9 +34563,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 648
+                  "y": 672
                },
-               "id": 250,
+               "id": 260,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -33611,9 +34715,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 656
+                  "y": 680
                },
-               "id": 251,
+               "id": 261,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -33763,9 +34867,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 656
+                  "y": 680
                },
-               "id": 252,
+               "id": 262,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -33915,9 +35019,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 656
+                  "y": 680
                },
-               "id": 253,
+               "id": 263,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -34067,9 +35171,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 656
+                  "y": 680
                },
-               "id": 254,
+               "id": 264,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -34219,9 +35323,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 664
+                  "y": 688
                },
-               "id": 255,
+               "id": 265,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -34371,9 +35475,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 664
+                  "y": 688
                },
-               "id": 256,
+               "id": 266,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -34523,9 +35627,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 664
+                  "y": 688
                },
-               "id": 257,
+               "id": 267,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -34675,9 +35779,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 664
+                  "y": 688
                },
-               "id": 258,
+               "id": 268,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -34827,9 +35931,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 672
+                  "y": 696
                },
-               "id": 259,
+               "id": 269,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -34979,9 +36083,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 672
+                  "y": 696
                },
-               "id": 260,
+               "id": 270,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -35131,9 +36235,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 672
+                  "y": 696
                },
-               "id": 261,
+               "id": 271,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -35283,9 +36387,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 672
+                  "y": 696
                },
-               "id": 262,
+               "id": 272,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -35439,9 +36543,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 680
+            "y": 704
          },
-         "id": 263,
+         "id": 273,
          "panels": [
             {
                "aliasColors": { },
@@ -35455,9 +36559,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 681
+                  "y": 705
                },
-               "id": 264,
+               "id": 274,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -35625,9 +36729,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 681
+                  "y": 705
                },
-               "id": 265,
+               "id": 275,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -35795,9 +36899,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 681
+                  "y": 705
                },
-               "id": 266,
+               "id": 276,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -35965,9 +37069,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 689
+                  "y": 713
                },
-               "id": 267,
+               "id": 277,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -36135,9 +37239,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 689
+                  "y": 713
                },
-               "id": 268,
+               "id": 278,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -36305,9 +37409,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 689
+                  "y": 713
                },
-               "id": 269,
+               "id": 279,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -36475,9 +37579,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 697
+                  "y": 721
                },
-               "id": 270,
+               "id": 280,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -36645,9 +37749,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 697
+                  "y": 721
                },
-               "id": 271,
+               "id": 281,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -36815,9 +37919,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 697
+                  "y": 721
                },
-               "id": 272,
+               "id": 282,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -36985,9 +38089,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 705
+                  "y": 729
                },
-               "id": 273,
+               "id": 283,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -37155,9 +38259,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 705
+                  "y": 729
                },
-               "id": 274,
+               "id": 284,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -37325,9 +38429,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 705
+                  "y": 729
                },
-               "id": 275,
+               "id": 285,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -37499,9 +38603,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 713
+            "y": 737
          },
-         "id": 276,
+         "id": 286,
          "panels": [
             {
                "aliasColors": { },
@@ -37515,9 +38619,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 714
+                  "y": 738
                },
-               "id": 277,
+               "id": 287,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -37661,9 +38765,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 714
+                  "y": 738
                },
-               "id": 278,
+               "id": 288,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -37807,9 +38911,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 714
+                  "y": 738
                },
-               "id": 279,
+               "id": 289,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -37953,9 +39057,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 722
+                  "y": 746
                },
-               "id": 280,
+               "id": 290,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -38093,9 +39197,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 722
+                  "y": 746
                },
-               "id": 281,
+               "id": 291,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -38197,9 +39301,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 730
+                  "y": 754
                },
-               "id": 282,
+               "id": 292,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -38349,9 +39453,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 730
+                  "y": 754
                },
-               "id": 283,
+               "id": 293,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -38501,9 +39605,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 730
+                  "y": 754
                },
-               "id": 284,
+               "id": 294,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -38653,9 +39757,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 730
+                  "y": 754
                },
-               "id": 285,
+               "id": 295,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -38805,9 +39909,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 738
+                  "y": 762
                },
-               "id": 286,
+               "id": 296,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -38951,9 +40055,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 738
+                  "y": 762
                },
-               "id": 287,
+               "id": 297,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -39055,9 +40159,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 746
+                  "y": 770
                },
-               "id": 288,
+               "id": 298,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -39207,9 +40311,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 746
+                  "y": 770
                },
-               "id": 289,
+               "id": 299,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -39359,9 +40463,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 746
+                  "y": 770
                },
-               "id": 290,
+               "id": 300,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -39511,9 +40615,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 754
+                  "y": 778
                },
-               "id": 291,
+               "id": 301,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -39657,9 +40761,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 754
+                  "y": 778
                },
-               "id": 292,
+               "id": 302,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
+++ b/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
@@ -14787,15 +14787,120 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$influxdb",
-               "description": "This is the average share of time\nspent by instance process executing in user mode.\nMetrics obtained using `getrusage()` call.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "description": "This is the average share of time spent\nby instance process executing.\n\nPanel minimal requirements: metrics 0.8.0.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 284
                },
                "id": 114,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT non_negative_derivative(SUM(\"value\"), 1s)\nFROM \"$policy\".\"$measurement\"\nWHERE ((\"metric_name\" = 'tnt_cpu_user_time' OR \"metric_name\" = 'tnt_cpu_system_time') AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter\nGROUP BY time($__interval), \"label_pairs_alias\" fill(none)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total time per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "This is the average share of time\nspent by instance process executing in user mode.\nMetrics obtained using `getrusage()` call.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 284
+               },
+               "id": 115,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14888,7 +14993,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "CPU user time",
+               "title": "CPU user time per instance",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -14932,11 +15037,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 284
                },
-               "id": 115,
+               "id": 116,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15029,7 +15134,322 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "CPU system time",
+               "title": "CPU system time per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "This is the total share of time spent\nby each cluster process executing.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 292
+               },
+               "id": 117,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "CPU total time per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT non_negative_derivative(SUM(\"value\"), 1s)\nFROM \"$policy\".\"$measurement\"\nWHERE ((\"metric_name\" = 'tnt_cpu_user_time' OR \"metric_name\" = 'tnt_cpu_system_time') AND true)\nAND $timeFilter\nGROUP BY time($__interval)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total time per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "This is the total share of time\nspent in user mode per cluster.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 292
+               },
+               "id": 118,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "CPU total user time per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT non_negative_derivative(SUM(\"value\"), 1s)\nFROM \"$policy\".\"$measurement\"\nWHERE \"metric_name\" = 'tnt_cpu_user_time' AND \"label_pairs_alias\" =~ /^$alias$/\nAND $timeFilter\nGROUP BY time($__interval)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total user time per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "This is the total share of time\nspent in system mode per cluster.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 292
+               },
+               "id": 119,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "CPU total system time per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT non_negative_derivative(SUM(\"value\"), 1s)\nFROM \"$policy\".\"$measurement\"\nWHERE \"metric_name\" = 'tnt_cpu_system_time' AND \"label_pairs_alias\" =~ /^$alias$/\nAND $timeFilter\nGROUP BY time($__interval)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total system time per cluster",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -15079,9 +15499,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 292
+            "y": 300
          },
-         "id": 116,
+         "id": 120,
          "panels": [
             {
                "aliasColors": { },
@@ -15089,15 +15509,699 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$influxdb",
-               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance. \n",
+               "description": "Total memory used by Tarantool.\n\nPanel minimal requirements: metrics 1.6.0.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 293
+                  "y": 301
                },
-               "id": 117,
+               "id": 121,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT SUM(\"value\")\nFROM \"$policy\".\"$measurement\"\nWHERE ((\"metric_name\" = 'tnt_memory' OR \"metric_name\" = 'tnt_memory_virt') AND \"label_pairs_alias\" =~ /^$alias$/)\nAND $timeFilter\nGROUP BY time($__interval), \"label_pairs_alias\" fill(none)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Resident memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 301
+               },
+               "id": 122,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "$measurement",
+                     "policy": "$policy",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_memory"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Resident memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Virtual memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 301
+               },
+               "id": 123,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "$measurement",
+                     "policy": "$policy",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "mean"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_memory_virt"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "label_pairs_alias",
+                           "operator": "=~",
+                           "value": "/^$alias$/"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Virtual memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Total memory used by Tarantool.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 309
+               },
+               "id": 124,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "Total memory per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT SUM(\"value\")\nFROM \"$policy\".\"$measurement\"\nWHERE ((\"metric_name\" = 'tnt_memory' OR \"metric_name\" = 'tnt_memory_virt') AND true)\nAND $timeFilter\nGROUP BY time($__interval) fill(previous)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Resident memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 309
+               },
+               "id": 125,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "Total resident memory per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT SUM(\"value\")\nFROM \"$policy\".\"$measurement\"\nWHERE \"metric_name\" = 'tnt_memory' AND \"label_pairs_alias\" =~ /^$alias$/\nAND $timeFilter\nGROUP BY time($__interval) fill(previous)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total resident memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Virtual memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 309
+               },
+               "id": 126,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "Total virtual memory per cluster",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "policy": "default",
+                     "query": "SELECT SUM(\"value\")\nFROM \"$policy\".\"$measurement\"\nWHERE \"metric_name\" = 'tnt_memory_virt' AND \"label_pairs_alias\" =~ /^$alias$/\nAND $timeFilter\nGROUP BY time($__interval) fill(previous)\n",
+                     "rawQuery": true,
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [ ],
+                     "tags": [ ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total virtual memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
+               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 317
+               },
+               "id": 127,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15229,9 +16333,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 293
+                  "y": 317
                },
-               "id": 118,
+               "id": 128,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15363,9 +16467,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 293
+                  "y": 317
                },
-               "id": 119,
+               "id": 129,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15497,9 +16601,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 301
+                  "y": 325
                },
-               "id": 120,
+               "id": 130,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15631,9 +16735,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 301
+                  "y": 325
                },
-               "id": 121,
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15766,9 +16870,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 309
+                  "y": 333
                },
-               "id": 122,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15902,9 +17006,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 309
+                  "y": 333
                },
-               "id": 123,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16036,9 +17140,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 309
+                  "y": 333
                },
-               "id": 124,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16174,9 +17278,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 317
+            "y": 341
          },
-         "id": 125,
+         "id": 135,
          "panels": [
             {
                "aliasColors": { },
@@ -16190,9 +17294,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 318
+                  "y": 342
                },
-               "id": 126,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16330,9 +17434,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 318
+                  "y": 342
                },
-               "id": 127,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16470,9 +17574,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 318
+                  "y": 342
                },
-               "id": 128,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16610,9 +17714,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 318
+                  "y": 342
                },
-               "id": 129,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16744,9 +17848,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 326
+                  "y": 350
                },
-               "id": 130,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16884,9 +17988,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 326
+                  "y": 350
                },
-               "id": 131,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17024,9 +18128,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 334
+                  "y": 358
                },
-               "id": 132,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17164,9 +18268,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 334
+                  "y": 358
                },
-               "id": 133,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17304,9 +18408,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 334
+                  "y": 358
                },
-               "id": 134,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17444,9 +18548,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 342
+                  "y": 366
                },
-               "id": 135,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17584,9 +18688,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 342
+                  "y": 366
                },
-               "id": 136,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17724,9 +18828,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 342
+                  "y": 366
                },
-               "id": 137,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17865,9 +18969,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 350
+                  "y": 374
                },
-               "id": 138,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18002,9 +19106,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 350
+                  "y": 374
                },
-               "id": 139,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18139,9 +19243,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 350
+                  "y": 374
                },
-               "id": 140,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18276,9 +19380,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 350
+                  "y": 374
                },
-               "id": 141,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18412,9 +19516,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 358
+                  "y": 382
                },
-               "id": 142,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18546,9 +19650,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 358
+                  "y": 382
                },
-               "id": 143,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18686,9 +19790,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 358
+                  "y": 382
                },
-               "id": 144,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18830,9 +19934,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 366
+            "y": 390
          },
-         "id": 145,
+         "id": 155,
          "panels": [
             {
                "aliasColors": { },
@@ -18846,9 +19950,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 367
+                  "y": 391
                },
-               "id": 146,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18992,9 +20096,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 367
+                  "y": 391
                },
-               "id": 147,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19138,9 +20242,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 367
+                  "y": 391
                },
-               "id": 148,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19284,9 +20388,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 375
+                  "y": 399
                },
-               "id": 149,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19430,9 +20534,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 375
+                  "y": 399
                },
-               "id": 150,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19576,9 +20680,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 375
+                  "y": 399
                },
-               "id": 151,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19722,9 +20826,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 383
+                  "y": 407
                },
-               "id": 152,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19868,9 +20972,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 383
+                  "y": 407
                },
-               "id": 153,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20014,9 +21118,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 383
+                  "y": 407
                },
-               "id": 154,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20160,9 +21264,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 391
+                  "y": 415
                },
-               "id": 155,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20306,9 +21410,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 391
+                  "y": 415
                },
-               "id": 156,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20452,9 +21556,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 391
+                  "y": 415
                },
-               "id": 157,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20598,9 +21702,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 399
+                  "y": 423
                },
-               "id": 158,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20744,9 +21848,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 399
+                  "y": 423
                },
-               "id": 159,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20890,9 +21994,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 399
+                  "y": 423
                },
-               "id": 160,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21040,9 +22144,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 407
+            "y": 431
          },
-         "id": 161,
+         "id": 171,
          "panels": [
             {
                "aliasColors": { },
@@ -21056,9 +22160,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 408
+                  "y": 432
                },
-               "id": 162,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21214,9 +22318,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 408
+                  "y": 432
                },
-               "id": 163,
+               "id": 173,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21372,9 +22476,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 408
+                  "y": 432
                },
-               "id": 164,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21530,9 +22634,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 408
+                  "y": 432
                },
-               "id": 165,
+               "id": 175,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21688,9 +22792,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 416
+                  "y": 440
                },
-               "id": 166,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21792,9 +22896,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 416
+                  "y": 440
                },
-               "id": 167,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21896,9 +23000,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 416
+                  "y": 440
                },
-               "id": 168,
+               "id": 178,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22048,9 +23152,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 424
+                  "y": 448
                },
-               "id": 169,
+               "id": 179,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22206,9 +23310,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 424
+                  "y": 448
                },
-               "id": 170,
+               "id": 180,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22364,9 +23468,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 424
+                  "y": 448
                },
-               "id": 171,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22522,9 +23626,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 424
+                  "y": 448
                },
-               "id": 172,
+               "id": 182,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22680,9 +23784,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 432
+                  "y": 456
                },
-               "id": 173,
+               "id": 183,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22838,9 +23942,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 432
+                  "y": 456
                },
-               "id": 174,
+               "id": 184,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22996,9 +24100,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 432
+                  "y": 456
                },
-               "id": 175,
+               "id": 185,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23154,9 +24258,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 432
+                  "y": 456
                },
-               "id": 176,
+               "id": 186,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23312,9 +24416,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 440
+                  "y": 464
                },
-               "id": 177,
+               "id": 187,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23470,9 +24574,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 440
+                  "y": 464
                },
-               "id": 178,
+               "id": 188,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23628,9 +24732,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 440
+                  "y": 464
                },
-               "id": 179,
+               "id": 189,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23786,9 +24890,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 440
+                  "y": 464
                },
-               "id": 180,
+               "id": 190,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23944,9 +25048,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 448
+                  "y": 472
                },
-               "id": 181,
+               "id": 191,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24102,9 +25206,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 448
+                  "y": 472
                },
-               "id": 182,
+               "id": 192,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24260,9 +25364,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 448
+                  "y": 472
                },
-               "id": 183,
+               "id": 193,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24418,9 +25522,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 448
+                  "y": 472
                },
-               "id": 184,
+               "id": 194,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24576,9 +25680,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 456
+                  "y": 480
                },
-               "id": 185,
+               "id": 195,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24734,9 +25838,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 456
+                  "y": 480
                },
-               "id": 186,
+               "id": 196,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24892,9 +25996,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 456
+                  "y": 480
                },
-               "id": 187,
+               "id": 197,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25050,9 +26154,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 456
+                  "y": 480
                },
-               "id": 188,
+               "id": 198,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25208,9 +26312,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 464
+                  "y": 488
                },
-               "id": 189,
+               "id": 199,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25366,9 +26470,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 464
+                  "y": 488
                },
-               "id": 190,
+               "id": 200,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25524,9 +26628,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 464
+                  "y": 488
                },
-               "id": 191,
+               "id": 201,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25682,9 +26786,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 464
+                  "y": 488
                },
-               "id": 192,
+               "id": 202,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25840,9 +26944,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 472
+                  "y": 496
                },
-               "id": 193,
+               "id": 203,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25998,9 +27102,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 472
+                  "y": 496
                },
-               "id": 194,
+               "id": 204,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26156,9 +27260,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 472
+                  "y": 496
                },
-               "id": 195,
+               "id": 205,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26314,9 +27418,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 472
+                  "y": 496
                },
-               "id": 196,
+               "id": 206,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26472,9 +27576,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 480
+                  "y": 504
                },
-               "id": 197,
+               "id": 207,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26630,9 +27734,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 480
+                  "y": 504
                },
-               "id": 198,
+               "id": 208,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26788,9 +27892,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 480
+                  "y": 504
                },
-               "id": 199,
+               "id": 209,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26946,9 +28050,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 480
+                  "y": 504
                },
-               "id": 200,
+               "id": 210,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27104,9 +28208,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 488
+                  "y": 512
                },
-               "id": 201,
+               "id": 211,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27262,9 +28366,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 488
+                  "y": 512
                },
-               "id": 202,
+               "id": 212,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27420,9 +28524,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 488
+                  "y": 512
                },
-               "id": 203,
+               "id": 213,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27578,9 +28682,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 488
+                  "y": 512
                },
-               "id": 204,
+               "id": 214,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27736,9 +28840,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 496
+                  "y": 520
                },
-               "id": 205,
+               "id": 215,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27894,9 +28998,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 496
+                  "y": 520
                },
-               "id": 206,
+               "id": 216,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28052,9 +29156,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 496
+                  "y": 520
                },
-               "id": 207,
+               "id": 217,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28210,9 +29314,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 496
+                  "y": 520
                },
-               "id": 208,
+               "id": 218,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28368,9 +29472,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 504
+                  "y": 528
                },
-               "id": 209,
+               "id": 219,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28526,9 +29630,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 504
+                  "y": 528
                },
-               "id": 210,
+               "id": 220,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28684,9 +29788,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 504
+                  "y": 528
                },
-               "id": 211,
+               "id": 221,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28842,9 +29946,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 504
+                  "y": 528
                },
-               "id": 212,
+               "id": 222,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29000,9 +30104,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 512
+                  "y": 536
                },
-               "id": 213,
+               "id": 223,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29158,9 +30262,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 512
+                  "y": 536
                },
-               "id": 214,
+               "id": 224,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29316,9 +30420,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 512
+                  "y": 536
                },
-               "id": 215,
+               "id": 225,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29474,9 +30578,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 512
+                  "y": 536
                },
-               "id": 216,
+               "id": 226,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29632,9 +30736,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 520
+                  "y": 544
                },
-               "id": 217,
+               "id": 227,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29790,9 +30894,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 520
+                  "y": 544
                },
-               "id": 218,
+               "id": 228,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29948,9 +31052,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 520
+                  "y": 544
                },
-               "id": 219,
+               "id": 229,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30106,9 +31210,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 520
+                  "y": 544
                },
-               "id": 220,
+               "id": 230,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30268,9 +31372,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 528
+            "y": 552
          },
-         "id": 221,
+         "id": 231,
          "panels": [
             {
                "aliasColors": { },
@@ -30284,9 +31388,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 529
+                  "y": 553
                },
-               "id": 222,
+               "id": 232,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30430,9 +31534,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 529
+                  "y": 553
                },
-               "id": 223,
+               "id": 233,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30577,9 +31681,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 537
+                  "y": 561
                },
-               "id": 224,
+               "id": 234,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30719,9 +31823,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 537
+                  "y": 561
                },
-               "id": 225,
+               "id": 235,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30863,9 +31967,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 545
+            "y": 569
          },
-         "id": 226,
+         "id": 236,
          "panels": [
             {
                "aliasColors": { },
@@ -30879,9 +31983,9 @@
                   "h": 6,
                   "w": 24,
                   "x": 0,
-                  "y": 546
+                  "y": 570
                },
-               "id": 227,
+               "id": 237,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31013,9 +32117,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 552
+                  "y": 576
                },
-               "id": 228,
+               "id": 238,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31153,9 +32257,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 552
+                  "y": 576
                },
-               "id": 229,
+               "id": 239,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_cartridge_compiled.json
+++ b/tests/Prometheus/dashboard_cartridge_compiled.json
@@ -10001,15 +10001,103 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$prometheus",
-               "description": "This is the average share of time\nspent by instance process executing in user mode.\nMetrics obtained using `getrusage()` call.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "description": "This is the average share of time spent\nby instance process executing.\n\nPanel minimal requirements: metrics 0.8.0.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 298
                },
                "id": 123,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tnt_cpu_user_time{alias=~\"$alias\",job=~\"$job\"}[$__rate_interval]) +\nrate(tnt_cpu_system_time{alias=~\"$alias\",job=~\"$job\"}[$__rate_interval])\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total time per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "This is the average share of time\nspent by instance process executing in user mode.\nMetrics obtained using `getrusage()` call.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 298
+               },
+               "id": 124,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10049,7 +10137,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "CPU user time",
+               "title": "CPU user time per instance",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -10093,11 +10181,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 298
                },
-               "id": 124,
+               "id": 125,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10137,7 +10225,271 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "CPU system time",
+               "title": "CPU system time per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "This is the total share of time spent\nby each cluster process executing.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 306
+               },
+               "id": 126,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(tnt_cpu_user_time{job=~\"$job\"}[$__rate_interval])) +\nsum(rate(tnt_cpu_system_time{job=~\"$job\"}[$__rate_interval]))\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "CPU total time per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total time per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "This is the total share of time\nspent in user mode per cluster.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 306
+               },
+               "id": 127,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(tnt_cpu_user_time{job=~\"$job\"}[$__rate_interval]))\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "CPU total user time per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total user time per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "This is the total share of time\nspent in system mode per cluster.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 306
+               },
+               "id": 128,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(tnt_cpu_system_time{job=~\"$job\"}[$__rate_interval]))\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "CPU total system time per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total system time per cluster",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -10187,9 +10539,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 306
+            "y": 314
          },
-         "id": 125,
+         "id": 129,
          "panels": [
             {
                "aliasColors": { },
@@ -10197,15 +10549,537 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$prometheus",
-               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance. \n",
+               "description": "Total memory used by Tarantool.\n\nPanel minimal requirements: metrics 1.6.0.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 307
+                  "y": 315
                },
-               "id": 126,
+               "id": 130,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "(tnt_memory{alias=~\"$alias\",job=~\"$job\"}) +\n(tnt_memory_virt{alias=~\"$alias\",job=~\"$job\"})\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Resident memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 315
+               },
+               "id": 131,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_memory{alias=~\"$alias\",job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Resident memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Virtual memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 315
+               },
+               "id": 132,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_memory_virt{alias=~\"$alias\",job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Virtual memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Total memory used by Tarantool.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 323
+               },
+               "id": 133,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(tnt_memory{job=~\"$job\"}) + sum(tnt_memory_virt{job=~\"$job\"})",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "Total memory per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Resident memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 323
+               },
+               "id": 134,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(tnt_memory{job=~\"$job\"})",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "Total resident memory per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total resident memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Virtual memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 323
+               },
+               "id": 135,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(tnt_memory_virt{job=~\"$job\"})",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "Total virtual memory per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total virtual memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 331
+               },
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10290,9 +11164,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 307
+                  "y": 331
                },
-               "id": 127,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -10377,9 +11251,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 307
+                  "y": 331
                },
-               "id": 128,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10464,9 +11338,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 315
+                  "y": 339
                },
-               "id": 129,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10551,9 +11425,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 315
+                  "y": 339
                },
-               "id": 130,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10639,9 +11513,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 323
+                  "y": 347
                },
-               "id": 131,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -10728,9 +11602,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 323
+                  "y": 347
                },
-               "id": 132,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10815,9 +11689,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 323
+                  "y": 347
                },
-               "id": 133,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10906,9 +11780,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 331
+            "y": 355
          },
-         "id": 134,
+         "id": 144,
          "panels": [
             {
                "aliasColors": { },
@@ -10922,9 +11796,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 332
+                  "y": 356
                },
-               "id": 135,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11009,9 +11883,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 332
+                  "y": 356
                },
-               "id": 136,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11096,9 +11970,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 332
+                  "y": 356
                },
-               "id": 137,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11183,9 +12057,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 332
+                  "y": 356
                },
-               "id": 138,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11270,9 +12144,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 340
+                  "y": 364
                },
-               "id": 139,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11357,9 +12231,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 340
+                  "y": 364
                },
-               "id": 140,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11444,9 +12318,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 348
+                  "y": 372
                },
-               "id": 141,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11531,9 +12405,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 348
+                  "y": 372
                },
-               "id": 142,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11618,9 +12492,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 348
+                  "y": 372
                },
-               "id": 143,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11705,9 +12579,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 356
+                  "y": 380
                },
-               "id": 144,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11792,9 +12666,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 356
+                  "y": 380
                },
-               "id": 145,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11879,9 +12753,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 356
+                  "y": 380
                },
-               "id": 146,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11967,9 +12841,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 364
+                  "y": 388
                },
-               "id": 147,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12057,9 +12931,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 364
+                  "y": 388
                },
-               "id": 148,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12147,9 +13021,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 364
+                  "y": 388
                },
-               "id": 149,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12237,9 +13111,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 364
+                  "y": 388
                },
-               "id": 150,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12326,9 +13200,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 372
+                  "y": 396
                },
-               "id": 151,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12413,9 +13287,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 372
+                  "y": 396
                },
-               "id": 152,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12500,9 +13374,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 372
+                  "y": 396
                },
-               "id": 153,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12591,9 +13465,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 380
+            "y": 404
          },
-         "id": 154,
+         "id": 164,
          "panels": [
             {
                "aliasColors": { },
@@ -12607,9 +13481,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 381
+                  "y": 405
                },
-               "id": 155,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12694,9 +13568,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 381
+                  "y": 405
                },
-               "id": 156,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12781,9 +13655,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 381
+                  "y": 405
                },
-               "id": 157,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12868,9 +13742,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 389
+                  "y": 413
                },
-               "id": 158,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12955,9 +13829,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 389
+                  "y": 413
                },
-               "id": 159,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13042,9 +13916,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 389
+                  "y": 413
                },
-               "id": 160,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13129,9 +14003,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 397
+                  "y": 421
                },
-               "id": 161,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13216,9 +14090,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 397
+                  "y": 421
                },
-               "id": 162,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13303,9 +14177,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 397
+                  "y": 421
                },
-               "id": 163,
+               "id": 173,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13390,9 +14264,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 405
+                  "y": 429
                },
-               "id": 164,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13477,9 +14351,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 405
+                  "y": 429
                },
-               "id": 165,
+               "id": 175,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13564,9 +14438,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 405
+                  "y": 429
                },
-               "id": 166,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13651,9 +14525,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 413
+                  "y": 437
                },
-               "id": 167,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13738,9 +14612,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 413
+                  "y": 437
                },
-               "id": 168,
+               "id": 178,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13825,9 +14699,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 413
+                  "y": 437
                },
-               "id": 169,
+               "id": 179,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13916,9 +14790,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 421
+            "y": 445
          },
-         "id": 170,
+         "id": 180,
          "panels": [
             {
                "aliasColors": { },
@@ -13932,9 +14806,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 422
+                  "y": 446
                },
-               "id": 171,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14019,9 +14893,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 422
+                  "y": 446
                },
-               "id": 172,
+               "id": 182,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14106,9 +14980,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 422
+                  "y": 446
                },
-               "id": 173,
+               "id": 183,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14193,9 +15067,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 422
+                  "y": 446
                },
-               "id": 174,
+               "id": 184,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14280,9 +15154,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 430
+                  "y": 454
                },
-               "id": 175,
+               "id": 185,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14367,9 +15241,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 430
+                  "y": 454
                },
-               "id": 176,
+               "id": 186,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14454,9 +15328,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 430
+                  "y": 454
                },
-               "id": 177,
+               "id": 187,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14541,9 +15415,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 438
+                  "y": 462
                },
-               "id": 178,
+               "id": 188,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14628,9 +15502,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 438
+                  "y": 462
                },
-               "id": 179,
+               "id": 189,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14715,9 +15589,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 438
+                  "y": 462
                },
-               "id": 180,
+               "id": 190,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14802,9 +15676,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 438
+                  "y": 462
                },
-               "id": 181,
+               "id": 191,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14889,9 +15763,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 446
+                  "y": 470
                },
-               "id": 182,
+               "id": 192,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14976,9 +15850,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 446
+                  "y": 470
                },
-               "id": 183,
+               "id": 193,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15063,9 +15937,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 446
+                  "y": 470
                },
-               "id": 184,
+               "id": 194,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15150,9 +16024,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 446
+                  "y": 470
                },
-               "id": 185,
+               "id": 195,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15237,9 +16111,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 454
+                  "y": 478
                },
-               "id": 186,
+               "id": 196,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15324,9 +16198,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 454
+                  "y": 478
                },
-               "id": 187,
+               "id": 197,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15411,9 +16285,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 454
+                  "y": 478
                },
-               "id": 188,
+               "id": 198,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15498,9 +16372,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 454
+                  "y": 478
                },
-               "id": 189,
+               "id": 199,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15585,9 +16459,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 462
+                  "y": 486
                },
-               "id": 190,
+               "id": 200,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15672,9 +16546,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 462
+                  "y": 486
                },
-               "id": 191,
+               "id": 201,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15759,9 +16633,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 462
+                  "y": 486
                },
-               "id": 192,
+               "id": 202,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15846,9 +16720,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 462
+                  "y": 486
                },
-               "id": 193,
+               "id": 203,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15933,9 +16807,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 470
+                  "y": 494
                },
-               "id": 194,
+               "id": 204,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16020,9 +16894,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 470
+                  "y": 494
                },
-               "id": 195,
+               "id": 205,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16107,9 +16981,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 470
+                  "y": 494
                },
-               "id": 196,
+               "id": 206,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16194,9 +17068,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 470
+                  "y": 494
                },
-               "id": 197,
+               "id": 207,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16281,9 +17155,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 478
+                  "y": 502
                },
-               "id": 198,
+               "id": 208,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16368,9 +17242,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 478
+                  "y": 502
                },
-               "id": 199,
+               "id": 209,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16455,9 +17329,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 478
+                  "y": 502
                },
-               "id": 200,
+               "id": 210,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16542,9 +17416,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 478
+                  "y": 502
                },
-               "id": 201,
+               "id": 211,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16629,9 +17503,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 486
+                  "y": 510
                },
-               "id": 202,
+               "id": 212,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16716,9 +17590,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 486
+                  "y": 510
                },
-               "id": 203,
+               "id": 213,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16803,9 +17677,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 486
+                  "y": 510
                },
-               "id": 204,
+               "id": 214,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16890,9 +17764,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 486
+                  "y": 510
                },
-               "id": 205,
+               "id": 215,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16977,9 +17851,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 494
+                  "y": 518
                },
-               "id": 206,
+               "id": 216,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17064,9 +17938,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 494
+                  "y": 518
                },
-               "id": 207,
+               "id": 217,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17151,9 +18025,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 494
+                  "y": 518
                },
-               "id": 208,
+               "id": 218,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17238,9 +18112,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 494
+                  "y": 518
                },
-               "id": 209,
+               "id": 219,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17325,9 +18199,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 502
+                  "y": 526
                },
-               "id": 210,
+               "id": 220,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17412,9 +18286,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 502
+                  "y": 526
                },
-               "id": 211,
+               "id": 221,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17499,9 +18373,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 502
+                  "y": 526
                },
-               "id": 212,
+               "id": 222,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17586,9 +18460,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 502
+                  "y": 526
                },
-               "id": 213,
+               "id": 223,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17673,9 +18547,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 510
+                  "y": 534
                },
-               "id": 214,
+               "id": 224,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17760,9 +18634,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 510
+                  "y": 534
                },
-               "id": 215,
+               "id": 225,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17847,9 +18721,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 510
+                  "y": 534
                },
-               "id": 216,
+               "id": 226,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17934,9 +18808,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 510
+                  "y": 534
                },
-               "id": 217,
+               "id": 227,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18021,9 +18895,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 518
+                  "y": 542
                },
-               "id": 218,
+               "id": 228,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18108,9 +18982,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 518
+                  "y": 542
                },
-               "id": 219,
+               "id": 229,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18195,9 +19069,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 518
+                  "y": 542
                },
-               "id": 220,
+               "id": 230,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18282,9 +19156,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 518
+                  "y": 542
                },
-               "id": 221,
+               "id": 231,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18369,9 +19243,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 526
+                  "y": 550
                },
-               "id": 222,
+               "id": 232,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18456,9 +19330,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 526
+                  "y": 550
                },
-               "id": 223,
+               "id": 233,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18543,9 +19417,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 526
+                  "y": 550
                },
-               "id": 224,
+               "id": 234,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18630,9 +19504,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 526
+                  "y": 550
                },
-               "id": 225,
+               "id": 235,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18717,9 +19591,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 534
+                  "y": 558
                },
-               "id": 226,
+               "id": 236,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18804,9 +19678,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 534
+                  "y": 558
                },
-               "id": 227,
+               "id": 237,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18891,9 +19765,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 534
+                  "y": 558
                },
-               "id": 228,
+               "id": 238,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18978,9 +19852,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 534
+                  "y": 558
                },
-               "id": 229,
+               "id": 239,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19069,9 +19943,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 542
+            "y": 566
          },
-         "id": 230,
+         "id": 240,
          "panels": [
             {
                "aliasColors": { },
@@ -19085,9 +19959,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 543
+                  "y": 567
                },
-               "id": 231,
+               "id": 241,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19172,9 +20046,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 543
+                  "y": 567
                },
-               "id": 232,
+               "id": 242,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19260,9 +20134,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 551
+                  "y": 575
                },
-               "id": 233,
+               "id": 243,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19349,9 +20223,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 551
+                  "y": 575
                },
-               "id": 234,
+               "id": 244,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_custom_compiled.json
+++ b/tests/Prometheus/dashboard_custom_compiled.json
@@ -5870,7 +5870,7 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$prometheus",
-               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance. \n",
+               "description": "Total memory used by Tarantool.\n\nPanel minimal requirements: metrics 1.6.0.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
@@ -5879,6 +5879,528 @@
                   "y": 178
                },
                "id": 73,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "(vendor_tt_tnt_memory{alias=~\"$alias\",vendor_app_label=\"MyCacheApplication\"}) +\n(vendor_tt_tnt_memory_virt{alias=~\"$alias\",vendor_app_label=\"MyCacheApplication\"})\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Resident memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 178
+               },
+               "id": 74,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "vendor_tt_tnt_memory{alias=~\"$alias\",vendor_app_label=\"MyCacheApplication\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Resident memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Virtual memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 178
+               },
+               "id": 75,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "vendor_tt_tnt_memory_virt{alias=~\"$alias\",vendor_app_label=\"MyCacheApplication\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Virtual memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Total memory used by Tarantool.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 186
+               },
+               "id": 76,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(vendor_tt_tnt_memory{vendor_app_label=\"MyCacheApplication\"}) + sum(vendor_tt_tnt_memory_virt{vendor_app_label=\"MyCacheApplication\"})",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "Total memory per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Resident memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 186
+               },
+               "id": 77,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(vendor_tt_tnt_memory{vendor_app_label=\"MyCacheApplication\"})",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "Total resident memory per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total resident memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Virtual memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 186
+               },
+               "id": 78,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(vendor_tt_tnt_memory_virt{vendor_app_label=\"MyCacheApplication\"})",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "Total virtual memory per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total virtual memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 194
+               },
+               "id": 79,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -5963,9 +6485,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 178
+                  "y": 194
                },
-               "id": 74,
+               "id": 80,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6050,9 +6572,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 178
+                  "y": 194
                },
-               "id": 75,
+               "id": 81,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6137,9 +6659,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 186
+                  "y": 202
                },
-               "id": 76,
+               "id": 82,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6224,9 +6746,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 186
+                  "y": 202
                },
-               "id": 77,
+               "id": 83,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6312,9 +6834,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 194
+                  "y": 210
                },
-               "id": 78,
+               "id": 84,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -6401,9 +6923,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 194
+                  "y": 210
                },
-               "id": 79,
+               "id": 85,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6488,9 +7010,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 194
+                  "y": 210
                },
-               "id": 80,
+               "id": 86,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6579,9 +7101,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 202
+            "y": 218
          },
-         "id": 81,
+         "id": 87,
          "panels": [
             {
                "aliasColors": { },
@@ -6595,9 +7117,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 203
+                  "y": 219
                },
-               "id": 82,
+               "id": 88,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6682,9 +7204,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 203
+                  "y": 219
                },
-               "id": 83,
+               "id": 89,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6769,9 +7291,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 203
+                  "y": 219
                },
-               "id": 84,
+               "id": 90,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6856,9 +7378,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 203
+                  "y": 219
                },
-               "id": 85,
+               "id": 91,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -6943,9 +7465,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 211
+                  "y": 227
                },
-               "id": 86,
+               "id": 92,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7030,9 +7552,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 211
+                  "y": 227
                },
-               "id": 87,
+               "id": 93,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7117,9 +7639,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 219
+                  "y": 235
                },
-               "id": 88,
+               "id": 94,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7204,9 +7726,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 219
+                  "y": 235
                },
-               "id": 89,
+               "id": 95,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7291,9 +7813,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 219
+                  "y": 235
                },
-               "id": 90,
+               "id": 96,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7378,9 +7900,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 227
+                  "y": 243
                },
-               "id": 91,
+               "id": 97,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7465,9 +7987,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 227
+                  "y": 243
                },
-               "id": 92,
+               "id": 98,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7552,9 +8074,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 227
+                  "y": 243
                },
-               "id": 93,
+               "id": 99,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7640,9 +8162,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 235
+                  "y": 251
                },
-               "id": 94,
+               "id": 100,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7730,9 +8252,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 235
+                  "y": 251
                },
-               "id": 95,
+               "id": 101,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7820,9 +8342,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 235
+                  "y": 251
                },
-               "id": 96,
+               "id": 102,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7910,9 +8432,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 235
+                  "y": 251
                },
-               "id": 97,
+               "id": 103,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -7999,9 +8521,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 243
+                  "y": 259
                },
-               "id": 98,
+               "id": 104,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8086,9 +8608,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 243
+                  "y": 259
                },
-               "id": 99,
+               "id": 105,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8173,9 +8695,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 243
+                  "y": 259
                },
-               "id": 100,
+               "id": 106,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8264,9 +8786,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 251
+            "y": 267
          },
-         "id": 101,
+         "id": 107,
          "panels": [
             {
                "aliasColors": { },
@@ -8280,9 +8802,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 252
+                  "y": 268
                },
-               "id": 102,
+               "id": 108,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8367,9 +8889,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 252
+                  "y": 268
                },
-               "id": 103,
+               "id": 109,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8454,9 +8976,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 252
+                  "y": 268
                },
-               "id": 104,
+               "id": 110,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8541,9 +9063,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 260
+                  "y": 276
                },
-               "id": 105,
+               "id": 111,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8628,9 +9150,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 260
+                  "y": 276
                },
-               "id": 106,
+               "id": 112,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8715,9 +9237,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 260
+                  "y": 276
                },
-               "id": 107,
+               "id": 113,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8802,9 +9324,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 268
+                  "y": 284
                },
-               "id": 108,
+               "id": 114,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8889,9 +9411,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 268
+                  "y": 284
                },
-               "id": 109,
+               "id": 115,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -8976,9 +9498,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 268
+                  "y": 284
                },
-               "id": 110,
+               "id": 116,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9063,9 +9585,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 276
+                  "y": 292
                },
-               "id": 111,
+               "id": 117,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9150,9 +9672,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 276
+                  "y": 292
                },
-               "id": 112,
+               "id": 118,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9237,9 +9759,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 276
+                  "y": 292
                },
-               "id": 113,
+               "id": 119,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9324,9 +9846,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 284
+                  "y": 300
                },
-               "id": 114,
+               "id": 120,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9411,9 +9933,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 284
+                  "y": 300
                },
-               "id": 115,
+               "id": 121,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9498,9 +10020,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 284
+                  "y": 300
                },
-               "id": 116,
+               "id": 122,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_tarantool3_compiled.json
+++ b/tests/Prometheus/dashboard_tarantool3_compiled.json
@@ -9933,15 +9933,103 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$prometheus",
-               "description": "This is the average share of time\nspent by instance process executing in user mode.\nMetrics obtained using `getrusage()` call.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "description": "This is the average share of time spent\nby instance process executing.\n\nPanel minimal requirements: metrics 0.8.0.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 292
                },
                "id": 121,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tnt_cpu_user_time{alias=~\"$alias\",job=~\"$job\"}[$__rate_interval]) +\nrate(tnt_cpu_system_time{alias=~\"$alias\",job=~\"$job\"}[$__rate_interval])\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total time per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "This is the average share of time\nspent by instance process executing in user mode.\nMetrics obtained using `getrusage()` call.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 292
+               },
+               "id": 122,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9981,7 +10069,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "CPU user time",
+               "title": "CPU user time per instance",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -10025,11 +10113,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 292
                },
-               "id": 122,
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10069,7 +10157,271 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "CPU system time",
+               "title": "CPU system time per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "This is the total share of time spent\nby each cluster process executing.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 300
+               },
+               "id": 124,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(tnt_cpu_user_time{job=~\"$job\"}[$__rate_interval])) +\nsum(rate(tnt_cpu_system_time{job=~\"$job\"}[$__rate_interval]))\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "CPU total time per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total time per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "This is the total share of time\nspent in user mode per cluster.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 300
+               },
+               "id": 125,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(tnt_cpu_user_time{job=~\"$job\"}[$__rate_interval]))\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "CPU total user time per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total user time per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "This is the total share of time\nspent in system mode per cluster.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 300
+               },
+               "id": 126,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(tnt_cpu_system_time{job=~\"$job\"}[$__rate_interval]))\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "CPU total system time per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total system time per cluster",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -10119,9 +10471,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 300
+            "y": 308
          },
-         "id": 123,
+         "id": 127,
          "panels": [
             {
                "aliasColors": { },
@@ -10129,15 +10481,537 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$prometheus",
-               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance. \n",
+               "description": "Total memory used by Tarantool.\n\nPanel minimal requirements: metrics 1.6.0.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 301
+                  "y": 309
                },
-               "id": 124,
+               "id": 128,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "(tnt_memory{alias=~\"$alias\",job=~\"$job\"}) +\n(tnt_memory_virt{alias=~\"$alias\",job=~\"$job\"})\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Resident memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 309
+               },
+               "id": 129,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_memory{alias=~\"$alias\",job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Resident memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Virtual memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 309
+               },
+               "id": 130,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_memory_virt{alias=~\"$alias\",job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Virtual memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Total memory used by Tarantool.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 317
+               },
+               "id": 131,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(tnt_memory{job=~\"$job\"}) + sum(tnt_memory_virt{job=~\"$job\"})",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "Total memory per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Resident memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 317
+               },
+               "id": 132,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(tnt_memory{job=~\"$job\"})",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "Total resident memory per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total resident memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Virtual memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 317
+               },
+               "id": 133,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(tnt_memory_virt{job=~\"$job\"})",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "Total virtual memory per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total virtual memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 325
+               },
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10222,9 +11096,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 301
+                  "y": 325
                },
-               "id": 125,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -10309,9 +11183,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 301
+                  "y": 325
                },
-               "id": 126,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10396,9 +11270,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 309
+                  "y": 333
                },
-               "id": 127,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10483,9 +11357,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 309
+                  "y": 333
                },
-               "id": 128,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10571,9 +11445,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 317
+                  "y": 341
                },
-               "id": 129,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -10660,9 +11534,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 317
+                  "y": 341
                },
-               "id": 130,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10747,9 +11621,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 317
+                  "y": 341
                },
-               "id": 131,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10838,9 +11712,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 325
+            "y": 349
          },
-         "id": 132,
+         "id": 142,
          "panels": [
             {
                "aliasColors": { },
@@ -10854,9 +11728,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 326
+                  "y": 350
                },
-               "id": 133,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10941,9 +11815,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 326
+                  "y": 350
                },
-               "id": 134,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11028,9 +11902,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 326
+                  "y": 350
                },
-               "id": 135,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11115,9 +11989,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 326
+                  "y": 350
                },
-               "id": 136,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11202,9 +12076,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 334
+                  "y": 358
                },
-               "id": 137,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11289,9 +12163,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 334
+                  "y": 358
                },
-               "id": 138,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11376,9 +12250,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 342
+                  "y": 366
                },
-               "id": 139,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11463,9 +12337,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 342
+                  "y": 366
                },
-               "id": 140,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11550,9 +12424,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 342
+                  "y": 366
                },
-               "id": 141,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11637,9 +12511,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 350
+                  "y": 374
                },
-               "id": 142,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11724,9 +12598,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 350
+                  "y": 374
                },
-               "id": 143,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11811,9 +12685,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 350
+                  "y": 374
                },
-               "id": 144,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11899,9 +12773,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 358
+                  "y": 382
                },
-               "id": 145,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11989,9 +12863,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 358
+                  "y": 382
                },
-               "id": 146,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12079,9 +12953,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 358
+                  "y": 382
                },
-               "id": 147,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12169,9 +13043,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 358
+                  "y": 382
                },
-               "id": 148,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12258,9 +13132,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 366
+                  "y": 390
                },
-               "id": 149,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12345,9 +13219,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 366
+                  "y": 390
                },
-               "id": 150,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12432,9 +13306,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 366
+                  "y": 390
                },
-               "id": 151,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12523,9 +13397,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 374
+            "y": 398
          },
-         "id": 152,
+         "id": 162,
          "panels": [
             {
                "aliasColors": { },
@@ -12539,9 +13413,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 375
+                  "y": 399
                },
-               "id": 153,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12626,9 +13500,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 375
+                  "y": 399
                },
-               "id": 154,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12713,9 +13587,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 375
+                  "y": 399
                },
-               "id": 155,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12800,9 +13674,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 383
+                  "y": 407
                },
-               "id": 156,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12887,9 +13761,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 383
+                  "y": 407
                },
-               "id": 157,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12974,9 +13848,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 383
+                  "y": 407
                },
-               "id": 158,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13061,9 +13935,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 391
+                  "y": 415
                },
-               "id": 159,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13148,9 +14022,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 391
+                  "y": 415
                },
-               "id": 160,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13235,9 +14109,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 391
+                  "y": 415
                },
-               "id": 161,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13322,9 +14196,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 399
+                  "y": 423
                },
-               "id": 162,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13409,9 +14283,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 399
+                  "y": 423
                },
-               "id": 163,
+               "id": 173,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13496,9 +14370,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 399
+                  "y": 423
                },
-               "id": 164,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13583,9 +14457,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 407
+                  "y": 431
                },
-               "id": 165,
+               "id": 175,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13670,9 +14544,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 407
+                  "y": 431
                },
-               "id": 166,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13757,9 +14631,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 407
+                  "y": 431
                },
-               "id": 167,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13848,9 +14722,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 415
+            "y": 439
          },
-         "id": 168,
+         "id": 178,
          "panels": [
             {
                "aliasColors": { },
@@ -13864,9 +14738,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 416
+                  "y": 440
                },
-               "id": 169,
+               "id": 179,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13951,9 +14825,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 416
+                  "y": 440
                },
-               "id": 170,
+               "id": 180,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14038,9 +14912,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 416
+                  "y": 440
                },
-               "id": 171,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14125,9 +14999,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 416
+                  "y": 440
                },
-               "id": 172,
+               "id": 182,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14212,9 +15086,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 424
+                  "y": 448
                },
-               "id": 173,
+               "id": 183,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14299,9 +15173,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 424
+                  "y": 448
                },
-               "id": 174,
+               "id": 184,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14386,9 +15260,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 424
+                  "y": 448
                },
-               "id": 175,
+               "id": 185,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14473,9 +15347,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 432
+                  "y": 456
                },
-               "id": 176,
+               "id": 186,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14560,9 +15434,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 432
+                  "y": 456
                },
-               "id": 177,
+               "id": 187,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14647,9 +15521,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 432
+                  "y": 456
                },
-               "id": 178,
+               "id": 188,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14734,9 +15608,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 432
+                  "y": 456
                },
-               "id": 179,
+               "id": 189,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14821,9 +15695,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 440
+                  "y": 464
                },
-               "id": 180,
+               "id": 190,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14908,9 +15782,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 440
+                  "y": 464
                },
-               "id": 181,
+               "id": 191,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14995,9 +15869,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 440
+                  "y": 464
                },
-               "id": 182,
+               "id": 192,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15082,9 +15956,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 440
+                  "y": 464
                },
-               "id": 183,
+               "id": 193,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15169,9 +16043,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 448
+                  "y": 472
                },
-               "id": 184,
+               "id": 194,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15256,9 +16130,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 448
+                  "y": 472
                },
-               "id": 185,
+               "id": 195,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15343,9 +16217,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 448
+                  "y": 472
                },
-               "id": 186,
+               "id": 196,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15430,9 +16304,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 448
+                  "y": 472
                },
-               "id": 187,
+               "id": 197,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15517,9 +16391,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 456
+                  "y": 480
                },
-               "id": 188,
+               "id": 198,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15604,9 +16478,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 456
+                  "y": 480
                },
-               "id": 189,
+               "id": 199,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15691,9 +16565,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 456
+                  "y": 480
                },
-               "id": 190,
+               "id": 200,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15778,9 +16652,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 456
+                  "y": 480
                },
-               "id": 191,
+               "id": 201,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15865,9 +16739,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 464
+                  "y": 488
                },
-               "id": 192,
+               "id": 202,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15952,9 +16826,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 464
+                  "y": 488
                },
-               "id": 193,
+               "id": 203,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16039,9 +16913,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 464
+                  "y": 488
                },
-               "id": 194,
+               "id": 204,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16126,9 +17000,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 464
+                  "y": 488
                },
-               "id": 195,
+               "id": 205,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16213,9 +17087,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 472
+                  "y": 496
                },
-               "id": 196,
+               "id": 206,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16300,9 +17174,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 472
+                  "y": 496
                },
-               "id": 197,
+               "id": 207,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16387,9 +17261,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 472
+                  "y": 496
                },
-               "id": 198,
+               "id": 208,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16474,9 +17348,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 472
+                  "y": 496
                },
-               "id": 199,
+               "id": 209,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16561,9 +17435,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 480
+                  "y": 504
                },
-               "id": 200,
+               "id": 210,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16648,9 +17522,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 480
+                  "y": 504
                },
-               "id": 201,
+               "id": 211,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16735,9 +17609,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 480
+                  "y": 504
                },
-               "id": 202,
+               "id": 212,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16822,9 +17696,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 480
+                  "y": 504
                },
-               "id": 203,
+               "id": 213,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16909,9 +17783,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 488
+                  "y": 512
                },
-               "id": 204,
+               "id": 214,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16996,9 +17870,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 488
+                  "y": 512
                },
-               "id": 205,
+               "id": 215,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17083,9 +17957,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 488
+                  "y": 512
                },
-               "id": 206,
+               "id": 216,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17170,9 +18044,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 488
+                  "y": 512
                },
-               "id": 207,
+               "id": 217,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17257,9 +18131,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 496
+                  "y": 520
                },
-               "id": 208,
+               "id": 218,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17344,9 +18218,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 496
+                  "y": 520
                },
-               "id": 209,
+               "id": 219,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17431,9 +18305,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 496
+                  "y": 520
                },
-               "id": 210,
+               "id": 220,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17518,9 +18392,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 496
+                  "y": 520
                },
-               "id": 211,
+               "id": 221,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17605,9 +18479,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 504
+                  "y": 528
                },
-               "id": 212,
+               "id": 222,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17692,9 +18566,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 504
+                  "y": 528
                },
-               "id": 213,
+               "id": 223,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17779,9 +18653,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 504
+                  "y": 528
                },
-               "id": 214,
+               "id": 224,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17866,9 +18740,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 504
+                  "y": 528
                },
-               "id": 215,
+               "id": 225,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17953,9 +18827,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 512
+                  "y": 536
                },
-               "id": 216,
+               "id": 226,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18040,9 +18914,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 512
+                  "y": 536
                },
-               "id": 217,
+               "id": 227,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18127,9 +19001,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 512
+                  "y": 536
                },
-               "id": 218,
+               "id": 228,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18214,9 +19088,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 512
+                  "y": 536
                },
-               "id": 219,
+               "id": 229,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18301,9 +19175,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 520
+                  "y": 544
                },
-               "id": 220,
+               "id": 230,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18388,9 +19262,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 520
+                  "y": 544
                },
-               "id": 221,
+               "id": 231,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18475,9 +19349,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 520
+                  "y": 544
                },
-               "id": 222,
+               "id": 232,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18562,9 +19436,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 520
+                  "y": 544
                },
-               "id": 223,
+               "id": 233,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18649,9 +19523,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 528
+                  "y": 552
                },
-               "id": 224,
+               "id": 234,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18736,9 +19610,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 528
+                  "y": 552
                },
-               "id": 225,
+               "id": 235,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18823,9 +19697,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 528
+                  "y": 552
                },
-               "id": 226,
+               "id": 236,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18910,9 +19784,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 528
+                  "y": 552
                },
-               "id": 227,
+               "id": 237,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19001,9 +19875,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 536
+            "y": 560
          },
-         "id": 228,
+         "id": 238,
          "panels": [
             {
                "aliasColors": { },
@@ -19017,9 +19891,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 537
+                  "y": 561
                },
-               "id": 229,
+               "id": 239,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19104,9 +19978,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 537
+                  "y": 561
                },
-               "id": 230,
+               "id": 240,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19192,9 +20066,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 545
+                  "y": 569
                },
-               "id": 231,
+               "id": 241,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19281,9 +20155,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 545
+                  "y": 569
                },
-               "id": 232,
+               "id": 242,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_tdg_compiled.json
+++ b/tests/Prometheus/dashboard_tdg_compiled.json
@@ -9459,15 +9459,103 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$prometheus",
-               "description": "This is the average share of time\nspent by instance process executing in user mode.\nMetrics obtained using `getrusage()` call.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "description": "This is the average share of time spent\nby instance process executing.\n\nPanel minimal requirements: metrics 0.8.0.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 281
                },
                "id": 116,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tnt_cpu_user_time{alias=~\"$alias\",job=~\"$job\"}[$__rate_interval]) +\nrate(tnt_cpu_system_time{alias=~\"$alias\",job=~\"$job\"}[$__rate_interval])\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total time per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "This is the average share of time\nspent by instance process executing in user mode.\nMetrics obtained using `getrusage()` call.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 281
+               },
+               "id": 117,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9507,7 +9595,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "CPU user time",
+               "title": "CPU user time per instance",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -9551,11 +9639,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 281
                },
-               "id": 117,
+               "id": 118,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9595,7 +9683,271 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "CPU system time",
+               "title": "CPU system time per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "This is the total share of time spent\nby each cluster process executing.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 289
+               },
+               "id": 119,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(tnt_cpu_user_time{job=~\"$job\"}[$__rate_interval])) +\nsum(rate(tnt_cpu_system_time{job=~\"$job\"}[$__rate_interval]))\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "CPU total time per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total time per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "This is the total share of time\nspent in user mode per cluster.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 289
+               },
+               "id": 120,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(tnt_cpu_user_time{job=~\"$job\"}[$__rate_interval]))\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "CPU total user time per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total user time per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "This is the total share of time\nspent in system mode per cluster.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 289
+               },
+               "id": 121,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(tnt_cpu_system_time{job=~\"$job\"}[$__rate_interval]))\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "CPU total system time per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total system time per cluster",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -9641,9 +9993,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 289
+                  "y": 297
                },
-               "id": 118,
+               "id": 122,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9728,9 +10080,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 289
+                  "y": 297
                },
-               "id": 119,
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9819,9 +10171,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 297
+            "y": 305
          },
-         "id": 120,
+         "id": 124,
          "panels": [
             {
                "aliasColors": { },
@@ -9829,15 +10181,537 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$prometheus",
-               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance. \n",
+               "description": "Total memory used by Tarantool.\n\nPanel minimal requirements: metrics 1.6.0.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 298
+                  "y": 306
                },
-               "id": 121,
+               "id": 125,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "(tnt_memory{alias=~\"$alias\",job=~\"$job\"}) +\n(tnt_memory_virt{alias=~\"$alias\",job=~\"$job\"})\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Resident memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 306
+               },
+               "id": 126,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_memory{alias=~\"$alias\",job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Resident memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Virtual memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 306
+               },
+               "id": 127,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_memory_virt{alias=~\"$alias\",job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Virtual memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Total memory used by Tarantool.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 314
+               },
+               "id": 128,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(tnt_memory{job=~\"$job\"}) + sum(tnt_memory_virt{job=~\"$job\"})",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "Total memory per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Resident memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 314
+               },
+               "id": 129,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(tnt_memory{job=~\"$job\"})",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "Total resident memory per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total resident memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Virtual memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 314
+               },
+               "id": 130,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(tnt_memory_virt{job=~\"$job\"})",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "Total virtual memory per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total virtual memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 322
+               },
+               "id": 131,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9922,9 +10796,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 298
+                  "y": 322
                },
-               "id": 122,
+               "id": 132,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -10009,9 +10883,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 298
+                  "y": 322
                },
-               "id": 123,
+               "id": 133,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10096,9 +10970,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 306
+                  "y": 330
                },
-               "id": 124,
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10183,9 +11057,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 306
+                  "y": 330
                },
-               "id": 125,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10271,9 +11145,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 314
+                  "y": 338
                },
-               "id": 126,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -10360,9 +11234,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 314
+                  "y": 338
                },
-               "id": 127,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10447,9 +11321,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 314
+                  "y": 338
                },
-               "id": 128,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10538,9 +11412,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 322
+            "y": 346
          },
-         "id": 129,
+         "id": 139,
          "panels": [
             {
                "aliasColors": { },
@@ -10554,9 +11428,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 323
+                  "y": 347
                },
-               "id": 130,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10641,9 +11515,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 323
+                  "y": 347
                },
-               "id": 131,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10728,9 +11602,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 323
+                  "y": 347
                },
-               "id": 132,
+               "id": 142,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10815,9 +11689,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 323
+                  "y": 347
                },
-               "id": 133,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10902,9 +11776,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 331
+                  "y": 355
                },
-               "id": 134,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10989,9 +11863,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 331
+                  "y": 355
                },
-               "id": 135,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11076,9 +11950,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 339
+                  "y": 363
                },
-               "id": 136,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11163,9 +12037,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 339
+                  "y": 363
                },
-               "id": 137,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11250,9 +12124,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 339
+                  "y": 363
                },
-               "id": 138,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11337,9 +12211,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 347
+                  "y": 371
                },
-               "id": 139,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11424,9 +12298,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 347
+                  "y": 371
                },
-               "id": 140,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11511,9 +12385,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 347
+                  "y": 371
                },
-               "id": 141,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11599,9 +12473,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 355
+                  "y": 379
                },
-               "id": 142,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11689,9 +12563,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 355
+                  "y": 379
                },
-               "id": 143,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11779,9 +12653,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 355
+                  "y": 379
                },
-               "id": 144,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11869,9 +12743,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 355
+                  "y": 379
                },
-               "id": 145,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11958,9 +12832,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 363
+                  "y": 387
                },
-               "id": 146,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12045,9 +12919,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 363
+                  "y": 387
                },
-               "id": 147,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12132,9 +13006,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 363
+                  "y": 387
                },
-               "id": 148,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12223,9 +13097,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 371
+            "y": 395
          },
-         "id": 149,
+         "id": 159,
          "panels": [
             {
                "aliasColors": { },
@@ -12239,9 +13113,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 372
+                  "y": 396
                },
-               "id": 150,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12326,9 +13200,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 372
+                  "y": 396
                },
-               "id": 151,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12413,9 +13287,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 372
+                  "y": 396
                },
-               "id": 152,
+               "id": 162,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12500,9 +13374,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 380
+                  "y": 404
                },
-               "id": 153,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12587,9 +13461,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 380
+                  "y": 404
                },
-               "id": 154,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12674,9 +13548,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 380
+                  "y": 404
                },
-               "id": 155,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12761,9 +13635,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 388
+                  "y": 412
                },
-               "id": 156,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12848,9 +13722,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 388
+                  "y": 412
                },
-               "id": 157,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12935,9 +13809,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 388
+                  "y": 412
                },
-               "id": 158,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13022,9 +13896,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 396
+                  "y": 420
                },
-               "id": 159,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13109,9 +13983,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 396
+                  "y": 420
                },
-               "id": 160,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13196,9 +14070,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 396
+                  "y": 420
                },
-               "id": 161,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13283,9 +14157,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 404
+                  "y": 428
                },
-               "id": 162,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13370,9 +14244,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 404
+                  "y": 428
                },
-               "id": 163,
+               "id": 173,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13457,9 +14331,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 404
+                  "y": 428
                },
-               "id": 164,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13548,9 +14422,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 412
+            "y": 436
          },
-         "id": 165,
+         "id": 175,
          "panels": [
             {
                "aliasColors": { },
@@ -13564,9 +14438,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 413
+                  "y": 437
                },
-               "id": 166,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13651,9 +14525,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 413
+                  "y": 437
                },
-               "id": 167,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13738,9 +14612,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 413
+                  "y": 437
                },
-               "id": 168,
+               "id": 178,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13825,9 +14699,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 421
+                  "y": 445
                },
-               "id": 169,
+               "id": 179,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13912,9 +14786,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 421
+                  "y": 445
                },
-               "id": 170,
+               "id": 180,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13999,9 +14873,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 421
+                  "y": 445
                },
-               "id": 171,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14086,9 +14960,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 421
+                  "y": 445
                },
-               "id": 172,
+               "id": 182,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14173,9 +15047,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 429
+                  "y": 453
                },
-               "id": 173,
+               "id": 183,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14260,9 +15134,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 429
+                  "y": 453
                },
-               "id": 174,
+               "id": 184,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14347,9 +15221,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 429
+                  "y": 453
                },
-               "id": 175,
+               "id": 185,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14434,9 +15308,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 429
+                  "y": 453
                },
-               "id": 176,
+               "id": 186,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14525,9 +15399,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 437
+            "y": 461
          },
-         "id": 177,
+         "id": 187,
          "panels": [
             {
                "aliasColors": { },
@@ -14541,9 +15415,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 438
+                  "y": 462
                },
-               "id": 178,
+               "id": 188,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -14628,9 +15502,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 438
+                  "y": 462
                },
-               "id": 179,
+               "id": 189,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14715,9 +15589,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 438
+                  "y": 462
                },
-               "id": 180,
+               "id": 190,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14802,9 +15676,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 438
+                  "y": 462
                },
-               "id": 181,
+               "id": 191,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14889,9 +15763,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 446
+                  "y": 470
                },
-               "id": 182,
+               "id": 192,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14976,9 +15850,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 446
+                  "y": 470
                },
-               "id": 183,
+               "id": 193,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15063,9 +15937,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 446
+                  "y": 470
                },
-               "id": 184,
+               "id": 194,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15150,9 +16024,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 446
+                  "y": 470
                },
-               "id": 185,
+               "id": 195,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15237,9 +16111,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 454
+                  "y": 478
                },
-               "id": 186,
+               "id": 196,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15324,9 +16198,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 454
+                  "y": 478
                },
-               "id": 187,
+               "id": 197,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15411,9 +16285,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 454
+                  "y": 478
                },
-               "id": 188,
+               "id": 198,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15498,9 +16372,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 462
+                  "y": 486
                },
-               "id": 189,
+               "id": 199,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15585,9 +16459,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 462
+                  "y": 486
                },
-               "id": 190,
+               "id": 200,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -15672,9 +16546,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 462
+                  "y": 486
                },
-               "id": 191,
+               "id": 201,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15759,9 +16633,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 470
+                  "y": 494
                },
-               "id": 192,
+               "id": 202,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15846,9 +16720,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 470
+                  "y": 494
                },
-               "id": 193,
+               "id": 203,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15933,9 +16807,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 470
+                  "y": 494
                },
-               "id": 194,
+               "id": 204,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16020,9 +16894,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 478
+                  "y": 502
                },
-               "id": 195,
+               "id": 205,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16107,9 +16981,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 478
+                  "y": 502
                },
-               "id": 196,
+               "id": 206,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -16194,9 +17068,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 478
+                  "y": 502
                },
-               "id": 197,
+               "id": 207,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16281,9 +17155,9 @@
                   "h": 10,
                   "w": 24,
                   "x": 0,
-                  "y": 486
+                  "y": 510
                },
-               "id": 198,
+               "id": 208,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16368,9 +17242,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 496
+                  "y": 520
                },
-               "id": 199,
+               "id": 209,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16455,9 +17329,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 496
+                  "y": 520
                },
-               "id": 200,
+               "id": 210,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16542,9 +17416,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 496
+                  "y": 520
                },
-               "id": 201,
+               "id": 211,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16629,9 +17503,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 496
+                  "y": 520
                },
-               "id": 202,
+               "id": 212,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16720,9 +17594,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 504
+            "y": 528
          },
-         "id": 203,
+         "id": 213,
          "panels": [
             {
                "aliasColors": { },
@@ -16736,9 +17610,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 505
+                  "y": 529
                },
-               "id": 204,
+               "id": 214,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16823,9 +17697,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 505
+                  "y": 529
                },
-               "id": 205,
+               "id": 215,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16910,9 +17784,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 513
+                  "y": 537
                },
-               "id": 206,
+               "id": 216,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16997,9 +17871,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 513
+                  "y": 537
                },
-               "id": 207,
+               "id": 217,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17084,9 +17958,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 521
+                  "y": 545
                },
-               "id": 208,
+               "id": 218,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17171,9 +18045,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 521
+                  "y": 545
                },
-               "id": 209,
+               "id": 219,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17258,9 +18132,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 521
+                  "y": 545
                },
-               "id": 210,
+               "id": 220,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17345,9 +18219,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 529
+                  "y": 553
                },
-               "id": 211,
+               "id": 221,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17432,9 +18306,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 529
+                  "y": 553
                },
-               "id": 212,
+               "id": 222,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17519,9 +18393,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 529
+                  "y": 553
                },
-               "id": 213,
+               "id": 223,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17606,9 +18480,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 537
+                  "y": 561
                },
-               "id": 214,
+               "id": 224,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17693,9 +18567,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 537
+                  "y": 561
                },
-               "id": 215,
+               "id": 225,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17780,9 +18654,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 537
+                  "y": 561
                },
-               "id": 216,
+               "id": 226,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17867,9 +18741,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 537
+                  "y": 561
                },
-               "id": 217,
+               "id": 227,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17954,9 +18828,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 545
+                  "y": 569
                },
-               "id": 218,
+               "id": 228,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18041,9 +18915,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 545
+                  "y": 569
                },
-               "id": 219,
+               "id": 229,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18132,9 +19006,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 553
+            "y": 577
          },
-         "id": 220,
+         "id": 230,
          "panels": [
             {
                "aliasColors": { },
@@ -18148,9 +19022,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 554
+                  "y": 578
                },
-               "id": 221,
+               "id": 231,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -18235,9 +19109,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 554
+                  "y": 578
                },
-               "id": 222,
+               "id": 232,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18322,9 +19196,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 562
+                  "y": 586
                },
-               "id": 223,
+               "id": 233,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18409,9 +19283,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 562
+                  "y": 586
                },
-               "id": 224,
+               "id": 234,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18500,9 +19374,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 570
+            "y": 594
          },
-         "id": 225,
+         "id": 235,
          "panels": [
             {
                "aliasColors": { },
@@ -18516,9 +19390,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 571
+                  "y": 595
                },
-               "id": 226,
+               "id": 236,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -18603,9 +19477,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 571
+                  "y": 595
                },
-               "id": 227,
+               "id": 237,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -18694,9 +19568,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 579
+            "y": 603
          },
-         "id": 228,
+         "id": 238,
          "panels": [
             {
                "aliasColors": { },
@@ -18710,9 +19584,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 580
+                  "y": 604
                },
-               "id": 229,
+               "id": 239,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18797,9 +19671,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 580
+                  "y": 604
                },
-               "id": 230,
+               "id": 240,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18885,9 +19759,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 588
+                  "y": 612
                },
-               "id": 231,
+               "id": 241,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18974,9 +19848,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 588
+                  "y": 612
                },
-               "id": 232,
+               "id": 242,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19065,9 +19939,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 596
+            "y": 620
          },
-         "id": 233,
+         "id": 243,
          "panels": [
             {
                "aliasColors": { },
@@ -19081,9 +19955,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 597
+                  "y": 621
                },
-               "id": 234,
+               "id": 244,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19168,9 +20042,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 597
+                  "y": 621
                },
-               "id": 235,
+               "id": 245,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19256,9 +20130,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 605
+                  "y": 629
                },
-               "id": 236,
+               "id": 246,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19346,9 +20220,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 605
+                  "y": 629
                },
-               "id": 237,
+               "id": 247,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19439,9 +20313,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 613
+            "y": 637
          },
-         "id": 238,
+         "id": 248,
          "panels": [
             {
                "aliasColors": { },
@@ -19456,9 +20330,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 614
+                  "y": 638
                },
-               "id": 239,
+               "id": 249,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -19546,9 +20420,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 614
+                  "y": 638
                },
-               "id": 240,
+               "id": 250,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -19636,9 +20510,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 614
+                  "y": 638
                },
-               "id": 241,
+               "id": 251,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -19725,9 +20599,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 622
+                  "y": 646
                },
-               "id": 242,
+               "id": 252,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -19812,9 +20686,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 622
+                  "y": 646
                },
-               "id": 243,
+               "id": 253,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -19900,9 +20774,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 622
+                  "y": 646
                },
-               "id": 244,
+               "id": 254,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -19993,9 +20867,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 630
+            "y": 654
          },
-         "id": 245,
+         "id": 255,
          "panels": [
             {
                "aliasColors": { },
@@ -20009,9 +20883,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 631
+                  "y": 655
                },
-               "id": 246,
+               "id": 256,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20096,9 +20970,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 631
+                  "y": 655
                },
-               "id": 247,
+               "id": 257,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20183,9 +21057,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 631
+                  "y": 655
                },
-               "id": 248,
+               "id": 258,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20270,9 +21144,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 639
+                  "y": 663
                },
-               "id": 249,
+               "id": 259,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20357,9 +21231,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 639
+                  "y": 663
                },
-               "id": 250,
+               "id": 260,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20444,9 +21318,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 639
+                  "y": 663
                },
-               "id": 251,
+               "id": 261,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20535,9 +21409,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 647
+            "y": 671
          },
-         "id": 252,
+         "id": 262,
          "panels": [
             {
                "aliasColors": { },
@@ -20551,9 +21425,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 648
+                  "y": 672
                },
-               "id": 253,
+               "id": 263,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20638,9 +21512,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 648
+                  "y": 672
                },
-               "id": 254,
+               "id": 264,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20725,9 +21599,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 648
+                  "y": 672
                },
-               "id": 255,
+               "id": 265,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20812,9 +21686,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 648
+                  "y": 672
                },
-               "id": 256,
+               "id": 266,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20899,9 +21773,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 656
+                  "y": 680
                },
-               "id": 257,
+               "id": 267,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20986,9 +21860,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 656
+                  "y": 680
                },
-               "id": 258,
+               "id": 268,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21073,9 +21947,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 664
+                  "y": 688
                },
-               "id": 259,
+               "id": 269,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21160,9 +22034,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 664
+                  "y": 688
                },
-               "id": 260,
+               "id": 270,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21247,9 +22121,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 664
+                  "y": 688
                },
-               "id": 261,
+               "id": 271,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21334,9 +22208,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 664
+                  "y": 688
                },
-               "id": 262,
+               "id": 272,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21421,9 +22295,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 672
+                  "y": 696
                },
-               "id": 263,
+               "id": 273,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21508,9 +22382,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 672
+                  "y": 696
                },
-               "id": 264,
+               "id": 274,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21595,9 +22469,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 672
+                  "y": 696
                },
-               "id": 265,
+               "id": 275,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21682,9 +22556,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 672
+                  "y": 696
                },
-               "id": 266,
+               "id": 276,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21769,9 +22643,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 680
+                  "y": 704
                },
-               "id": 267,
+               "id": 277,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21856,9 +22730,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 680
+                  "y": 704
                },
-               "id": 268,
+               "id": 278,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -21943,9 +22817,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 680
+                  "y": 704
                },
-               "id": 269,
+               "id": 279,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22030,9 +22904,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 680
+                  "y": 704
                },
-               "id": 270,
+               "id": 280,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22121,9 +22995,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 688
+            "y": 712
          },
-         "id": 271,
+         "id": 281,
          "panels": [
             {
                "aliasColors": { },
@@ -22137,9 +23011,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 689
+                  "y": 713
                },
-               "id": 272,
+               "id": 282,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22224,9 +23098,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 689
+                  "y": 713
                },
-               "id": 273,
+               "id": 283,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22311,9 +23185,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 689
+                  "y": 713
                },
-               "id": 274,
+               "id": 284,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22398,9 +23272,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 697
+                  "y": 721
                },
-               "id": 275,
+               "id": 285,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22485,9 +23359,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 697
+                  "y": 721
                },
-               "id": 276,
+               "id": 286,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22572,9 +23446,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 697
+                  "y": 721
                },
-               "id": 277,
+               "id": 287,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22659,9 +23533,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 705
+                  "y": 729
                },
-               "id": 278,
+               "id": 288,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22746,9 +23620,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 705
+                  "y": 729
                },
-               "id": 279,
+               "id": 289,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22833,9 +23707,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 705
+                  "y": 729
                },
-               "id": 280,
+               "id": 290,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22920,9 +23794,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 713
+                  "y": 737
                },
-               "id": 281,
+               "id": 291,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23007,9 +23881,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 713
+                  "y": 737
                },
-               "id": 282,
+               "id": 292,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23094,9 +23968,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 713
+                  "y": 737
                },
-               "id": 283,
+               "id": 293,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23185,9 +24059,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 721
+            "y": 745
          },
-         "id": 284,
+         "id": 294,
          "panels": [
             {
                "aliasColors": { },
@@ -23201,9 +24075,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 722
+                  "y": 746
                },
-               "id": 285,
+               "id": 295,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23288,9 +24162,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 722
+                  "y": 746
                },
-               "id": 286,
+               "id": 296,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23375,9 +24249,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 722
+                  "y": 746
                },
-               "id": 287,
+               "id": 297,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23462,9 +24336,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 730
+                  "y": 754
                },
-               "id": 288,
+               "id": 298,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -23549,9 +24423,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 730
+                  "y": 754
                },
-               "id": 289,
+               "id": 299,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23636,9 +24510,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 738
+                  "y": 762
                },
-               "id": 290,
+               "id": 300,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23723,9 +24597,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 738
+                  "y": 762
                },
-               "id": 291,
+               "id": 301,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23810,9 +24684,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 738
+                  "y": 762
                },
-               "id": 292,
+               "id": 302,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23897,9 +24771,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 738
+                  "y": 762
                },
-               "id": 293,
+               "id": 303,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23984,9 +24858,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 746
+                  "y": 770
                },
-               "id": 294,
+               "id": 304,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -24071,9 +24945,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 746
+                  "y": 770
                },
-               "id": 295,
+               "id": 305,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24158,9 +25032,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 754
+                  "y": 778
                },
-               "id": 296,
+               "id": 306,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24245,9 +25119,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 754
+                  "y": 778
                },
-               "id": 297,
+               "id": 307,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24332,9 +25206,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 754
+                  "y": 778
                },
-               "id": 298,
+               "id": 308,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24419,9 +25293,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 762
+                  "y": 786
                },
-               "id": 299,
+               "id": 309,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -24506,9 +25380,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 762
+                  "y": 786
                },
-               "id": 300,
+               "id": 310,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_with_custom_panels_compiled.json
+++ b/tests/Prometheus/dashboard_with_custom_panels_compiled.json
@@ -9933,15 +9933,103 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$prometheus",
-               "description": "This is the average share of time\nspent by instance process executing in user mode.\nMetrics obtained using `getrusage()` call.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "description": "This is the average share of time spent\nby instance process executing.\n\nPanel minimal requirements: metrics 0.8.0.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
+                  "w": 8,
                   "x": 0,
                   "y": 292
                },
                "id": 121,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "rate(tnt_cpu_user_time{alias=~\"$alias\",job=~\"$job\"}[$__rate_interval]) +\nrate(tnt_cpu_system_time{alias=~\"$alias\",job=~\"$job\"}[$__rate_interval])\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total time per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "This is the average share of time\nspent by instance process executing in user mode.\nMetrics obtained using `getrusage()` call.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 292
+               },
+               "id": 122,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -9981,7 +10069,7 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "CPU user time",
+               "title": "CPU user time per instance",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -10025,11 +10113,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 12,
-                  "x": 12,
+                  "w": 8,
+                  "x": 16,
                   "y": 292
                },
-               "id": 122,
+               "id": 123,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10069,7 +10157,271 @@
                "thresholds": [ ],
                "timeFrom": null,
                "timeShift": null,
-               "title": "CPU system time",
+               "title": "CPU system time per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "This is the total share of time spent\nby each cluster process executing.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 300
+               },
+               "id": 124,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(tnt_cpu_user_time{job=~\"$job\"}[$__rate_interval])) +\nsum(rate(tnt_cpu_system_time{job=~\"$job\"}[$__rate_interval]))\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "CPU total time per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total time per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "This is the total share of time\nspent in user mode per cluster.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 300
+               },
+               "id": 125,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(tnt_cpu_user_time{job=~\"$job\"}[$__rate_interval]))\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "CPU total user time per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total user time per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "decimals": 0,
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  },
+                  {
+                     "format": "percentunit",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": 0,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "This is the total share of time\nspent in system mode per cluster.\n\nPanel minimal requirements: metrics 0.8.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 300
+               },
+               "id": 126,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(rate(tnt_cpu_system_time{job=~\"$job\"}[$__rate_interval]))\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "CPU total system time per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "CPU total system time per cluster",
                "tooltip": {
                   "shared": true,
                   "sort": 2,
@@ -10119,9 +10471,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 300
+            "y": 308
          },
-         "id": 123,
+         "id": 127,
          "panels": [
             {
                "aliasColors": { },
@@ -10129,15 +10481,537 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$prometheus",
-               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance. \n",
+               "description": "Total memory used by Tarantool.\n\nPanel minimal requirements: metrics 1.6.0.\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 301
+                  "y": 309
                },
-               "id": 124,
+               "id": 128,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "(tnt_memory{alias=~\"$alias\",job=~\"$job\"}) +\n(tnt_memory_virt{alias=~\"$alias\",job=~\"$job\"})\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Resident memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 309
+               },
+               "id": 129,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_memory{alias=~\"$alias\",job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Resident memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Virtual memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 309
+               },
+               "id": 130,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "tnt_memory_virt{alias=~\"$alias\",job=~\"$job\"}",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Virtual memory per instance",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Total memory used by Tarantool.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 317
+               },
+               "id": 131,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(tnt_memory{job=~\"$job\"}) + sum(tnt_memory_virt{job=~\"$job\"})",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "Total memory per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Resident memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 8,
+                  "y": 317
+               },
+               "id": 132,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(tnt_memory{job=~\"$job\"})",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "Total resident memory per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total resident memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Virtual memory used by Tarantool instance.\n\nPanel minimal requirements: metrics 1.6.0.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 16,
+                  "y": 317
+               },
+               "id": 133,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": true,
+                  "current": true,
+                  "max": true,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "sum(tnt_memory_virt{job=~\"$job\"})",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "Total virtual memory per cluster",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Total virtual memory per cluster",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "bytes",
+                     "label": "in bytes",
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "bytes",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
+               "description": "Memory used for objects allocated with Lua\nby using its internal mechanisms.\nLua memory is bounded by 2 GB per instance.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 8,
+                  "x": 0,
+                  "y": 325
+               },
+               "id": 134,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10222,9 +11096,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 301
+                  "y": 325
                },
-               "id": 125,
+               "id": 135,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -10309,9 +11183,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 301
+                  "y": 325
                },
-               "id": 126,
+               "id": 136,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10396,9 +11270,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 309
+                  "y": 333
                },
-               "id": 127,
+               "id": 137,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10483,9 +11357,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 309
+                  "y": 333
                },
-               "id": 128,
+               "id": 138,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10571,9 +11445,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 317
+                  "y": 341
                },
-               "id": 129,
+               "id": 139,
                "legend": {
                   "alignAsTable": true,
                   "avg": false,
@@ -10660,9 +11534,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 317
+                  "y": 341
                },
-               "id": 130,
+               "id": 140,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10747,9 +11621,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 317
+                  "y": 341
                },
-               "id": 131,
+               "id": 141,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10838,9 +11712,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 325
+            "y": 349
          },
-         "id": 132,
+         "id": 142,
          "panels": [
             {
                "aliasColors": { },
@@ -10854,9 +11728,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 326
+                  "y": 350
                },
-               "id": 133,
+               "id": 143,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -10941,9 +11815,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 326
+                  "y": 350
                },
-               "id": 134,
+               "id": 144,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11028,9 +11902,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 326
+                  "y": 350
                },
-               "id": 135,
+               "id": 145,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11115,9 +11989,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 326
+                  "y": 350
                },
-               "id": 136,
+               "id": 146,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11202,9 +12076,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 334
+                  "y": 358
                },
-               "id": 137,
+               "id": 147,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11289,9 +12163,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 334
+                  "y": 358
                },
-               "id": 138,
+               "id": 148,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11376,9 +12250,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 342
+                  "y": 366
                },
-               "id": 139,
+               "id": 149,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11463,9 +12337,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 342
+                  "y": 366
                },
-               "id": 140,
+               "id": 150,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11550,9 +12424,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 342
+                  "y": 366
                },
-               "id": 141,
+               "id": 151,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11637,9 +12511,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 350
+                  "y": 374
                },
-               "id": 142,
+               "id": 152,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11724,9 +12598,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 350
+                  "y": 374
                },
-               "id": 143,
+               "id": 153,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11811,9 +12685,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 350
+                  "y": 374
                },
-               "id": 144,
+               "id": 154,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11899,9 +12773,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 358
+                  "y": 382
                },
-               "id": 145,
+               "id": 155,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -11989,9 +12863,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 358
+                  "y": 382
                },
-               "id": 146,
+               "id": 156,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12079,9 +12953,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 358
+                  "y": 382
                },
-               "id": 147,
+               "id": 157,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12169,9 +13043,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 358
+                  "y": 382
                },
-               "id": 148,
+               "id": 158,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12258,9 +13132,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 366
+                  "y": 390
                },
-               "id": 149,
+               "id": 159,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12345,9 +13219,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 366
+                  "y": 390
                },
-               "id": 150,
+               "id": 160,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12432,9 +13306,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 366
+                  "y": 390
                },
-               "id": 151,
+               "id": 161,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12523,9 +13397,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 374
+            "y": 398
          },
-         "id": 152,
+         "id": 162,
          "panels": [
             {
                "aliasColors": { },
@@ -12539,9 +13413,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 375
+                  "y": 399
                },
-               "id": 153,
+               "id": 163,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12626,9 +13500,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 375
+                  "y": 399
                },
-               "id": 154,
+               "id": 164,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12713,9 +13587,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 375
+                  "y": 399
                },
-               "id": 155,
+               "id": 165,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12800,9 +13674,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 383
+                  "y": 407
                },
-               "id": 156,
+               "id": 166,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12887,9 +13761,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 383
+                  "y": 407
                },
-               "id": 157,
+               "id": 167,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -12974,9 +13848,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 383
+                  "y": 407
                },
-               "id": 158,
+               "id": 168,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13061,9 +13935,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 391
+                  "y": 415
                },
-               "id": 159,
+               "id": 169,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13148,9 +14022,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 391
+                  "y": 415
                },
-               "id": 160,
+               "id": 170,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13235,9 +14109,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 391
+                  "y": 415
                },
-               "id": 161,
+               "id": 171,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13322,9 +14196,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 399
+                  "y": 423
                },
-               "id": 162,
+               "id": 172,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13409,9 +14283,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 399
+                  "y": 423
                },
-               "id": 163,
+               "id": 173,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13496,9 +14370,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 399
+                  "y": 423
                },
-               "id": 164,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13583,9 +14457,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 407
+                  "y": 431
                },
-               "id": 165,
+               "id": 175,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13670,9 +14544,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 407
+                  "y": 431
                },
-               "id": 166,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13757,9 +14631,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 407
+                  "y": 431
                },
-               "id": 167,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13848,9 +14722,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 415
+            "y": 439
          },
-         "id": 168,
+         "id": 178,
          "panels": [
             {
                "aliasColors": { },
@@ -13864,9 +14738,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 416
+                  "y": 440
                },
-               "id": 169,
+               "id": 179,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -13951,9 +14825,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 416
+                  "y": 440
                },
-               "id": 170,
+               "id": 180,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14038,9 +14912,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 416
+                  "y": 440
                },
-               "id": 171,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14125,9 +14999,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 416
+                  "y": 440
                },
-               "id": 172,
+               "id": 182,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14212,9 +15086,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 0,
-                  "y": 424
+                  "y": 448
                },
-               "id": 173,
+               "id": 183,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14299,9 +15173,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 8,
-                  "y": 424
+                  "y": 448
                },
-               "id": 174,
+               "id": 184,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14386,9 +15260,9 @@
                   "h": 8,
                   "w": 8,
                   "x": 16,
-                  "y": 424
+                  "y": 448
                },
-               "id": 175,
+               "id": 185,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14473,9 +15347,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 432
+                  "y": 456
                },
-               "id": 176,
+               "id": 186,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14560,9 +15434,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 432
+                  "y": 456
                },
-               "id": 177,
+               "id": 187,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14647,9 +15521,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 432
+                  "y": 456
                },
-               "id": 178,
+               "id": 188,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14734,9 +15608,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 432
+                  "y": 456
                },
-               "id": 179,
+               "id": 189,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14821,9 +15695,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 440
+                  "y": 464
                },
-               "id": 180,
+               "id": 190,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14908,9 +15782,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 440
+                  "y": 464
                },
-               "id": 181,
+               "id": 191,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14995,9 +15869,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 440
+                  "y": 464
                },
-               "id": 182,
+               "id": 192,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15082,9 +15956,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 440
+                  "y": 464
                },
-               "id": 183,
+               "id": 193,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15169,9 +16043,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 448
+                  "y": 472
                },
-               "id": 184,
+               "id": 194,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15256,9 +16130,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 448
+                  "y": 472
                },
-               "id": 185,
+               "id": 195,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15343,9 +16217,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 448
+                  "y": 472
                },
-               "id": 186,
+               "id": 196,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15430,9 +16304,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 448
+                  "y": 472
                },
-               "id": 187,
+               "id": 197,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15517,9 +16391,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 456
+                  "y": 480
                },
-               "id": 188,
+               "id": 198,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15604,9 +16478,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 456
+                  "y": 480
                },
-               "id": 189,
+               "id": 199,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15691,9 +16565,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 456
+                  "y": 480
                },
-               "id": 190,
+               "id": 200,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15778,9 +16652,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 456
+                  "y": 480
                },
-               "id": 191,
+               "id": 201,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15865,9 +16739,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 464
+                  "y": 488
                },
-               "id": 192,
+               "id": 202,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15952,9 +16826,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 464
+                  "y": 488
                },
-               "id": 193,
+               "id": 203,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16039,9 +16913,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 464
+                  "y": 488
                },
-               "id": 194,
+               "id": 204,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16126,9 +17000,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 464
+                  "y": 488
                },
-               "id": 195,
+               "id": 205,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16213,9 +17087,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 472
+                  "y": 496
                },
-               "id": 196,
+               "id": 206,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16300,9 +17174,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 472
+                  "y": 496
                },
-               "id": 197,
+               "id": 207,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16387,9 +17261,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 472
+                  "y": 496
                },
-               "id": 198,
+               "id": 208,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16474,9 +17348,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 472
+                  "y": 496
                },
-               "id": 199,
+               "id": 209,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16561,9 +17435,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 480
+                  "y": 504
                },
-               "id": 200,
+               "id": 210,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16648,9 +17522,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 480
+                  "y": 504
                },
-               "id": 201,
+               "id": 211,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16735,9 +17609,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 480
+                  "y": 504
                },
-               "id": 202,
+               "id": 212,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16822,9 +17696,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 480
+                  "y": 504
                },
-               "id": 203,
+               "id": 213,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16909,9 +17783,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 488
+                  "y": 512
                },
-               "id": 204,
+               "id": 214,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16996,9 +17870,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 488
+                  "y": 512
                },
-               "id": 205,
+               "id": 215,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17083,9 +17957,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 488
+                  "y": 512
                },
-               "id": 206,
+               "id": 216,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17170,9 +18044,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 488
+                  "y": 512
                },
-               "id": 207,
+               "id": 217,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17257,9 +18131,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 496
+                  "y": 520
                },
-               "id": 208,
+               "id": 218,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17344,9 +18218,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 496
+                  "y": 520
                },
-               "id": 209,
+               "id": 219,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17431,9 +18305,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 496
+                  "y": 520
                },
-               "id": 210,
+               "id": 220,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17518,9 +18392,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 496
+                  "y": 520
                },
-               "id": 211,
+               "id": 221,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17605,9 +18479,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 504
+                  "y": 528
                },
-               "id": 212,
+               "id": 222,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17692,9 +18566,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 504
+                  "y": 528
                },
-               "id": 213,
+               "id": 223,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17779,9 +18653,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 504
+                  "y": 528
                },
-               "id": 214,
+               "id": 224,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17866,9 +18740,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 504
+                  "y": 528
                },
-               "id": 215,
+               "id": 225,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17953,9 +18827,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 512
+                  "y": 536
                },
-               "id": 216,
+               "id": 226,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18040,9 +18914,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 512
+                  "y": 536
                },
-               "id": 217,
+               "id": 227,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18127,9 +19001,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 512
+                  "y": 536
                },
-               "id": 218,
+               "id": 228,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18214,9 +19088,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 512
+                  "y": 536
                },
-               "id": 219,
+               "id": 229,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18301,9 +19175,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 520
+                  "y": 544
                },
-               "id": 220,
+               "id": 230,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18388,9 +19262,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 520
+                  "y": 544
                },
-               "id": 221,
+               "id": 231,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18475,9 +19349,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 520
+                  "y": 544
                },
-               "id": 222,
+               "id": 232,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18562,9 +19436,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 520
+                  "y": 544
                },
-               "id": 223,
+               "id": 233,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18649,9 +19523,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 528
+                  "y": 552
                },
-               "id": 224,
+               "id": 234,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18736,9 +19610,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 528
+                  "y": 552
                },
-               "id": 225,
+               "id": 235,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18823,9 +19697,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 528
+                  "y": 552
                },
-               "id": 226,
+               "id": 236,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18910,9 +19784,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 528
+                  "y": 552
                },
-               "id": 227,
+               "id": 237,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19001,9 +19875,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 536
+            "y": 560
          },
-         "id": 228,
+         "id": 238,
          "panels": [
             {
                "aliasColors": { },
@@ -19017,9 +19891,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 537
+                  "y": 561
                },
-               "id": 229,
+               "id": 239,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19104,9 +19978,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 537
+                  "y": 561
                },
-               "id": 230,
+               "id": 240,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19192,9 +20066,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 545
+                  "y": 569
                },
-               "id": 231,
+               "id": 241,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19281,9 +20155,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 545
+                  "y": 569
                },
-               "id": 232,
+               "id": 242,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19372,9 +20246,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 553
+            "y": 577
          },
-         "id": 233,
+         "id": 243,
          "panels": [
             {
                "aliasColors": { },
@@ -19388,9 +20262,9 @@
                   "h": 6,
                   "w": 24,
                   "x": 0,
-                  "y": 554
+                  "y": 578
                },
-               "id": 234,
+               "id": 244,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19475,9 +20349,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 560
+                  "y": 584
                },
-               "id": 235,
+               "id": 245,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19562,9 +20436,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 560
+                  "y": 584
                },
-               "id": 236,
+               "id": 246,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,


### PR DESCRIPTION
This patch adds `CPU/memory/virtual memory` utilization panels per instance and total.

Closes #TNTP-4365

<details>
<summary>screenshots</summary>
<img width="1173" height="1162" alt="image" src="https://github.com/user-attachments/assets/51be33f5-784b-4e01-a83a-a87397dfe28a" />
<img width="1178" height="1164" alt="image" src="https://github.com/user-attachments/assets/0de5d5e7-0a99-407a-93e9-7509fdfc6df1" />
</details>
