### PR TITLE
dashboard: add panel with time of last CRUD router cache clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Panel with CRUD safe mode status (#249)
+- Panel with time of last CRUD router cache clear (#250)
 
 ### Changed
 

--- a/dashboard/section.libsonnet
+++ b/dashboard/section.libsonnet
@@ -311,6 +311,7 @@ local vinyl = import 'dashboard/panels/vinyl.libsonnet';
   crud(cfg):: [
     crud.row,
     crud.safe_mode_enabled(cfg),
+    crud.router_cache_clear(cfg),
     crud.select_success_rps(cfg),
     crud.select_success_latency(cfg),
     crud.select_error_rps(cfg),

--- a/supported_metrics.md
+++ b/supported_metrics.md
@@ -168,6 +168,7 @@ Based on [tarantool/metrics 1.6.1](https://github.com/tarantool/metrics/releases
 # tarantool/crud
 
 - [x] **tnt_crud_storage_safe_mode_enabled**: see *CRUD module statistics/Safe mode status* panel ([#249](https://github.com/tarantool/grafana-dashboard/pull/249))
+- [x] **tnt_crud_router_cache_clear_ts**: see *CRUD module statistics/Router cache last cleared* panel ([#250](https://github.com/tarantool/grafana-dashboard/pull/250))
 
 Based on [tarantool/crud 1.5.2](https://github.com/tarantool/crud/releases/tag/1.5.2).
 

--- a/tests/InfluxDB/dashboard_cartridge_compiled.json
+++ b/tests/InfluxDB/dashboard_cartridge_compiled.json
@@ -22298,7 +22298,7 @@
                },
                "gridPos": {
                   "h": 8,
-                  "w": 6,
+                  "w": 12,
                   "x": 0,
                   "y": 438
                },
@@ -22380,15 +22380,155 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$influxdb",
+               "description": "How long ago the route cache was last cleared on router instance.\n\nPanel minimal requirements: CRUD 1.7.3.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 438
+               },
+               "id": 174,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "$measurement",
+                     "policy": "$policy",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           },
+                           {
+                              "params": [
+                                 "*1000"
+                              ],
+                              "type": "math"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_router_cache_clear_ts"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "value",
+                           "operator": ">",
+                           "value": "0"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Router cache last cleared",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "dateTimeFromNow",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "dateTimeFromNow",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
                "description": "Total count of success SELECT and PAIRS requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 6,
-                  "y": 438
+                  "x": 0,
+                  "y": 446
                },
-               "id": 174,
+               "id": 175,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22543,10 +22683,10 @@
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 12,
-                  "y": 438
+                  "x": 6,
+                  "y": 446
                },
-               "id": 175,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22701,10 +22841,10 @@
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 18,
-                  "y": 438
+                  "x": 12,
+                  "y": 446
                },
-               "id": 176,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22859,10 +22999,10 @@
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 0,
+                  "x": 18,
                   "y": 446
                },
-               "id": 177,
+               "id": 178,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23016,11 +23156,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 6,
-                  "y": 446
+                  "w": 8,
+                  "x": 0,
+                  "y": 454
                },
-               "id": 178,
+               "id": 179,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23120,11 +23260,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 12,
-                  "y": 446
+                  "w": 8,
+                  "x": 8,
+                  "y": 454
                },
-               "id": 179,
+               "id": 180,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23224,11 +23364,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 18,
-                  "y": 446
+                  "w": 8,
+                  "x": 16,
+                  "y": 454
                },
-               "id": 180,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23378,9 +23518,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 454
+                  "y": 462
                },
-               "id": 181,
+               "id": 182,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23536,9 +23676,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 454
+                  "y": 462
                },
-               "id": 182,
+               "id": 183,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23694,9 +23834,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 454
+                  "y": 462
                },
-               "id": 183,
+               "id": 184,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23852,9 +23992,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 454
+                  "y": 462
                },
-               "id": 184,
+               "id": 185,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24010,9 +24150,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 462
+                  "y": 470
                },
-               "id": 185,
+               "id": 186,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24168,9 +24308,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 462
+                  "y": 470
                },
-               "id": 186,
+               "id": 187,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24326,9 +24466,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 462
+                  "y": 470
                },
-               "id": 187,
+               "id": 188,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24484,9 +24624,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 462
+                  "y": 470
                },
-               "id": 188,
+               "id": 189,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24642,9 +24782,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 470
+                  "y": 478
                },
-               "id": 189,
+               "id": 190,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24800,9 +24940,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 470
+                  "y": 478
                },
-               "id": 190,
+               "id": 191,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24958,9 +25098,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 470
+                  "y": 478
                },
-               "id": 191,
+               "id": 192,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25116,9 +25256,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 470
+                  "y": 478
                },
-               "id": 192,
+               "id": 193,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25274,9 +25414,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 478
+                  "y": 486
                },
-               "id": 193,
+               "id": 194,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25432,9 +25572,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 478
+                  "y": 486
                },
-               "id": 194,
+               "id": 195,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25590,9 +25730,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 478
+                  "y": 486
                },
-               "id": 195,
+               "id": 196,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25748,9 +25888,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 478
+                  "y": 486
                },
-               "id": 196,
+               "id": 197,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25906,9 +26046,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 486
+                  "y": 494
                },
-               "id": 197,
+               "id": 198,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26064,9 +26204,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 486
+                  "y": 494
                },
-               "id": 198,
+               "id": 199,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26222,9 +26362,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 486
+                  "y": 494
                },
-               "id": 199,
+               "id": 200,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26380,9 +26520,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 486
+                  "y": 494
                },
-               "id": 200,
+               "id": 201,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26538,9 +26678,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 494
+                  "y": 502
                },
-               "id": 201,
+               "id": 202,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26696,9 +26836,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 494
+                  "y": 502
                },
-               "id": 202,
+               "id": 203,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26854,9 +26994,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 494
+                  "y": 502
                },
-               "id": 203,
+               "id": 204,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27012,9 +27152,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 494
+                  "y": 502
                },
-               "id": 204,
+               "id": 205,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27170,9 +27310,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 502
+                  "y": 510
                },
-               "id": 205,
+               "id": 206,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27328,9 +27468,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 502
+                  "y": 510
                },
-               "id": 206,
+               "id": 207,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27486,9 +27626,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 502
+                  "y": 510
                },
-               "id": 207,
+               "id": 208,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27644,9 +27784,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 502
+                  "y": 510
                },
-               "id": 208,
+               "id": 209,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27802,9 +27942,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 510
+                  "y": 518
                },
-               "id": 209,
+               "id": 210,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27960,9 +28100,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 510
+                  "y": 518
                },
-               "id": 210,
+               "id": 211,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28118,9 +28258,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 510
+                  "y": 518
                },
-               "id": 211,
+               "id": 212,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28276,9 +28416,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 510
+                  "y": 518
                },
-               "id": 212,
+               "id": 213,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28434,9 +28574,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 518
+                  "y": 526
                },
-               "id": 213,
+               "id": 214,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28592,9 +28732,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 518
+                  "y": 526
                },
-               "id": 214,
+               "id": 215,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28750,9 +28890,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 518
+                  "y": 526
                },
-               "id": 215,
+               "id": 216,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28908,9 +29048,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 518
+                  "y": 526
                },
-               "id": 216,
+               "id": 217,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29066,9 +29206,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 526
+                  "y": 534
                },
-               "id": 217,
+               "id": 218,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29224,9 +29364,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 526
+                  "y": 534
                },
-               "id": 218,
+               "id": 219,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29382,9 +29522,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 526
+                  "y": 534
                },
-               "id": 219,
+               "id": 220,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29540,9 +29680,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 526
+                  "y": 534
                },
-               "id": 220,
+               "id": 221,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29698,9 +29838,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 534
+                  "y": 542
                },
-               "id": 221,
+               "id": 222,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29856,9 +29996,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 534
+                  "y": 542
                },
-               "id": 222,
+               "id": 223,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30014,9 +30154,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 534
+                  "y": 542
                },
-               "id": 223,
+               "id": 224,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30172,9 +30312,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 534
+                  "y": 542
                },
-               "id": 224,
+               "id": 225,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30330,9 +30470,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 542
+                  "y": 550
                },
-               "id": 225,
+               "id": 226,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30488,9 +30628,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 542
+                  "y": 550
                },
-               "id": 226,
+               "id": 227,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30646,9 +30786,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 542
+                  "y": 550
                },
-               "id": 227,
+               "id": 228,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30804,9 +30944,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 542
+                  "y": 550
                },
-               "id": 228,
+               "id": 229,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30962,9 +31102,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 550
+                  "y": 558
                },
-               "id": 229,
+               "id": 230,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31120,9 +31260,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 550
+                  "y": 558
                },
-               "id": 230,
+               "id": 231,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31278,9 +31418,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 550
+                  "y": 558
                },
-               "id": 231,
+               "id": 232,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31436,9 +31576,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 550
+                  "y": 558
                },
-               "id": 232,
+               "id": 233,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31598,9 +31738,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 558
+            "y": 566
          },
-         "id": 233,
+         "id": 234,
          "panels": [
             {
                "aliasColors": { },
@@ -31614,9 +31754,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 559
+                  "y": 567
                },
-               "id": 234,
+               "id": 235,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31760,9 +31900,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 559
+                  "y": 567
                },
-               "id": 235,
+               "id": 236,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31907,9 +32047,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 567
+                  "y": 575
                },
-               "id": 236,
+               "id": 237,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -32049,9 +32189,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 567
+                  "y": 575
                },
-               "id": 237,
+               "id": 238,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/InfluxDB/dashboard_tarantool3_compiled.json
+++ b/tests/InfluxDB/dashboard_tarantool3_compiled.json
@@ -22228,7 +22228,7 @@
                },
                "gridPos": {
                   "h": 8,
-                  "w": 6,
+                  "w": 12,
                   "x": 0,
                   "y": 432
                },
@@ -22310,15 +22310,155 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$influxdb",
+               "description": "How long ago the route cache was last cleared on router instance.\n\nPanel minimal requirements: CRUD 1.7.3.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 432
+               },
+               "id": 173,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "$measurement",
+                     "policy": "$policy",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           },
+                           {
+                              "params": [
+                                 "*1000"
+                              ],
+                              "type": "math"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_router_cache_clear_ts"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "value",
+                           "operator": ">",
+                           "value": "0"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Router cache last cleared",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "dateTimeFromNow",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "dateTimeFromNow",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
                "description": "Total count of success SELECT and PAIRS requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 6,
-                  "y": 432
+                  "x": 0,
+                  "y": 440
                },
-               "id": 173,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22473,10 +22613,10 @@
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 12,
-                  "y": 432
+                  "x": 6,
+                  "y": 440
                },
-               "id": 174,
+               "id": 175,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22631,10 +22771,10 @@
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 18,
-                  "y": 432
+                  "x": 12,
+                  "y": 440
                },
-               "id": 175,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22789,10 +22929,10 @@
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 0,
+                  "x": 18,
                   "y": 440
                },
-               "id": 176,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22946,11 +23086,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 6,
-                  "y": 440
+                  "w": 8,
+                  "x": 0,
+                  "y": 448
                },
-               "id": 177,
+               "id": 178,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23050,11 +23190,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 12,
-                  "y": 440
+                  "w": 8,
+                  "x": 8,
+                  "y": 448
                },
-               "id": 178,
+               "id": 179,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23154,11 +23294,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 18,
-                  "y": 440
+                  "w": 8,
+                  "x": 16,
+                  "y": 448
                },
-               "id": 179,
+               "id": 180,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23308,9 +23448,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 448
+                  "y": 456
                },
-               "id": 180,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23466,9 +23606,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 448
+                  "y": 456
                },
-               "id": 181,
+               "id": 182,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23624,9 +23764,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 448
+                  "y": 456
                },
-               "id": 182,
+               "id": 183,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23782,9 +23922,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 448
+                  "y": 456
                },
-               "id": 183,
+               "id": 184,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23940,9 +24080,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 456
+                  "y": 464
                },
-               "id": 184,
+               "id": 185,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24098,9 +24238,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 456
+                  "y": 464
                },
-               "id": 185,
+               "id": 186,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24256,9 +24396,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 456
+                  "y": 464
                },
-               "id": 186,
+               "id": 187,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24414,9 +24554,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 456
+                  "y": 464
                },
-               "id": 187,
+               "id": 188,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24572,9 +24712,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 464
+                  "y": 472
                },
-               "id": 188,
+               "id": 189,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24730,9 +24870,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 464
+                  "y": 472
                },
-               "id": 189,
+               "id": 190,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24888,9 +25028,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 464
+                  "y": 472
                },
-               "id": 190,
+               "id": 191,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25046,9 +25186,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 464
+                  "y": 472
                },
-               "id": 191,
+               "id": 192,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25204,9 +25344,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 472
+                  "y": 480
                },
-               "id": 192,
+               "id": 193,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25362,9 +25502,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 472
+                  "y": 480
                },
-               "id": 193,
+               "id": 194,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25520,9 +25660,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 472
+                  "y": 480
                },
-               "id": 194,
+               "id": 195,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25678,9 +25818,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 472
+                  "y": 480
                },
-               "id": 195,
+               "id": 196,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25836,9 +25976,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 480
+                  "y": 488
                },
-               "id": 196,
+               "id": 197,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25994,9 +26134,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 480
+                  "y": 488
                },
-               "id": 197,
+               "id": 198,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26152,9 +26292,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 480
+                  "y": 488
                },
-               "id": 198,
+               "id": 199,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26310,9 +26450,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 480
+                  "y": 488
                },
-               "id": 199,
+               "id": 200,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26468,9 +26608,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 488
+                  "y": 496
                },
-               "id": 200,
+               "id": 201,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26626,9 +26766,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 488
+                  "y": 496
                },
-               "id": 201,
+               "id": 202,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26784,9 +26924,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 488
+                  "y": 496
                },
-               "id": 202,
+               "id": 203,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26942,9 +27082,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 488
+                  "y": 496
                },
-               "id": 203,
+               "id": 204,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27100,9 +27240,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 496
+                  "y": 504
                },
-               "id": 204,
+               "id": 205,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27258,9 +27398,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 496
+                  "y": 504
                },
-               "id": 205,
+               "id": 206,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27416,9 +27556,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 496
+                  "y": 504
                },
-               "id": 206,
+               "id": 207,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27574,9 +27714,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 496
+                  "y": 504
                },
-               "id": 207,
+               "id": 208,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27732,9 +27872,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 504
+                  "y": 512
                },
-               "id": 208,
+               "id": 209,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27890,9 +28030,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 504
+                  "y": 512
                },
-               "id": 209,
+               "id": 210,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28048,9 +28188,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 504
+                  "y": 512
                },
-               "id": 210,
+               "id": 211,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28206,9 +28346,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 504
+                  "y": 512
                },
-               "id": 211,
+               "id": 212,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28364,9 +28504,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 512
+                  "y": 520
                },
-               "id": 212,
+               "id": 213,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28522,9 +28662,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 512
+                  "y": 520
                },
-               "id": 213,
+               "id": 214,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28680,9 +28820,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 512
+                  "y": 520
                },
-               "id": 214,
+               "id": 215,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28838,9 +28978,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 512
+                  "y": 520
                },
-               "id": 215,
+               "id": 216,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28996,9 +29136,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 520
+                  "y": 528
                },
-               "id": 216,
+               "id": 217,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29154,9 +29294,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 520
+                  "y": 528
                },
-               "id": 217,
+               "id": 218,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29312,9 +29452,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 520
+                  "y": 528
                },
-               "id": 218,
+               "id": 219,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29470,9 +29610,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 520
+                  "y": 528
                },
-               "id": 219,
+               "id": 220,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29628,9 +29768,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 528
+                  "y": 536
                },
-               "id": 220,
+               "id": 221,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29786,9 +29926,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 528
+                  "y": 536
                },
-               "id": 221,
+               "id": 222,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29944,9 +30084,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 528
+                  "y": 536
                },
-               "id": 222,
+               "id": 223,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30102,9 +30242,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 528
+                  "y": 536
                },
-               "id": 223,
+               "id": 224,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30260,9 +30400,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 536
+                  "y": 544
                },
-               "id": 224,
+               "id": 225,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30418,9 +30558,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 536
+                  "y": 544
                },
-               "id": 225,
+               "id": 226,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30576,9 +30716,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 536
+                  "y": 544
                },
-               "id": 226,
+               "id": 227,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30734,9 +30874,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 536
+                  "y": 544
                },
-               "id": 227,
+               "id": 228,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30892,9 +31032,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 544
+                  "y": 552
                },
-               "id": 228,
+               "id": 229,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31050,9 +31190,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 544
+                  "y": 552
                },
-               "id": 229,
+               "id": 230,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31208,9 +31348,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 544
+                  "y": 552
                },
-               "id": 230,
+               "id": 231,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31366,9 +31506,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 544
+                  "y": 552
                },
-               "id": 231,
+               "id": 232,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31528,9 +31668,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 552
+            "y": 560
          },
-         "id": 232,
+         "id": 233,
          "panels": [
             {
                "aliasColors": { },
@@ -31544,9 +31684,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 553
+                  "y": 561
                },
-               "id": 233,
+               "id": 234,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31690,9 +31830,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 553
+                  "y": 561
                },
-               "id": 234,
+               "id": 235,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31837,9 +31977,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 561
+                  "y": 569
                },
-               "id": 235,
+               "id": 236,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31979,9 +32119,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 561
+                  "y": 569
                },
-               "id": 236,
+               "id": 237,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
+++ b/tests/InfluxDB/dashboard_with_custom_panels_compiled.json
@@ -22228,7 +22228,7 @@
                },
                "gridPos": {
                   "h": 8,
-                  "w": 6,
+                  "w": 12,
                   "x": 0,
                   "y": 432
                },
@@ -22310,15 +22310,155 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$influxdb",
+               "description": "How long ago the route cache was last cleared on router instance.\n\nPanel minimal requirements: CRUD 1.7.3.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 432
+               },
+               "id": 173,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "alias": "$tag_label_pairs_alias",
+                     "groupBy": [
+                        {
+                           "params": [
+                              "$__interval"
+                           ],
+                           "type": "time"
+                        },
+                        {
+                           "params": [
+                              "label_pairs_alias"
+                           ],
+                           "type": "tag"
+                        },
+                        {
+                           "params": [
+                              "none"
+                           ],
+                           "type": "fill"
+                        }
+                     ],
+                     "measurement": "$measurement",
+                     "policy": "$policy",
+                     "refId": "A",
+                     "resultFormat": "time_series",
+                     "select": [
+                        [
+                           {
+                              "params": [
+                                 "value"
+                              ],
+                              "type": "field"
+                           },
+                           {
+                              "params": [ ],
+                              "type": "last"
+                           },
+                           {
+                              "params": [
+                                 "*1000"
+                              ],
+                              "type": "math"
+                           }
+                        ]
+                     ],
+                     "tags": [
+                        {
+                           "key": "metric_name",
+                           "operator": "=",
+                           "value": "tnt_crud_router_cache_clear_ts"
+                        },
+                        {
+                           "condition": "AND",
+                           "key": "value",
+                           "operator": ">",
+                           "value": "0"
+                        }
+                     ]
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Router cache last cleared",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "dateTimeFromNow",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "dateTimeFromNow",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$influxdb",
                "description": "Total count of success SELECT and PAIRS requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 6,
-                  "y": 432
+                  "x": 0,
+                  "y": 440
                },
-               "id": 173,
+               "id": 174,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22473,10 +22613,10 @@
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 12,
-                  "y": 432
+                  "x": 6,
+                  "y": 440
                },
-               "id": 174,
+               "id": 175,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22631,10 +22771,10 @@
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 18,
-                  "y": 432
+                  "x": 12,
+                  "y": 440
                },
-               "id": 175,
+               "id": 176,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22789,10 +22929,10 @@
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 0,
+                  "x": 18,
                   "y": 440
                },
-               "id": 176,
+               "id": 177,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -22946,11 +23086,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 6,
-                  "y": 440
+                  "w": 8,
+                  "x": 0,
+                  "y": 448
                },
-               "id": 177,
+               "id": 178,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23050,11 +23190,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 12,
-                  "y": 440
+                  "w": 8,
+                  "x": 8,
+                  "y": 448
                },
-               "id": 178,
+               "id": 179,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23154,11 +23294,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 18,
-                  "y": 440
+                  "w": 8,
+                  "x": 16,
+                  "y": 448
                },
-               "id": 179,
+               "id": 180,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23308,9 +23448,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 448
+                  "y": 456
                },
-               "id": 180,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23466,9 +23606,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 448
+                  "y": 456
                },
-               "id": 181,
+               "id": 182,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23624,9 +23764,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 448
+                  "y": 456
                },
-               "id": 182,
+               "id": 183,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23782,9 +23922,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 448
+                  "y": 456
                },
-               "id": 183,
+               "id": 184,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -23940,9 +24080,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 456
+                  "y": 464
                },
-               "id": 184,
+               "id": 185,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24098,9 +24238,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 456
+                  "y": 464
                },
-               "id": 185,
+               "id": 186,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24256,9 +24396,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 456
+                  "y": 464
                },
-               "id": 186,
+               "id": 187,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24414,9 +24554,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 456
+                  "y": 464
                },
-               "id": 187,
+               "id": 188,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24572,9 +24712,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 464
+                  "y": 472
                },
-               "id": 188,
+               "id": 189,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24730,9 +24870,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 464
+                  "y": 472
                },
-               "id": 189,
+               "id": 190,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -24888,9 +25028,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 464
+                  "y": 472
                },
-               "id": 190,
+               "id": 191,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25046,9 +25186,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 464
+                  "y": 472
                },
-               "id": 191,
+               "id": 192,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25204,9 +25344,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 472
+                  "y": 480
                },
-               "id": 192,
+               "id": 193,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25362,9 +25502,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 472
+                  "y": 480
                },
-               "id": 193,
+               "id": 194,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25520,9 +25660,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 472
+                  "y": 480
                },
-               "id": 194,
+               "id": 195,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25678,9 +25818,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 472
+                  "y": 480
                },
-               "id": 195,
+               "id": 196,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25836,9 +25976,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 480
+                  "y": 488
                },
-               "id": 196,
+               "id": 197,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -25994,9 +26134,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 480
+                  "y": 488
                },
-               "id": 197,
+               "id": 198,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26152,9 +26292,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 480
+                  "y": 488
                },
-               "id": 198,
+               "id": 199,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26310,9 +26450,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 480
+                  "y": 488
                },
-               "id": 199,
+               "id": 200,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26468,9 +26608,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 488
+                  "y": 496
                },
-               "id": 200,
+               "id": 201,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26626,9 +26766,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 488
+                  "y": 496
                },
-               "id": 201,
+               "id": 202,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26784,9 +26924,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 488
+                  "y": 496
                },
-               "id": 202,
+               "id": 203,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -26942,9 +27082,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 488
+                  "y": 496
                },
-               "id": 203,
+               "id": 204,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27100,9 +27240,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 496
+                  "y": 504
                },
-               "id": 204,
+               "id": 205,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27258,9 +27398,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 496
+                  "y": 504
                },
-               "id": 205,
+               "id": 206,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27416,9 +27556,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 496
+                  "y": 504
                },
-               "id": 206,
+               "id": 207,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27574,9 +27714,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 496
+                  "y": 504
                },
-               "id": 207,
+               "id": 208,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27732,9 +27872,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 504
+                  "y": 512
                },
-               "id": 208,
+               "id": 209,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -27890,9 +28030,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 504
+                  "y": 512
                },
-               "id": 209,
+               "id": 210,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28048,9 +28188,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 504
+                  "y": 512
                },
-               "id": 210,
+               "id": 211,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28206,9 +28346,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 504
+                  "y": 512
                },
-               "id": 211,
+               "id": 212,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28364,9 +28504,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 512
+                  "y": 520
                },
-               "id": 212,
+               "id": 213,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28522,9 +28662,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 512
+                  "y": 520
                },
-               "id": 213,
+               "id": 214,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28680,9 +28820,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 512
+                  "y": 520
                },
-               "id": 214,
+               "id": 215,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28838,9 +28978,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 512
+                  "y": 520
                },
-               "id": 215,
+               "id": 216,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -28996,9 +29136,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 520
+                  "y": 528
                },
-               "id": 216,
+               "id": 217,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29154,9 +29294,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 520
+                  "y": 528
                },
-               "id": 217,
+               "id": 218,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29312,9 +29452,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 520
+                  "y": 528
                },
-               "id": 218,
+               "id": 219,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29470,9 +29610,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 520
+                  "y": 528
                },
-               "id": 219,
+               "id": 220,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29628,9 +29768,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 528
+                  "y": 536
                },
-               "id": 220,
+               "id": 221,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29786,9 +29926,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 528
+                  "y": 536
                },
-               "id": 221,
+               "id": 222,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -29944,9 +30084,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 528
+                  "y": 536
                },
-               "id": 222,
+               "id": 223,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30102,9 +30242,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 528
+                  "y": 536
                },
-               "id": 223,
+               "id": 224,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30260,9 +30400,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 536
+                  "y": 544
                },
-               "id": 224,
+               "id": 225,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30418,9 +30558,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 536
+                  "y": 544
                },
-               "id": 225,
+               "id": 226,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30576,9 +30716,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 536
+                  "y": 544
                },
-               "id": 226,
+               "id": 227,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30734,9 +30874,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 536
+                  "y": 544
                },
-               "id": 227,
+               "id": 228,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -30892,9 +31032,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 544
+                  "y": 552
                },
-               "id": 228,
+               "id": 229,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31050,9 +31190,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 544
+                  "y": 552
                },
-               "id": 229,
+               "id": 230,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31208,9 +31348,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 544
+                  "y": 552
                },
-               "id": 230,
+               "id": 231,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31366,9 +31506,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 544
+                  "y": 552
                },
-               "id": 231,
+               "id": 232,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31528,9 +31668,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 552
+            "y": 560
          },
-         "id": 232,
+         "id": 233,
          "panels": [
             {
                "aliasColors": { },
@@ -31544,9 +31684,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 553
+                  "y": 561
                },
-               "id": 233,
+               "id": 234,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31690,9 +31830,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 553
+                  "y": 561
                },
-               "id": 234,
+               "id": 235,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31837,9 +31977,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 561
+                  "y": 569
                },
-               "id": 235,
+               "id": 236,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -31979,9 +32119,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 561
+                  "y": 569
                },
-               "id": 236,
+               "id": 237,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -32123,9 +32263,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 569
+            "y": 577
          },
-         "id": 237,
+         "id": 238,
          "panels": [
             {
                "aliasColors": { },
@@ -32139,9 +32279,9 @@
                   "h": 6,
                   "w": 24,
                   "x": 0,
-                  "y": 570
+                  "y": 578
                },
-               "id": 238,
+               "id": 239,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -32273,9 +32413,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 576
+                  "y": 584
                },
-               "id": 239,
+               "id": 240,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -32413,9 +32553,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 576
+                  "y": 584
                },
-               "id": 240,
+               "id": 241,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_cartridge_compiled.json
+++ b/tests/Prometheus/dashboard_cartridge_compiled.json
@@ -14874,7 +14874,7 @@
                },
                "gridPos": {
                   "h": 8,
-                  "w": 6,
+                  "w": 12,
                   "x": 0,
                   "y": 446
                },
@@ -14909,15 +14909,102 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$prometheus",
+               "description": "How long ago the route cache was last cleared on router instance.\n\nPanel minimal requirements: CRUD 1.7.3.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 446
+               },
+               "id": 182,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "(\n  tnt_crud_router_cache_clear_ts{alias=~\"$alias\",job=~\"$job\"}\n  and\n  tnt_crud_router_cache_clear_ts{alias=~\"$alias\",job=~\"$job\"} > 0\n) * 1000\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Router cache last cleared",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "dateTimeFromNow",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "dateTimeFromNow",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
                "description": "Total count of success SELECT and PAIRS requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 6,
-                  "y": 446
+                  "x": 0,
+                  "y": 454
                },
-               "id": 182,
+               "id": 183,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15001,10 +15088,10 @@
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 12,
-                  "y": 446
+                  "x": 6,
+                  "y": 454
                },
-               "id": 183,
+               "id": 184,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15088,10 +15175,10 @@
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 18,
-                  "y": 446
+                  "x": 12,
+                  "y": 454
                },
-               "id": 184,
+               "id": 185,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15175,10 +15262,10 @@
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 0,
+                  "x": 18,
                   "y": 454
                },
-               "id": 185,
+               "id": 186,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15261,11 +15348,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 6,
-                  "y": 454
+                  "w": 8,
+                  "x": 0,
+                  "y": 462
                },
-               "id": 186,
+               "id": 187,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15348,11 +15435,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 12,
-                  "y": 454
+                  "w": 8,
+                  "x": 8,
+                  "y": 462
                },
-               "id": 187,
+               "id": 188,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15435,11 +15522,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 18,
-                  "y": 454
+                  "w": 8,
+                  "x": 16,
+                  "y": 462
                },
-               "id": 188,
+               "id": 189,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15524,9 +15611,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 462
+                  "y": 470
                },
-               "id": 189,
+               "id": 190,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15611,9 +15698,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 462
+                  "y": 470
                },
-               "id": 190,
+               "id": 191,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15698,9 +15785,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 462
+                  "y": 470
                },
-               "id": 191,
+               "id": 192,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15785,9 +15872,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 462
+                  "y": 470
                },
-               "id": 192,
+               "id": 193,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15872,9 +15959,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 470
+                  "y": 478
                },
-               "id": 193,
+               "id": 194,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15959,9 +16046,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 470
+                  "y": 478
                },
-               "id": 194,
+               "id": 195,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16046,9 +16133,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 470
+                  "y": 478
                },
-               "id": 195,
+               "id": 196,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16133,9 +16220,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 470
+                  "y": 478
                },
-               "id": 196,
+               "id": 197,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16220,9 +16307,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 478
+                  "y": 486
                },
-               "id": 197,
+               "id": 198,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16307,9 +16394,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 478
+                  "y": 486
                },
-               "id": 198,
+               "id": 199,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16394,9 +16481,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 478
+                  "y": 486
                },
-               "id": 199,
+               "id": 200,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16481,9 +16568,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 478
+                  "y": 486
                },
-               "id": 200,
+               "id": 201,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16568,9 +16655,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 486
+                  "y": 494
                },
-               "id": 201,
+               "id": 202,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16655,9 +16742,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 486
+                  "y": 494
                },
-               "id": 202,
+               "id": 203,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16742,9 +16829,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 486
+                  "y": 494
                },
-               "id": 203,
+               "id": 204,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16829,9 +16916,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 486
+                  "y": 494
                },
-               "id": 204,
+               "id": 205,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16916,9 +17003,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 494
+                  "y": 502
                },
-               "id": 205,
+               "id": 206,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17003,9 +17090,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 494
+                  "y": 502
                },
-               "id": 206,
+               "id": 207,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17090,9 +17177,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 494
+                  "y": 502
                },
-               "id": 207,
+               "id": 208,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17177,9 +17264,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 494
+                  "y": 502
                },
-               "id": 208,
+               "id": 209,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17264,9 +17351,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 502
+                  "y": 510
                },
-               "id": 209,
+               "id": 210,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17351,9 +17438,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 502
+                  "y": 510
                },
-               "id": 210,
+               "id": 211,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17438,9 +17525,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 502
+                  "y": 510
                },
-               "id": 211,
+               "id": 212,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17525,9 +17612,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 502
+                  "y": 510
                },
-               "id": 212,
+               "id": 213,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17612,9 +17699,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 510
+                  "y": 518
                },
-               "id": 213,
+               "id": 214,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17699,9 +17786,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 510
+                  "y": 518
                },
-               "id": 214,
+               "id": 215,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17786,9 +17873,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 510
+                  "y": 518
                },
-               "id": 215,
+               "id": 216,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17873,9 +17960,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 510
+                  "y": 518
                },
-               "id": 216,
+               "id": 217,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17960,9 +18047,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 518
+                  "y": 526
                },
-               "id": 217,
+               "id": 218,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18047,9 +18134,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 518
+                  "y": 526
                },
-               "id": 218,
+               "id": 219,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18134,9 +18221,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 518
+                  "y": 526
                },
-               "id": 219,
+               "id": 220,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18221,9 +18308,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 518
+                  "y": 526
                },
-               "id": 220,
+               "id": 221,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18308,9 +18395,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 526
+                  "y": 534
                },
-               "id": 221,
+               "id": 222,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18395,9 +18482,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 526
+                  "y": 534
                },
-               "id": 222,
+               "id": 223,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18482,9 +18569,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 526
+                  "y": 534
                },
-               "id": 223,
+               "id": 224,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18569,9 +18656,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 526
+                  "y": 534
                },
-               "id": 224,
+               "id": 225,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18656,9 +18743,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 534
+                  "y": 542
                },
-               "id": 225,
+               "id": 226,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18743,9 +18830,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 534
+                  "y": 542
                },
-               "id": 226,
+               "id": 227,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18830,9 +18917,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 534
+                  "y": 542
                },
-               "id": 227,
+               "id": 228,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18917,9 +19004,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 534
+                  "y": 542
                },
-               "id": 228,
+               "id": 229,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19004,9 +19091,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 542
+                  "y": 550
                },
-               "id": 229,
+               "id": 230,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19091,9 +19178,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 542
+                  "y": 550
                },
-               "id": 230,
+               "id": 231,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19178,9 +19265,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 542
+                  "y": 550
                },
-               "id": 231,
+               "id": 232,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19265,9 +19352,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 542
+                  "y": 550
                },
-               "id": 232,
+               "id": 233,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19352,9 +19439,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 550
+                  "y": 558
                },
-               "id": 233,
+               "id": 234,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19439,9 +19526,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 550
+                  "y": 558
                },
-               "id": 234,
+               "id": 235,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19526,9 +19613,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 550
+                  "y": 558
                },
-               "id": 235,
+               "id": 236,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19613,9 +19700,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 550
+                  "y": 558
                },
-               "id": 236,
+               "id": 237,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19700,9 +19787,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 558
+                  "y": 566
                },
-               "id": 237,
+               "id": 238,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19787,9 +19874,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 558
+                  "y": 566
                },
-               "id": 238,
+               "id": 239,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19874,9 +19961,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 558
+                  "y": 566
                },
-               "id": 239,
+               "id": 240,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19961,9 +20048,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 558
+                  "y": 566
                },
-               "id": 240,
+               "id": 241,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20052,9 +20139,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 566
+            "y": 574
          },
-         "id": 241,
+         "id": 242,
          "panels": [
             {
                "aliasColors": { },
@@ -20068,9 +20155,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 567
+                  "y": 575
                },
-               "id": 242,
+               "id": 243,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20155,9 +20242,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 567
+                  "y": 575
                },
-               "id": 243,
+               "id": 244,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20243,9 +20330,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 575
+                  "y": 583
                },
-               "id": 244,
+               "id": 245,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20332,9 +20419,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 575
+                  "y": 583
                },
-               "id": 245,
+               "id": 246,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_tarantool3_compiled.json
+++ b/tests/Prometheus/dashboard_tarantool3_compiled.json
@@ -14806,7 +14806,7 @@
                },
                "gridPos": {
                   "h": 8,
-                  "w": 6,
+                  "w": 12,
                   "x": 0,
                   "y": 440
                },
@@ -14841,15 +14841,102 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$prometheus",
+               "description": "How long ago the route cache was last cleared on router instance.\n\nPanel minimal requirements: CRUD 1.7.3.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 440
+               },
+               "id": 180,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "(\n  tnt_crud_router_cache_clear_ts{alias=~\"$alias\",job=~\"$job\"}\n  and\n  tnt_crud_router_cache_clear_ts{alias=~\"$alias\",job=~\"$job\"} > 0\n) * 1000\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Router cache last cleared",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "dateTimeFromNow",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "dateTimeFromNow",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
                "description": "Total count of success SELECT and PAIRS requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 6,
-                  "y": 440
+                  "x": 0,
+                  "y": 448
                },
-               "id": 180,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14933,10 +15020,10 @@
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 12,
-                  "y": 440
+                  "x": 6,
+                  "y": 448
                },
-               "id": 181,
+               "id": 182,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15020,10 +15107,10 @@
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 18,
-                  "y": 440
+                  "x": 12,
+                  "y": 448
                },
-               "id": 182,
+               "id": 183,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15107,10 +15194,10 @@
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 0,
+                  "x": 18,
                   "y": 448
                },
-               "id": 183,
+               "id": 184,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15193,11 +15280,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 6,
-                  "y": 448
+                  "w": 8,
+                  "x": 0,
+                  "y": 456
                },
-               "id": 184,
+               "id": 185,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15280,11 +15367,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 12,
-                  "y": 448
+                  "w": 8,
+                  "x": 8,
+                  "y": 456
                },
-               "id": 185,
+               "id": 186,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15367,11 +15454,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 18,
-                  "y": 448
+                  "w": 8,
+                  "x": 16,
+                  "y": 456
                },
-               "id": 186,
+               "id": 187,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15456,9 +15543,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 456
+                  "y": 464
                },
-               "id": 187,
+               "id": 188,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15543,9 +15630,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 456
+                  "y": 464
                },
-               "id": 188,
+               "id": 189,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15630,9 +15717,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 456
+                  "y": 464
                },
-               "id": 189,
+               "id": 190,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15717,9 +15804,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 456
+                  "y": 464
                },
-               "id": 190,
+               "id": 191,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15804,9 +15891,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 464
+                  "y": 472
                },
-               "id": 191,
+               "id": 192,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15891,9 +15978,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 464
+                  "y": 472
                },
-               "id": 192,
+               "id": 193,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15978,9 +16065,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 464
+                  "y": 472
                },
-               "id": 193,
+               "id": 194,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16065,9 +16152,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 464
+                  "y": 472
                },
-               "id": 194,
+               "id": 195,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16152,9 +16239,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 472
+                  "y": 480
                },
-               "id": 195,
+               "id": 196,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16239,9 +16326,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 472
+                  "y": 480
                },
-               "id": 196,
+               "id": 197,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16326,9 +16413,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 472
+                  "y": 480
                },
-               "id": 197,
+               "id": 198,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16413,9 +16500,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 472
+                  "y": 480
                },
-               "id": 198,
+               "id": 199,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16500,9 +16587,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 480
+                  "y": 488
                },
-               "id": 199,
+               "id": 200,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16587,9 +16674,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 480
+                  "y": 488
                },
-               "id": 200,
+               "id": 201,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16674,9 +16761,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 480
+                  "y": 488
                },
-               "id": 201,
+               "id": 202,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16761,9 +16848,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 480
+                  "y": 488
                },
-               "id": 202,
+               "id": 203,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16848,9 +16935,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 488
+                  "y": 496
                },
-               "id": 203,
+               "id": 204,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16935,9 +17022,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 488
+                  "y": 496
                },
-               "id": 204,
+               "id": 205,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17022,9 +17109,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 488
+                  "y": 496
                },
-               "id": 205,
+               "id": 206,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17109,9 +17196,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 488
+                  "y": 496
                },
-               "id": 206,
+               "id": 207,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17196,9 +17283,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 496
+                  "y": 504
                },
-               "id": 207,
+               "id": 208,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17283,9 +17370,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 496
+                  "y": 504
                },
-               "id": 208,
+               "id": 209,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17370,9 +17457,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 496
+                  "y": 504
                },
-               "id": 209,
+               "id": 210,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17457,9 +17544,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 496
+                  "y": 504
                },
-               "id": 210,
+               "id": 211,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17544,9 +17631,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 504
+                  "y": 512
                },
-               "id": 211,
+               "id": 212,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17631,9 +17718,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 504
+                  "y": 512
                },
-               "id": 212,
+               "id": 213,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17718,9 +17805,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 504
+                  "y": 512
                },
-               "id": 213,
+               "id": 214,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17805,9 +17892,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 504
+                  "y": 512
                },
-               "id": 214,
+               "id": 215,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17892,9 +17979,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 512
+                  "y": 520
                },
-               "id": 215,
+               "id": 216,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17979,9 +18066,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 512
+                  "y": 520
                },
-               "id": 216,
+               "id": 217,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18066,9 +18153,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 512
+                  "y": 520
                },
-               "id": 217,
+               "id": 218,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18153,9 +18240,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 512
+                  "y": 520
                },
-               "id": 218,
+               "id": 219,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18240,9 +18327,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 520
+                  "y": 528
                },
-               "id": 219,
+               "id": 220,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18327,9 +18414,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 520
+                  "y": 528
                },
-               "id": 220,
+               "id": 221,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18414,9 +18501,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 520
+                  "y": 528
                },
-               "id": 221,
+               "id": 222,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18501,9 +18588,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 520
+                  "y": 528
                },
-               "id": 222,
+               "id": 223,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18588,9 +18675,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 528
+                  "y": 536
                },
-               "id": 223,
+               "id": 224,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18675,9 +18762,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 528
+                  "y": 536
                },
-               "id": 224,
+               "id": 225,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18762,9 +18849,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 528
+                  "y": 536
                },
-               "id": 225,
+               "id": 226,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18849,9 +18936,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 528
+                  "y": 536
                },
-               "id": 226,
+               "id": 227,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18936,9 +19023,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 536
+                  "y": 544
                },
-               "id": 227,
+               "id": 228,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19023,9 +19110,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 536
+                  "y": 544
                },
-               "id": 228,
+               "id": 229,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19110,9 +19197,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 536
+                  "y": 544
                },
-               "id": 229,
+               "id": 230,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19197,9 +19284,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 536
+                  "y": 544
                },
-               "id": 230,
+               "id": 231,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19284,9 +19371,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 544
+                  "y": 552
                },
-               "id": 231,
+               "id": 232,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19371,9 +19458,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 544
+                  "y": 552
                },
-               "id": 232,
+               "id": 233,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19458,9 +19545,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 544
+                  "y": 552
                },
-               "id": 233,
+               "id": 234,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19545,9 +19632,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 544
+                  "y": 552
                },
-               "id": 234,
+               "id": 235,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19632,9 +19719,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 552
+                  "y": 560
                },
-               "id": 235,
+               "id": 236,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19719,9 +19806,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 552
+                  "y": 560
                },
-               "id": 236,
+               "id": 237,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19806,9 +19893,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 552
+                  "y": 560
                },
-               "id": 237,
+               "id": 238,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19893,9 +19980,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 552
+                  "y": 560
                },
-               "id": 238,
+               "id": 239,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19984,9 +20071,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 560
+            "y": 568
          },
-         "id": 239,
+         "id": 240,
          "panels": [
             {
                "aliasColors": { },
@@ -20000,9 +20087,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 561
+                  "y": 569
                },
-               "id": 240,
+               "id": 241,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20087,9 +20174,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 561
+                  "y": 569
                },
-               "id": 241,
+               "id": 242,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20175,9 +20262,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 569
+                  "y": 577
                },
-               "id": 242,
+               "id": 243,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20264,9 +20351,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 569
+                  "y": 577
                },
-               "id": 243,
+               "id": 244,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,

--- a/tests/Prometheus/dashboard_with_custom_panels_compiled.json
+++ b/tests/Prometheus/dashboard_with_custom_panels_compiled.json
@@ -14806,7 +14806,7 @@
                },
                "gridPos": {
                   "h": 8,
-                  "w": 6,
+                  "w": 12,
                   "x": 0,
                   "y": 440
                },
@@ -14841,15 +14841,102 @@
                "dashLength": 10,
                "dashes": false,
                "datasource": "$prometheus",
+               "description": "How long ago the route cache was last cleared on router instance.\n\nPanel minimal requirements: CRUD 1.7.3.\n",
+               "fill": 0,
+               "gridPos": {
+                  "h": 8,
+                  "w": 12,
+                  "x": 12,
+                  "y": 440
+               },
+               "id": 180,
+               "legend": {
+                  "alignAsTable": true,
+                  "avg": false,
+                  "current": true,
+                  "max": false,
+                  "min": false,
+                  "rightSide": false,
+                  "show": true,
+                  "sideWidth": null,
+                  "sort": "current",
+                  "sortDesc": true,
+                  "total": false,
+                  "values": true
+               },
+               "lines": true,
+               "linewidth": 1,
+               "links": [ ],
+               "nullPointMode": "null",
+               "percentage": false,
+               "pointradius": 5,
+               "points": false,
+               "renderer": "flot",
+               "repeat": null,
+               "seriesOverrides": [ ],
+               "spaceLength": 10,
+               "stack": false,
+               "steppedLine": false,
+               "targets": [
+                  {
+                     "expr": "(\n  tnt_crud_router_cache_clear_ts{alias=~\"$alias\",job=~\"$job\"}\n  and\n  tnt_crud_router_cache_clear_ts{alias=~\"$alias\",job=~\"$job\"} > 0\n) * 1000\n",
+                     "format": "time_series",
+                     "intervalFactor": 2,
+                     "legendFormat": "{{alias}}",
+                     "refId": "A"
+                  }
+               ],
+               "thresholds": [ ],
+               "timeFrom": null,
+               "timeShift": null,
+               "title": "Router cache last cleared",
+               "tooltip": {
+                  "shared": true,
+                  "sort": 2,
+                  "value_type": "individual"
+               },
+               "type": "graph",
+               "xaxis": {
+                  "buckets": null,
+                  "mode": "time",
+                  "name": null,
+                  "show": true,
+                  "values": [ ]
+               },
+               "yaxes": [
+                  {
+                     "format": "dateTimeFromNow",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  },
+                  {
+                     "format": "dateTimeFromNow",
+                     "label": null,
+                     "logBase": 1,
+                     "max": null,
+                     "min": null,
+                     "show": true
+                  }
+               ]
+            },
+            {
+               "aliasColors": { },
+               "bars": false,
+               "dashLength": 10,
+               "dashes": false,
+               "datasource": "$prometheus",
                "description": "Total count of success SELECT and PAIRS requests to cluster spaces with CRUD module.\nGraph shows average requests per second.\n\nCRUD 0.11.0 or newer is required to use statistics.\nEnable statistics with `crud.cfg{stats = true, stats_driver = 'metrics'}`\n",
                "fill": 0,
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 6,
-                  "y": 440
+                  "x": 0,
+                  "y": 448
                },
-               "id": 180,
+               "id": 181,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -14933,10 +15020,10 @@
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 12,
-                  "y": 440
+                  "x": 6,
+                  "y": 448
                },
-               "id": 181,
+               "id": 182,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15020,10 +15107,10 @@
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 18,
-                  "y": 440
+                  "x": 12,
+                  "y": 448
                },
-               "id": 182,
+               "id": 183,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15107,10 +15194,10 @@
                "gridPos": {
                   "h": 8,
                   "w": 6,
-                  "x": 0,
+                  "x": 18,
                   "y": 448
                },
-               "id": 183,
+               "id": 184,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15193,11 +15280,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 6,
-                  "y": 448
+                  "w": 8,
+                  "x": 0,
+                  "y": 456
                },
-               "id": 184,
+               "id": 185,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15280,11 +15367,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 12,
-                  "y": 448
+                  "w": 8,
+                  "x": 8,
+                  "y": 456
                },
-               "id": 185,
+               "id": 186,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15367,11 +15454,11 @@
                "fill": 0,
                "gridPos": {
                   "h": 8,
-                  "w": 6,
-                  "x": 18,
-                  "y": 448
+                  "w": 8,
+                  "x": 16,
+                  "y": 456
                },
-               "id": 186,
+               "id": 187,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15456,9 +15543,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 456
+                  "y": 464
                },
-               "id": 187,
+               "id": 188,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15543,9 +15630,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 456
+                  "y": 464
                },
-               "id": 188,
+               "id": 189,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15630,9 +15717,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 456
+                  "y": 464
                },
-               "id": 189,
+               "id": 190,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15717,9 +15804,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 456
+                  "y": 464
                },
-               "id": 190,
+               "id": 191,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15804,9 +15891,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 464
+                  "y": 472
                },
-               "id": 191,
+               "id": 192,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15891,9 +15978,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 464
+                  "y": 472
                },
-               "id": 192,
+               "id": 193,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -15978,9 +16065,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 464
+                  "y": 472
                },
-               "id": 193,
+               "id": 194,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16065,9 +16152,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 464
+                  "y": 472
                },
-               "id": 194,
+               "id": 195,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16152,9 +16239,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 472
+                  "y": 480
                },
-               "id": 195,
+               "id": 196,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16239,9 +16326,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 472
+                  "y": 480
                },
-               "id": 196,
+               "id": 197,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16326,9 +16413,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 472
+                  "y": 480
                },
-               "id": 197,
+               "id": 198,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16413,9 +16500,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 472
+                  "y": 480
                },
-               "id": 198,
+               "id": 199,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16500,9 +16587,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 480
+                  "y": 488
                },
-               "id": 199,
+               "id": 200,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16587,9 +16674,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 480
+                  "y": 488
                },
-               "id": 200,
+               "id": 201,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16674,9 +16761,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 480
+                  "y": 488
                },
-               "id": 201,
+               "id": 202,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16761,9 +16848,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 480
+                  "y": 488
                },
-               "id": 202,
+               "id": 203,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16848,9 +16935,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 488
+                  "y": 496
                },
-               "id": 203,
+               "id": 204,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -16935,9 +17022,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 488
+                  "y": 496
                },
-               "id": 204,
+               "id": 205,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17022,9 +17109,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 488
+                  "y": 496
                },
-               "id": 205,
+               "id": 206,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17109,9 +17196,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 488
+                  "y": 496
                },
-               "id": 206,
+               "id": 207,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17196,9 +17283,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 496
+                  "y": 504
                },
-               "id": 207,
+               "id": 208,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17283,9 +17370,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 496
+                  "y": 504
                },
-               "id": 208,
+               "id": 209,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17370,9 +17457,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 496
+                  "y": 504
                },
-               "id": 209,
+               "id": 210,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17457,9 +17544,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 496
+                  "y": 504
                },
-               "id": 210,
+               "id": 211,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17544,9 +17631,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 504
+                  "y": 512
                },
-               "id": 211,
+               "id": 212,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17631,9 +17718,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 504
+                  "y": 512
                },
-               "id": 212,
+               "id": 213,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17718,9 +17805,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 504
+                  "y": 512
                },
-               "id": 213,
+               "id": 214,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17805,9 +17892,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 504
+                  "y": 512
                },
-               "id": 214,
+               "id": 215,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17892,9 +17979,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 512
+                  "y": 520
                },
-               "id": 215,
+               "id": 216,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -17979,9 +18066,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 512
+                  "y": 520
                },
-               "id": 216,
+               "id": 217,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18066,9 +18153,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 512
+                  "y": 520
                },
-               "id": 217,
+               "id": 218,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18153,9 +18240,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 512
+                  "y": 520
                },
-               "id": 218,
+               "id": 219,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18240,9 +18327,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 520
+                  "y": 528
                },
-               "id": 219,
+               "id": 220,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18327,9 +18414,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 520
+                  "y": 528
                },
-               "id": 220,
+               "id": 221,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18414,9 +18501,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 520
+                  "y": 528
                },
-               "id": 221,
+               "id": 222,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18501,9 +18588,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 520
+                  "y": 528
                },
-               "id": 222,
+               "id": 223,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18588,9 +18675,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 528
+                  "y": 536
                },
-               "id": 223,
+               "id": 224,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18675,9 +18762,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 528
+                  "y": 536
                },
-               "id": 224,
+               "id": 225,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18762,9 +18849,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 528
+                  "y": 536
                },
-               "id": 225,
+               "id": 226,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18849,9 +18936,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 528
+                  "y": 536
                },
-               "id": 226,
+               "id": 227,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -18936,9 +19023,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 536
+                  "y": 544
                },
-               "id": 227,
+               "id": 228,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19023,9 +19110,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 536
+                  "y": 544
                },
-               "id": 228,
+               "id": 229,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19110,9 +19197,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 536
+                  "y": 544
                },
-               "id": 229,
+               "id": 230,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19197,9 +19284,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 536
+                  "y": 544
                },
-               "id": 230,
+               "id": 231,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19284,9 +19371,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 544
+                  "y": 552
                },
-               "id": 231,
+               "id": 232,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19371,9 +19458,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 544
+                  "y": 552
                },
-               "id": 232,
+               "id": 233,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19458,9 +19545,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 544
+                  "y": 552
                },
-               "id": 233,
+               "id": 234,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19545,9 +19632,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 544
+                  "y": 552
                },
-               "id": 234,
+               "id": 235,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19632,9 +19719,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 0,
-                  "y": 552
+                  "y": 560
                },
-               "id": 235,
+               "id": 236,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19719,9 +19806,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 6,
-                  "y": 552
+                  "y": 560
                },
-               "id": 236,
+               "id": 237,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19806,9 +19893,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 12,
-                  "y": 552
+                  "y": 560
                },
-               "id": 237,
+               "id": 238,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19893,9 +19980,9 @@
                   "h": 8,
                   "w": 6,
                   "x": 18,
-                  "y": 552
+                  "y": 560
                },
-               "id": 238,
+               "id": 239,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -19984,9 +20071,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 560
+            "y": 568
          },
-         "id": 239,
+         "id": 240,
          "panels": [
             {
                "aliasColors": { },
@@ -20000,9 +20087,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 561
+                  "y": 569
                },
-               "id": 240,
+               "id": 241,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20087,9 +20174,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 561
+                  "y": 569
                },
-               "id": 241,
+               "id": 242,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20175,9 +20262,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 569
+                  "y": 577
                },
-               "id": 242,
+               "id": 243,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20264,9 +20351,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 569
+                  "y": 577
                },
-               "id": 243,
+               "id": 244,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20355,9 +20442,9 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 577
+            "y": 585
          },
-         "id": 244,
+         "id": 245,
          "panels": [
             {
                "aliasColors": { },
@@ -20371,9 +20458,9 @@
                   "h": 6,
                   "w": 24,
                   "x": 0,
-                  "y": 578
+                  "y": 586
                },
-               "id": 245,
+               "id": 246,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20458,9 +20545,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 0,
-                  "y": 584
+                  "y": 592
                },
-               "id": 246,
+               "id": 247,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,
@@ -20545,9 +20632,9 @@
                   "h": 8,
                   "w": 12,
                   "x": 12,
-                  "y": 584
+                  "y": 592
                },
-               "id": 247,
+               "id": 248,
                "legend": {
                   "alignAsTable": true,
                   "avg": true,


### PR DESCRIPTION
Add panel with time of last CRUD router cache clear.

<img width="700" alt="Снимок экрана от 2026-02-04 11-49-10" src="https://github.com/user-attachments/assets/8127f20e-f8c6-4e09-8e51-d8a52d39e9de" />

Closes TNTP-6316
